### PR TITLE
Automatically upload release asset for feature branch feat-kv-extensibility

### DIFF
--- a/.github/workflows/upload-release-asset.yml
+++ b/.github/workflows/upload-release-asset.yml
@@ -1,0 +1,57 @@
+name: upload-release-asset
+
+on:
+  push:
+    branches: 
+      - 'feat-kv-extensibility'
+
+jobs:
+  build:
+    name: Upload Release Asset
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [1.17]
+      fail-fast: true
+    steps:
+    - name: Set up Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set env variables
+      run: |
+        echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+        echo "SHORT_HASH=$(git rev-parse --short=7 ${{ github.sha }})" >> $GITHUB_ENV
+        echo "DATETIME=$(date "+%Y%m%d%H%M%S")" >> $GITHUB_ENV
+
+    - name: Get upload_url
+      run: |
+        upload_url=$(curl -sL https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ env.BRANCH_NAME }} | jq -r '.upload_url')
+        echo "UPLOAD_URL=$upload_url" >> $GITHUB_ENV
+
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v2
+      with:
+        distribution: goreleaser
+        version: latest
+        args: release --rm-dist --snapshot
+
+    - name: Archive binaries
+      run: cd dist && tar -cvzf notation.tar.gz notation*.*
+
+    - name: Upload release asset
+      uses: actions/upload-release-asset@v1
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ env.UPLOAD_URL }}
+        asset_name: notation-${{ env.BRANCH_NAME }}-${{ env.DATETIME }}-${{ env.SHORT_HASH }}.tar.gz
+        asset_path: dist/notation.tar.gz
+        asset_content_type: application/gzip
+
+
+


### PR DESCRIPTION
Resolve https://github.com/notaryproject/notaryproject/issues/120

The new Github action will automatically build binaries when there is a new commit (including PR-merge) on the `feat-kv-extensibility` feature branch, and upload the asset to the dedicated release page.

Format:
- Release tag: [branch name]

- Assets: notation-[branch name]-[YYmmddHHMMSS]-[short commit hash].tar.gz

Sample job: https://github.com/Wwwsylvia/notation/actions/workflows/upload-release-asset.yml
Sample release: https://github.com/Wwwsylvia/notation/releases/tag/feat-kv-extensibility