### PR TITLE
feat: add initial framework for notation extensibility

### DIFF
--- a/cmd/notation/cert.go
+++ b/cmd/notation/cert.go
@@ -137,7 +137,7 @@ func listCerts(ctx *cli.Context) error {
 	}
 
 	// write out
-	printCertificateSet(cfg.VerificationCertificates.Certificates)
+	printCertificateSet(cfg.VerificationCertificates.Certificates, cfg.VerificationCertificates.KMSCerts)
 	return nil
 }
 
@@ -172,7 +172,7 @@ func removeCerts(ctx *cli.Context) error {
 	return nil
 }
 
-func printCertificateSet(s config.CertificateMap) {
+func printCertificateSet(s config.CertificateMap, k config.KMSProfileMap) {
 	maxNameSize := 0
 	for _, ref := range s {
 		if len(ref.Name) > maxNameSize {
@@ -183,6 +183,23 @@ func printCertificateSet(s config.CertificateMap) {
 	fmt.Printf(format, "NAME", "PATH")
 	for _, ref := range s {
 		fmt.Printf(format, ref.Name, ref.Path)
+	}
+
+	var maxKeyIDSize int
+	for _, ref := range k {
+		if len(ref.Name) > maxNameSize {
+			maxNameSize = len(ref.Name)
+		}
+		if len(ref.ID) > maxKeyIDSize {
+			maxKeyIDSize = len(ref.ID)
+		}
+	}
+	fmt.Println()
+	// iterate over KMS profiles
+	format = fmt.Sprintf("%%-%ds\t%%-%ds\t%%s\n", maxNameSize, maxKeyIDSize)
+	fmt.Printf(format, "NAME", "ID", "PLUGIN NAME")
+	for _, ref := range k {
+		fmt.Printf(format, ref.Name, ref.ID, ref.PluginName)
 	}
 }
 

--- a/cmd/notation/cert.go
+++ b/cmd/notation/cert.go
@@ -34,6 +34,20 @@ var (
 				Aliases: []string{"n"},
 				Usage:   "certificate name",
 			},
+			&cli.StringFlag{
+				Name:    "id",
+				Aliases: []string{"i"},
+				Usage:   "key id",
+			},
+			&cli.StringFlag{
+				Name:    "plugin",
+				Aliases: []string{"p"},
+				Usage:   "key plugin",
+			},
+			&cli.BoolFlag{
+				Name:  "kms",
+				Usage: "add key to KMS cert list",
+			},
 		},
 		Action: addCert,
 	}
@@ -86,6 +100,13 @@ var (
 )
 
 func addCert(ctx *cli.Context) error {
+	if ctx.Bool("kms") {
+		return addKMSCertToList(ctx)
+	}
+	return addCertToList(ctx)
+}
+
+func addCertToList(ctx *cli.Context) error {
 	// initialize
 	path := ctx.Args().First()
 	if path == "" {
@@ -122,8 +143,48 @@ func addCert(ctx *cli.Context) error {
 	return nil
 }
 
+func addKMSCertToList(ctx *cli.Context) error {
+	keyID := ctx.String("id")
+	plugin := ctx.String("plugin")
+	name := ctx.String("name")
+
+	// initialize
+	if keyID == "" {
+		return errors.New("missing key id")
+	}
+	if plugin == "" {
+		return errors.New("missing key plugin")
+	}
+	if name == "" {
+		name = keyID
+	}
+
+	// core process
+	cfg, err := config.LoadOrDefault()
+	if err != nil {
+		return err
+	}
+	if err = addKMSCertCore(cfg, name, keyID, plugin); err != nil {
+		return err
+	}
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+
+	// write out
+	fmt.Println(name)
+	return nil
+}
+
 func addCertCore(cfg *config.File, name, path string) error {
 	if ok := cfg.VerificationCertificates.Certificates.Append(name, path); !ok {
+		return errors.New(name + ": already exists")
+	}
+	return nil
+}
+
+func addKMSCertCore(cfg *config.File, name, keyID, plugin string) error {
+	if ok := cfg.VerificationCertificates.KMSCerts.Append(name, keyID, plugin); !ok {
 		return errors.New(name + ": already exists")
 	}
 	return nil
@@ -157,7 +218,9 @@ func removeCerts(ctx *cli.Context) error {
 	var removedNames []string
 	for _, name := range names {
 		if ok := cfg.VerificationCertificates.Certificates.Remove(name); !ok {
-			return errors.New(name + ": not found")
+			if ok := cfg.VerificationCertificates.KMSCerts.Remove(name); !ok {
+				return errors.New(name + ": not found")
+			}
 		}
 		removedNames = append(removedNames, name)
 	}

--- a/cmd/notation/cert.go
+++ b/cmd/notation/cert.go
@@ -42,7 +42,7 @@ var (
 			&cli.StringFlag{
 				Name:    "plugin",
 				Aliases: []string{"p"},
-				Usage:   "key plugin",
+				Usage:   "signing plugin",
 			},
 			&cli.BoolFlag{
 				Name:  "kms",
@@ -153,7 +153,7 @@ func addKMSCertToList(ctx *cli.Context) error {
 		return errors.New("missing key id")
 	}
 	if plugin == "" {
-		return errors.New("missing key plugin")
+		return errors.New("missing signing plugin")
 	}
 	if name == "" {
 		name = keyID

--- a/cmd/notation/common.go
+++ b/cmd/notation/common.go
@@ -40,4 +40,9 @@ var (
 		Usage:     "signature files",
 		TakesFile: true,
 	}
+	flagCert = &cli.StringSliceFlag{
+		Name:    "cert",
+		Aliases: []string{"c"},
+		Usage:   "certificate names for verification",
+	}
 )

--- a/cmd/notation/key.go
+++ b/cmd/notation/key.go
@@ -46,7 +46,7 @@ var (
 			&cli.StringFlag{
 				Name:    "plugin",
 				Aliases: []string{"p"},
-				Usage:   "key plugin",
+				Usage:   "signing plugin",
 			},
 			&cli.BoolFlag{
 				Name:  "kms",
@@ -152,7 +152,7 @@ func addKMSKeyToList(ctx *cli.Context) error {
 		return errors.New("missing key id")
 	}
 	if plugin == "" {
-		return errors.New("missing key plugin")
+		return errors.New("missing signing plugin")
 	}
 	if name == "" {
 		name = keyID

--- a/cmd/notation/key.go
+++ b/cmd/notation/key.go
@@ -168,7 +168,7 @@ func listKeys(ctx *cli.Context) error {
 	}
 
 	// write out
-	printKeySet(cfg.SigningKeys.Default, cfg.SigningKeys.Keys)
+	printKeySet(cfg.SigningKeys.Default, cfg.SigningKeys.Keys, cfg.SigningKeys.KMSKeys)
 	return nil
 }
 
@@ -211,8 +211,8 @@ func removeKeys(ctx *cli.Context) error {
 	return nil
 }
 
-func printKeySet(target string, s config.KeyMap) {
-	if len(s) == 0 {
+func printKeySet(target string, s config.KeyMap, k config.KMSKeyMap) {
+	if len(s) == 0 && len(k) == 0 {
 		fmt.Println("NAME\tPATH")
 		return
 	}
@@ -234,5 +234,27 @@ func printKeySet(target string, s config.KeyMap) {
 			mark = '*'
 		}
 		fmt.Printf(format, mark, ref.Name, ref.KeyPath, ref.CertificatePath)
+	}
+
+	var maxKeyIDSize int
+	for _, ref := range k {
+		if len(ref.Name) > maxNameSize {
+			maxNameSize = len(ref.Name)
+		}
+		if len(ref.ID) > maxKeyIDSize {
+			maxKeyIDSize = len(ref.ID)
+		}
+	}
+
+	fmt.Println()
+	// iterate over KMS keys
+	format = fmt.Sprintf("%%c %%-%ds\t%%-%ds\t%%s\n", maxNameSize, maxKeyIDSize)
+	fmt.Printf(format, ' ', "NAME", "KEY ID", "PLUGIN NAME")
+	for _, ref := range k {
+		mark := ' '
+		if ref.Name == target {
+			mark = '*'
+		}
+		fmt.Printf(format, mark, ref.Name, ref.ID, ref.PluginName)
 	}
 }

--- a/cmd/notation/key.go
+++ b/cmd/notation/key.go
@@ -211,7 +211,7 @@ func removeKeys(ctx *cli.Context) error {
 	return nil
 }
 
-func printKeySet(target string, s config.KeyMap, k config.KMSKeyMap) {
+func printKeySet(target string, s config.KeyMap, k config.KMSProfileMap) {
 	if len(s) == 0 && len(k) == 0 {
 		fmt.Println("NAME\tPATH")
 		return
@@ -247,9 +247,9 @@ func printKeySet(target string, s config.KeyMap, k config.KMSKeyMap) {
 	}
 
 	fmt.Println()
-	// iterate over KMS keys
+	// iterate over KMS profiles
 	format = fmt.Sprintf("%%c %%-%ds\t%%-%ds\t%%s\n", maxNameSize, maxKeyIDSize)
-	fmt.Printf(format, ' ', "NAME", "KEY ID", "PLUGIN NAME")
+	fmt.Printf(format, ' ', "NAME", "ID", "PLUGIN NAME")
 	for _, ref := range k {
 		mark := ' '
 		if ref.Name == target {

--- a/cmd/notation/main.go
+++ b/cmd/notation/main.go
@@ -27,6 +27,7 @@ func main() {
 			certCommand,
 			keyCommand,
 			cacheCommand,
+			pluginCommand,
 		},
 	}
 	if err := app.Run(os.Args); err != nil {

--- a/cmd/notation/main.go
+++ b/cmd/notation/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"log"
 	"os"
 
 	"github.com/notaryproject/notation/internal/version"
+	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
 

--- a/cmd/notation/plugin.go
+++ b/cmd/notation/plugin.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/notaryproject/notation/pkg/config"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	pluginCommand = &cli.Command{
+		Name:  "plugin",
+		Usage: "Manage KMS plugins",
+		Subcommands: []*cli.Command{
+			pluginAddCommand,
+			pluginListCommand,
+			pluginRemoveCommand,
+		},
+	}
+
+	pluginDefaultFlag = &cli.BoolFlag{
+		Name:    "default",
+		Aliases: []string{"d"},
+		Usage:   "mark as default",
+	}
+
+	pluginAddCommand = &cli.Command{
+		Name:      "add",
+		Usage:     "Register a plugin",
+		ArgsUsage: "<plugin-name> <plugin-path>",
+		Flags: []cli.Flag{
+			pluginDefaultFlag,
+		},
+		Action: addPlugin,
+	}
+
+	pluginListCommand = &cli.Command{
+		Name:    "list",
+		Usage:   "List registered plugins",
+		Aliases: []string{"ls"},
+		Action:  listPlugins,
+	}
+
+	pluginRemoveCommand = &cli.Command{
+		Name:      "remove",
+		Usage:     "Remove a plugin",
+		Aliases:   []string{"rm"},
+		ArgsUsage: "<plugin-name> ...",
+		Action:    removePlugins,
+	}
+)
+
+func addPlugin(ctx *cli.Context) error {
+	// initialize
+	args := ctx.Args()
+	switch args.Len() {
+	case 0:
+		return errors.New("missing plugin name and path")
+	case 1:
+		return errors.New("missing plugin path for the correspoding plugin name")
+	}
+
+	pluginPath, err := filepath.Abs(args.Get(1))
+	if err != nil {
+		return err
+	}
+	pluginName := args.Get(0)
+
+	// core process
+	cfg, err := config.LoadOrDefault()
+	if err != nil {
+		return err
+	}
+	if err := addPluginCore(cfg, pluginName, pluginPath); err != nil {
+		return err
+	}
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+
+	// write out
+	fmt.Printf("plugin %s added\n", pluginName)
+
+	return nil
+}
+
+func addPluginCore(cfg *config.File, pluginName, pluginPath string) error {
+	// Should we run discover plugin here?
+	if ok := cfg.KMSPlugins.Plugins.Append(pluginName, pluginPath); !ok {
+		return errors.New(pluginName + ": already exists")
+	}
+	return nil
+}
+
+func listPlugins(ctx *cli.Context) error {
+	// core process
+	cfg, err := config.LoadOrDefault()
+	if err != nil {
+		return err
+	}
+
+	// write out
+	printPluginSet(cfg.KMSPlugins.Plugins)
+	return nil
+}
+
+func removePlugins(ctx *cli.Context) error {
+	// initialize
+	names := ctx.Args().Slice()
+	if len(names) == 0 {
+		return errors.New("missing plugin names")
+	}
+
+	// core process
+	cfg, err := config.LoadOrDefault()
+	if err != nil {
+		return err
+	}
+
+	var removedNames []string
+	for _, name := range names {
+		if ok := cfg.KMSPlugins.Plugins.Remove(name); !ok {
+			return errors.New(name + ": not found")
+		}
+		removedNames = append(removedNames, name)
+	}
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+
+	// write out
+	for _, name := range removedNames {
+		fmt.Println(name)
+	}
+
+	return nil
+}
+
+func printPluginSet(s config.PluginMap) {
+	maxNameSize := 0
+	for _, ref := range s {
+		if len(ref.Name) > maxNameSize {
+			maxNameSize = len(ref.Name)
+		}
+	}
+	format := fmt.Sprintf("%%-%ds\t%%s\n", maxNameSize)
+	fmt.Printf(format, "NAME", "PATH")
+	for _, ref := range s {
+		fmt.Printf(format, ref.Name, ref.Path)
+	}
+}

--- a/cmd/notation/sign.go
+++ b/cmd/notation/sign.go
@@ -63,6 +63,7 @@ func runSign(ctx *cli.Context) error {
 	if path == "" {
 		path = config.SignaturePath(digest.Digest(desc.Digest), digest.FromBytes(sig))
 	}
+	fmt.Println("writing signature to", path)
 	if err := osutil.WriteFile(path, sig); err != nil {
 		return err
 	}

--- a/cmd/notation/verify.go
+++ b/cmd/notation/verify.go
@@ -6,12 +6,14 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/notaryproject/notation-go-lib"
 	"github.com/notaryproject/notation/internal/cmd"
 	"github.com/notaryproject/notation/pkg/cache"
 	"github.com/notaryproject/notation/pkg/config"
 	"github.com/notaryproject/notation/pkg/signature"
+
+	"github.com/notaryproject/notation-go-lib"
 	"github.com/opencontainers/go-digest"
+	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
 
@@ -21,11 +23,7 @@ var verifyCommand = &cli.Command{
 	ArgsUsage: "<reference>",
 	Flags: []cli.Flag{
 		flagSignature,
-		&cli.StringSliceFlag{
-			Name:    "cert",
-			Aliases: []string{"c"},
-			Usage:   "certificate names for verification",
-		},
+		flagCert,
 		&cli.StringSliceFlag{
 			Name:      cmd.FlagCertFile.Name,
 			Usage:     "certificate files for verification",
@@ -111,9 +109,28 @@ func verifySignatures(ctx context.Context, verifier notation.Verifier, manifestD
 }
 
 func getVerifier(ctx *cli.Context) (notation.Verifier, error) {
+	var certName string
+	if len(ctx.StringSlice(flagCert.Name)) != 0 {
+		certName = ctx.StringSlice(flagCert.Name)[0]
+	}
+	kmsProfile, err := config.ResolveKMSCert(certName)
+	if err != nil && !errors.Is(err, config.ErrCertificateNotFound) {
+		return nil, err
+	}
+	if err == nil {
+		var pluginPath string
+		// get the plugin path for the external kms key
+
+		if pluginPath, err = config.ResolveKMSPluginPath(kmsProfile.PluginName); err != nil {
+			return nil, err
+		}
+		log.Infof("Using external kms plugin: %s", kmsProfile.PluginName)
+		// this could be the kms plugin cert
+		return signature.NewVerifierWithPlugin(kmsProfile, pluginPath)
+	}
+
 	certPaths := ctx.StringSlice(cmd.FlagCertFile.Name)
-	certPaths, err := appendCertPathFromName(certPaths, ctx.StringSlice("cert"))
-	if err != nil {
+	if certPaths, err = appendCertPathFromName(certPaths, ctx.StringSlice("cert")); err != nil {
 		return nil, err
 	}
 	if len(certPaths) == 0 {

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2
 	github.com/oras-project/artifacts-spec v1.0.0-draft.1.1
+	github.com/pkg/errors v0.9.1
+	github.com/sirupsen/logrus v1.8.1
 	github.com/urfave/cli/v2 v2.3.0
 )
 
@@ -17,10 +19,8 @@ require (
 	github.com/docker/docker v20.10.8+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect
 	github.com/golang-jwt/jwt/v4 v4.1.0 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
-	github.com/sirupsen/logrus v1.8.1 // indirect
 	golang.org/x/sys v0.0.0-20210925032602-92d5a993a665 // indirect
 	gotest.tools/v3 v3.0.3 // indirect
 )

--- a/internal/cmd/signer.go
+++ b/internal/cmd/signer.go
@@ -1,10 +1,10 @@
 package cmd
 
 import (
+	"errors"
 	"time"
 
 	"github.com/notaryproject/notation-go-lib"
-	"github.com/notaryproject/notation-go-lib/crypto/timestamp"
 	"github.com/notaryproject/notation/pkg/config"
 	"github.com/notaryproject/notation/pkg/signature"
 	"github.com/urfave/cli/v2"
@@ -14,27 +14,48 @@ import (
 func GetSigner(ctx *cli.Context) (notation.Signer, error) {
 	// read paths of the signing key and its corresponding cert.
 	var keyPath, certPath string
+	var pluginPath string
+	var kmsKey config.KMSKeySuite
+	var err error
 	if path := ctx.String(FlagKeyFile.Name); path != "" {
 		keyPath = path
 		certPath = ctx.String(FlagCertFile.Name)
 	} else {
-		var err error
 		keyPath, certPath, err = config.ResolveKeyPath(ctx.String(FlagKey.Name))
 		if err != nil {
+			if !errors.Is(err, config.ErrKeyNotFound) {
+				return nil, err
+			}
+
+			// check if the key is an external kms key
+			if kmsKey, err = config.ResolveKMSKey(ctx.String(FlagKey.Name)); err != nil {
+				return nil, err
+			}
+			// get the plugin path for the external kms key
+			if pluginPath, err = config.ResolveKMSPluginPath(kmsKey.PluginName); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	var signer notation.Signer
+	if keyPath != "" && certPath != "" {
+		// construct signer
+		if signer, err = signature.NewSignerFromFiles(keyPath, certPath); err != nil {
+			return nil, err
+		}
+	} else {
+		// construct signer with external kms plugin
+		if signer, err = signature.NewSignerWithPlugin(kmsKey, pluginPath); err != nil {
 			return nil, err
 		}
 	}
 
-	// construct signer
-	signer, err := signature.NewSignerFromFiles(keyPath, certPath)
-	if err != nil {
-		return nil, err
-	}
-	if endpoint := ctx.String(FlagTimestamp.Name); endpoint != "" {
-		if signer.TSA, err = timestamp.NewHTTPTimestamper(nil, endpoint); err != nil {
-			return nil, err
-		}
-	}
+	// if endpoint := ctx.String(FlagTimestamp.Name); endpoint != "" {
+	// 	if signer.TSA, err = timestamp.NewHTTPTimestamper(nil, endpoint); err != nil {
+	// 		return nil, err
+	// 	}
+	// }
 	return signer, nil
 }
 

--- a/internal/cmd/signer.go
+++ b/internal/cmd/signer.go
@@ -15,7 +15,7 @@ func GetSigner(ctx *cli.Context) (notation.Signer, error) {
 	// read paths of the signing key and its corresponding cert.
 	var keyPath, certPath string
 	var pluginPath string
-	var kmsKey config.KMSKeySuite
+	var kmsProfile config.KMSProfileSuite
 	var err error
 	if path := ctx.String(FlagKeyFile.Name); path != "" {
 		keyPath = path
@@ -28,11 +28,11 @@ func GetSigner(ctx *cli.Context) (notation.Signer, error) {
 			}
 
 			// check if the key is an external kms key
-			if kmsKey, err = config.ResolveKMSKey(ctx.String(FlagKey.Name)); err != nil {
+			if kmsProfile, err = config.ResolveKMSKey(ctx.String(FlagKey.Name)); err != nil {
 				return nil, err
 			}
 			// get the plugin path for the external kms key
-			if pluginPath, err = config.ResolveKMSPluginPath(kmsKey.PluginName); err != nil {
+			if pluginPath, err = config.ResolveKMSPluginPath(kmsProfile.PluginName); err != nil {
 				return nil, err
 			}
 		}
@@ -46,7 +46,7 @@ func GetSigner(ctx *cli.Context) (notation.Signer, error) {
 		}
 	} else {
 		// construct signer with external kms plugin
-		if signer, err = signature.NewSignerWithPlugin(kmsKey, pluginPath); err != nil {
+		if signer, err = signature.NewSignerWithPlugin(kmsProfile, pluginPath); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,13 +18,14 @@ type File struct {
 // VerificationCertificates is a collection of public certs used for verification.
 type VerificationCertificates struct {
 	Certificates CertificateMap `json:"certs"`
+	KMSCerts     KMSProfileMap  `json:"kmsCerts"`
 }
 
 // SigningKeys is a collection of signing keys.
 type SigningKeys struct {
-	Default string    `json:"default"`
-	Keys    KeyMap    `json:"keys"`
-	KMSKeys KMSKeyMap `json:"kmsKeys"`
+	Default string        `json:"default"`
+	Keys    KeyMap        `json:"keys"`
+	KMSKeys KMSProfileMap `json:"kmsKeys"`
 }
 
 // KMSPlugins is a collection of plugins.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,8 +22,9 @@ type VerificationCertificates struct {
 
 // SigningKeys is a collection of signing keys.
 type SigningKeys struct {
-	Default string `json:"default"`
-	Keys    KeyMap `json:"keys"`
+	Default string    `json:"default"`
+	Keys    KeyMap    `json:"keys"`
+	KMSKeys KMSKeyMap `json:"kmsKeys"`
 }
 
 // KMSPlugins is a collection of plugins.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,6 +12,7 @@ type File struct {
 	VerificationCertificates VerificationCertificates `json:"verificationCerts"`
 	SigningKeys              SigningKeys              `json:"signingKeys,omitempty"`
 	InsecureRegistries       []string                 `json:"insecureRegistries"`
+	KMSPlugins               KMSPlugins               `json:"kmsPlugins"`
 }
 
 // VerificationCertificates is a collection of public certs used for verification.
@@ -23,6 +24,11 @@ type VerificationCertificates struct {
 type SigningKeys struct {
 	Default string `json:"default"`
 	Keys    KeyMap `json:"keys"`
+}
+
+// KMSPlugins is a collection of plugins.
+type KMSPlugins struct {
+	Plugins PluginMap `json:"plugins"`
 }
 
 // New creates a new config file

--- a/pkg/config/map.go
+++ b/pkg/config/map.go
@@ -146,26 +146,26 @@ func (m PluginMap) Get(name string) (string, bool) {
 	return "", false
 }
 
-// KMSKeySuite is a named kms key suite with key id and type.
-type KMSKeySuite struct {
+// KMSProfileSuite is a named kms profile suite with key id and type.
+type KMSProfileSuite struct {
 	Name       string `json:"name"`
 	PluginName string `json:"pluginName"`
 	ID         string `json:"id"`
 }
 
-// KMSKeyMap is a set of KMSKeySuite indexed by name.
+// KMSProfileMap is a set of KMSProfileMap indexed by name.
 // The overall performance is O(n) while the order of entries is persevered.
-type KMSKeyMap []KMSKeySuite
+type KMSProfileMap []KMSProfileSuite
 
 // Append appends a uniquely named KeySuite to the map.
 // Return true if new values are appended.
-func (m *KMSKeyMap) Append(name, id, pluginName string) bool {
+func (m *KMSProfileMap) Append(name, id, pluginName string) bool {
 	for _, ref := range *m {
 		if ref.Name == name {
 			return false
 		}
 	}
-	*m = append(*m, KMSKeySuite{
+	*m = append(*m, KMSProfileSuite{
 		Name:       name,
 		ID:         id,
 		PluginName: pluginName,
@@ -175,7 +175,7 @@ func (m *KMSKeyMap) Append(name, id, pluginName string) bool {
 
 // Remove removes a named path from the map.
 // Return true if an entry is found and removed.
-func (m *KMSKeyMap) Remove(name string) bool {
+func (m *KMSProfileMap) Remove(name string) bool {
 	for i, ref := range *m {
 		if ref.Name == name {
 			*m = append((*m)[:i], (*m)[i+1:]...)
@@ -187,11 +187,11 @@ func (m *KMSKeyMap) Remove(name string) bool {
 
 // Get return the paths of the given name.
 // Return true if found.
-func (m KMSKeyMap) Get(name string) (KMSKeySuite, bool) {
+func (m KMSProfileMap) Get(name string) (KMSProfileSuite, bool) {
 	for _, ref := range m {
 		if ref.Name == name {
 			return ref, true
 		}
 	}
-	return KMSKeySuite{}, false
+	return KMSProfileSuite{}, false
 }

--- a/pkg/config/map.go
+++ b/pkg/config/map.go
@@ -145,3 +145,53 @@ func (m PluginMap) Get(name string) (string, bool) {
 	}
 	return "", false
 }
+
+// KMSKeySuite is a named kms key suite with key id and type.
+type KMSKeySuite struct {
+	Name       string `json:"name"`
+	PluginName string `json:"pluginName"`
+	ID         string `json:"id"`
+}
+
+// KMSKeyMap is a set of KMSKeySuite indexed by name.
+// The overall performance is O(n) while the order of entries is persevered.
+type KMSKeyMap []KMSKeySuite
+
+// Append appends a uniquely named KeySuite to the map.
+// Return true if new values are appended.
+func (m *KMSKeyMap) Append(name, id, pluginName string) bool {
+	for _, ref := range *m {
+		if ref.Name == name {
+			return false
+		}
+	}
+	*m = append(*m, KMSKeySuite{
+		Name:       name,
+		ID:         id,
+		PluginName: pluginName,
+	})
+	return true
+}
+
+// Remove removes a named path from the map.
+// Return true if an entry is found and removed.
+func (m *KMSKeyMap) Remove(name string) bool {
+	for i, ref := range *m {
+		if ref.Name == name {
+			*m = append((*m)[:i], (*m)[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+// Get return the paths of the given name.
+// Return true if found.
+func (m KMSKeyMap) Get(name string) (KMSKeySuite, bool) {
+	for _, ref := range m {
+		if ref.Name == name {
+			return ref, true
+		}
+	}
+	return KMSKeySuite{}, false
+}

--- a/pkg/config/map.go
+++ b/pkg/config/map.go
@@ -97,3 +97,51 @@ func (m CertificateMap) Get(name string) (string, bool) {
 	}
 	return "", false
 }
+
+// PluginReference is a a named plugin.
+type PluginReference struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
+// PluginMap is a set of PluginReference indexed by name.
+// The overall performance is O(n) while the order of entries is persevered.
+type PluginMap []PluginReference
+
+// Append appends a uniquely named path to the map.
+// Return true if new values are appended.
+func (m *PluginMap) Append(name, path string) bool {
+	for _, ref := range *m {
+		if ref.Name == name {
+			return false
+		}
+	}
+	*m = append(*m, PluginReference{
+		Name: name,
+		Path: path,
+	})
+	return true
+}
+
+// Remove removes a named path from the map.
+// Return true if an entry is found and removed.
+func (m *PluginMap) Remove(name string) bool {
+	for i, ref := range *m {
+		if ref.Name == name {
+			*m = append((*m)[:i], (*m)[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+// Get return the path of the given name.
+// Return true if found.
+func (m PluginMap) Get(name string) (string, bool) {
+	for _, ref := range m {
+		if ref.Name == name {
+			return ref.Path, true
+		}
+	}
+	return "", false
+}

--- a/pkg/config/util.go
+++ b/pkg/config/util.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 )
 
@@ -61,11 +62,10 @@ func ResolveCertificatePath(name string) (string, error) {
 	return path, nil
 }
 
-// ResolveKMSKeyID resolves the KMS key ID by name along
-// with its corresponding plugin name.
+// ResolveKMSKey resolves the KMS profile by name.
 // The default key is attempted if name is empty.
-func ResolveKMSKey(name string) (KMSKeySuite, error) {
-	key := KMSKeySuite{}
+func ResolveKMSKey(name string) (KMSProfileSuite, error) {
+	key := KMSProfileSuite{}
 	config, err := LoadOrDefaultOnce()
 	if err != nil {
 		return key, err
@@ -78,6 +78,21 @@ func ResolveKMSKey(name string) (KMSKeySuite, error) {
 		return key, ErrKeyNotFound
 	}
 	return kmsKey, nil
+}
+
+// ResolveKMSCert resolves the KMS profile by name.
+func ResolveKMSCert(name string) (KMSProfileSuite, error) {
+	cert := KMSProfileSuite{}
+	config, err := LoadOrDefaultOnce()
+	if err != nil {
+		return cert, err
+	}
+	fmt.Printf("ResolveKMSCert: name: %s\n", name)
+	kmsCert, ok := config.VerificationCertificates.KMSCerts.Get(name)
+	if !ok {
+		return cert, ErrCertificateNotFound
+	}
+	return kmsCert, nil
 }
 
 func ResolveKMSPluginPath(name string) (string, error) {

--- a/pkg/config/util.go
+++ b/pkg/config/util.go
@@ -11,6 +11,9 @@ var (
 
 	// ErrCertificateNotFound indicates that the verification certificate is not found.
 	ErrCertificateNotFound = errors.New("verification certificate not found")
+
+	// ErrKMSPluginNotFound indicates that the KMS plugin is not found.
+	ErrPluginNotFound = errors.New("plugin not found")
 )
 
 // IsRegistryInsecure checks whether the registry is in the list of insecure registries.
@@ -54,6 +57,37 @@ func ResolveCertificatePath(name string) (string, error) {
 	path, ok := config.VerificationCertificates.Certificates.Get(name)
 	if !ok {
 		return "", ErrCertificateNotFound
+	}
+	return path, nil
+}
+
+// ResolveKMSKeyID resolves the KMS key ID by name along
+// with its corresponding plugin name.
+// The default key is attempted if name is empty.
+func ResolveKMSKey(name string) (KMSKeySuite, error) {
+	key := KMSKeySuite{}
+	config, err := LoadOrDefaultOnce()
+	if err != nil {
+		return key, err
+	}
+	if name == "" {
+		name = config.SigningKeys.Default
+	}
+	kmsKey, ok := config.SigningKeys.KMSKeys.Get(name)
+	if !ok {
+		return key, ErrKeyNotFound
+	}
+	return kmsKey, nil
+}
+
+func ResolveKMSPluginPath(name string) (string, error) {
+	config, err := LoadOrDefaultOnce()
+	if err != nil {
+		return "", err
+	}
+	path, ok := config.KMSPlugins.Plugins.Get(name)
+	if !ok {
+		return "", ErrPluginNotFound
 	}
 	return path, nil
 }

--- a/pkg/config/util.go
+++ b/pkg/config/util.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 )
 
@@ -87,7 +86,6 @@ func ResolveKMSCert(name string) (KMSProfileSuite, error) {
 	if err != nil {
 		return cert, err
 	}
-	fmt.Printf("ResolveKMSCert: name: %s\n", name)
 	kmsCert, ok := config.VerificationCertificates.KMSCerts.Get(name)
 	if !ok {
 		return cert, ErrCertificateNotFound

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -1,0 +1,41 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+type Interface interface {
+	Execute(ctx context.Context, argsf string, a ...interface{}) ([]byte, error)
+}
+
+type executor struct {
+	cmd     string
+	prepend []string
+}
+
+var _ Interface = &executor{}
+
+func NewExecutor(cmd string, prepend ...string) Interface {
+	return &executor{
+		cmd:     cmd,
+		prepend: prepend,
+	}
+}
+
+func (e *executor) Execute(ctx context.Context, argsf string, a ...interface{}) ([]byte, error) {
+	substituted := fmt.Sprintf(argsf, a...)
+	args := append(e.prepend, strings.Split(substituted, " ")...)
+	log.Infof("Executing: %s %s", e.cmd, strings.Join(args, " "))
+	cmd := exec.CommandContext(ctx, e.cmd, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to execute %s %s", e.cmd, strings.Join(args, " "))
+	}
+	return out, nil
+}

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -11,7 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type Interface interface {
+type Executor interface {
 	Execute(ctx context.Context, argsf string, a ...interface{}) ([]byte, error)
 }
 
@@ -20,9 +20,7 @@ type executor struct {
 	prepend []string
 }
 
-var _ Interface = &executor{}
-
-func NewExecutor(cmd string, prepend ...string) Interface {
+func NewExecutor(cmd string, prepend ...string) Executor {
 	return &executor{
 		cmd:     cmd,
 		prepend: prepend,
@@ -32,6 +30,8 @@ func NewExecutor(cmd string, prepend ...string) Interface {
 // Execute executes the command with the given arguments.
 func (e *executor) Execute(ctx context.Context, argsf string, a ...interface{}) ([]byte, error) {
 	substituted := fmt.Sprintf(argsf, a...)
+	// "%s %s", "foo", "foo bar" will become ["foo", "foo", "bar"], not [ "foo", "foo bar"]
+	// TODO: handle scenarios with space in the arguments
 	args := append(e.prepend, strings.Split(substituted, " ")...)
 	log.Debugf("Executing: %s %s", e.cmd, strings.Join(args, " "))
 	log.Infof("Executing: %s <args>", e.cmd)

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -34,6 +34,7 @@ func (e *executor) Execute(ctx context.Context, argsf string, a ...interface{}) 
 	log.Infof("Executing: %s %s", e.cmd, strings.Join(args, " "))
 	cmd := exec.CommandContext(ctx, e.cmd, args...)
 	out, err := cmd.CombinedOutput()
+	log.Infof("Output: %s", out)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to execute %s %s", e.cmd, strings.Join(args, " "))
 	}

--- a/pkg/signature/kms_jws.go
+++ b/pkg/signature/kms_jws.go
@@ -29,7 +29,7 @@ type VerifyRequest struct {
 type externalPlugin struct {
 	kmsProfile config.KMSProfileSuite
 
-	executor executor.Interface
+	executor executor.Executor
 }
 
 // NewSignerWithPlugin returns a signer that uses the given plugin
@@ -73,7 +73,7 @@ func (p *externalPlugin) Sign(ctx context.Context, desc notation.Descriptor, opt
 	}
 
 	// execute plugin
-	return p.executor.Execute(ctx, string(reqBytes))
+	return p.executor.Execute(ctx, "%s", string(reqBytes))
 }
 
 func (p *externalPlugin) Verify(ctx context.Context, signature []byte, opts notation.VerifyOptions) (notation.Descriptor, error) {

--- a/pkg/signature/kms_jws.go
+++ b/pkg/signature/kms_jws.go
@@ -1,0 +1,110 @@
+package signature
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/notaryproject/notation-go-lib"
+	"github.com/notaryproject/notation/pkg/config"
+	"github.com/notaryproject/notation/pkg/executor"
+)
+
+// SignRequest is the request to sign artifacts
+type SignRequest struct {
+	Version     string               `json:"version"`
+	Descriptor  notation.Descriptor  `json:"descriptor"`
+	SignOptions notation.SignOptions `json:"signOptions"`
+	Key         config.KMSKeySuite   `json:"key"`
+}
+
+// VerifyRequest is the request to verify a signature.
+type VerifyRequest struct {
+	Version       string                 `json:"version"`
+	Signature     []byte                 `json:"signature"`
+	VerifyOptions notation.VerifyOptions `json:"verifyOptions"`
+	Key           config.KMSKeySuite     `json:"key"`
+}
+
+type externalPlugin struct {
+	key        config.KMSKeySuite
+	pluginPath string
+
+	executor executor.Interface
+}
+
+// NewSignerWithPlugin returns a signer that uses the given plugin
+func NewSignerWithPlugin(key config.KMSKeySuite, pluginPath string) (notation.Signer, error) {
+	if pluginPath == "" {
+		return nil, errors.New("plugin path not specified")
+	}
+
+	// create signer
+	return &externalPlugin{
+		key:        key,
+		pluginPath: pluginPath,
+		executor:   executor.NewExecutor(pluginPath, "sign"),
+	}, nil
+}
+
+func NewVerifierWithPlugin(pluginName, pluginPath string) (notation.Verifier, error) {
+	if pluginPath == "" {
+		return nil, errors.New("plugin path not specified")
+	}
+
+	// create verifier
+	return &externalPlugin{
+		pluginPath: pluginPath,
+		executor:   executor.NewExecutor(pluginPath, "verify"),
+	}, nil
+}
+
+func (p *externalPlugin) Sign(ctx context.Context, desc notation.Descriptor, opts notation.SignOptions) ([]byte, error) {
+	// create request
+	req := SignRequest{
+		Version:     "v0.1.0-alpha.0",
+		Descriptor:  desc,
+		SignOptions: opts,
+		Key:         p.key,
+	}
+
+	// marshal request
+	reqBytes, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// execute plugin
+	return p.executor.Execute(ctx, string(reqBytes))
+}
+
+func (p *externalPlugin) Verify(ctx context.Context, signature []byte, opts notation.VerifyOptions) (notation.Descriptor, error) {
+	retDesc := notation.Descriptor{}
+
+	// create request
+	req := VerifyRequest{
+		Version:       "v0.1.0-alpha.0",
+		Signature:     signature,
+		VerifyOptions: opts,
+	}
+
+	// marshal request
+	reqBytes, err := json.Marshal(req)
+	if err != nil {
+		return retDesc, err
+	}
+
+	// execute plugin
+	respBytes, err := p.executor.Execute(ctx, string(reqBytes))
+	if err != nil {
+		return retDesc, err
+	}
+
+	// unmarshal response
+	err = json.Unmarshal(respBytes, &retDesc)
+	if err != nil {
+		return retDesc, err
+	}
+
+	return retDesc, nil
+}


### PR DESCRIPTION
Adds framework to:

- Add, remove, list kms plugin
- Add kms keys for signing and verification

This is a proof of concept based on the initial hackmd spec. For more details on the implementation refer to https://docs.google.com/document/d/1tDxprA7_H2tVJP0YZFznuTTqDwFP4qks5SaSMaOpS80/edit?usp=sharing. 