### PR TITLE
Update demo compose files to use tree output

### DIFF
--- a/docs/nv2/demo-compose.md
+++ b/docs/nv2/demo-compose.md
@@ -52,7 +52,7 @@ docker push $IMAGE
 Inspect image on registry:
 
 ```shell
-oras discover $IMAGE
+oras discover $IMAGE --output tree
 ```
 
 Pull signed image (fails without signature):

--- a/docs/nv2/demo-compose.md
+++ b/docs/nv2/demo-compose.md
@@ -86,7 +86,7 @@ oras push $REPO \
   --artifact-reference $IMAGE \
   --export-manifest sbom-manifest.json \
   ./sbom.json:application/tar
-oras discover $IMAGE
+oras discover $IMAGE --output tree
 ```
 
 Sign the SBoM:
@@ -94,7 +94,7 @@ Sign the SBoM:
 ```shell
 DIGEST=$(oras discover \
     --artifact-type application/x.example.sbom.v0 \
-    --output-json \
+    --output json \
     $IMAGE | jq -r .references[0].digest)
 nv2 sign \
   -m x509 \
@@ -103,7 +103,7 @@ nv2 sign \
   --push \
   --push-reference oci://${REPO}@${DIGEST} \
   file:sbom-manifest.json
-oras discover ${REPO}@${DIGEST}
+oras discover ${REPO}@${DIGEST} --output tree
 ```
 
 Exit the sandbox:

--- a/docs/nv2/sandbox/Dockerfile
+++ b/docs/nv2/sandbox/Dockerfile
@@ -9,8 +9,9 @@ RUN apk add \
 
 FROM go as nv2
 
-RUN git clone https://github.com/notaryproject/nv2.git /nv2 \
- && cd /nv2 \
+RUN git clone https://github.com/notaryproject/notation.git /notation \
+ && cd /notation \
+ && git checkout prototype-2 \
  && make build
 
 FROM go as oras
@@ -33,7 +34,7 @@ RUN apk add \
       make \
       openssl
 
-COPY --from=nv2 /nv2/bin/ /usr/local/bin/
+COPY --from=nv2 /notation/bin/ /usr/local/bin/
 COPY --from=oras /usr/local/bin/oras /usr/local/bin/oras
 COPY --from=docker /usr/local/bin/docker /usr/local/bin/docker
 COPY rebuild.sh /usr/local/bin/


### PR DESCRIPTION
* Update to use tree output from https://github.com/oras-project/oras/pull/297
* Update nv2 source branch
* Begin rename from nv2 to notation

Sample output using tree
```
 oras discover $IMAGE -o tree
registry.wabbit-networks.io/net-monitor:v1
├── [application/x.example.sbom.v0]sha256:b89becf281d96b32cfed1c8cd2a3e8a856de388fe3670c48f9ba08da32c2480e
│   └── [application/vnd.cncf.notary.v2]sha256:d472fa6e74ff024138eebfa49265389769c5febd98912c3b106d365c35888153
└── [application/vnd.cncf.notary.v2]sha256:4243d006c9546bcb099e3a57e0bf3be7195553662a53254c3f6ed0500d6681f4
```

Signed-off-by: Lachlan Evenson <lachlan.evenson@microsoft.com>