### PR TITLE
Update deps links for notation-go

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Discussions](https://github.com/notaryproject/notaryproject/discussions).
 This project is composed of:
 
 - [notation](https://github.com/notaryproject/notation): The Notary v2 CLI and Docker plugins
-- [notation-go-lib](https://github.com/notaryproject/notation-go-lib): A collection of libraries for supporting Notation sign, verify of oci artifacts. Based on Notary V2 standard.
+- [notation-go-lib](https://github.com/notaryproject/notation-go): A collection of libraries for supporting Notation sign, verify of oci artifacts. Based on Notary V2 standard.
 - [notaryproject](https://github.com/notaryproject/notaryproject): The Notary v2 requirements and scenarios to frame the scope of the Notary project
 - [tuf-notary](https://github.com/notaryproject/tuf): Integration of Notary v2 and TUF
 

--- a/cmd/docker-notation/docker/manifest.go
+++ b/cmd/docker-notation/docker/manifest.go
@@ -5,7 +5,7 @@ import (
 	"os/exec"
 
 	"github.com/distribution/distribution/v3/manifest/schema2"
-	"github.com/notaryproject/notation-go-lib"
+	"github.com/notaryproject/notation-go"
 	"github.com/notaryproject/notation/pkg/docker"
 	"github.com/opencontainers/go-digest"
 	"oras.land/oras-go/v2/registry"

--- a/cmd/docker-notation/pull.go
+++ b/cmd/docker-notation/pull.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/notaryproject/notation-go-lib"
+	"github.com/notaryproject/notation-go"
 	"github.com/notaryproject/notation/cmd/docker-notation/docker"
 	"github.com/notaryproject/notation/pkg/cache"
 	"github.com/notaryproject/notation/pkg/config"

--- a/cmd/docker-notation/push.go
+++ b/cmd/docker-notation/push.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/distribution/distribution/v3/manifest/schema2"
-	"github.com/notaryproject/notation-go-lib"
+	"github.com/notaryproject/notation-go"
 	"github.com/notaryproject/notation/cmd/docker-notation/docker"
 	"github.com/notaryproject/notation/pkg/cache"
 	"github.com/notaryproject/notation/pkg/config"

--- a/cmd/docker-notation/sign.go
+++ b/cmd/docker-notation/sign.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/notaryproject/notation-go-lib"
+	"github.com/notaryproject/notation-go"
 	"github.com/notaryproject/notation/cmd/docker-notation/docker"
 	"github.com/notaryproject/notation/internal/cmd"
 	"github.com/notaryproject/notation/internal/osutil"

--- a/cmd/docker-notation/util.go
+++ b/cmd/docker-notation/util.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/notaryproject/notation-go-lib"
+	"github.com/notaryproject/notation-go"
 	"github.com/notaryproject/notation/pkg/config"
 	"github.com/notaryproject/notation/pkg/signature"
 )

--- a/cmd/notation/cert.go
+++ b/cmd/notation/cert.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/notaryproject/notation-go-lib/crypto/cryptoutil"
+	"github.com/notaryproject/notation-go/crypto/cryptoutil"
 	"github.com/notaryproject/notation/pkg/config"
 	"github.com/urfave/cli/v2"
 )

--- a/cmd/notation/manifest.go
+++ b/cmd/notation/manifest.go
@@ -6,7 +6,7 @@ import (
 	"math"
 	"os"
 
-	"github.com/notaryproject/notation-go-lib"
+	"github.com/notaryproject/notation-go"
 	"github.com/opencontainers/go-digest"
 	"github.com/urfave/cli/v2"
 	"oras.land/oras-go/v2/registry"

--- a/cmd/notation/push.go
+++ b/cmd/notation/push.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/notaryproject/notation-go-lib"
+	"github.com/notaryproject/notation-go"
 	"github.com/notaryproject/notation/pkg/cache"
 	"github.com/notaryproject/notation/pkg/config"
 	"github.com/urfave/cli/v2"

--- a/cmd/notation/sign.go
+++ b/cmd/notation/sign.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/notaryproject/notation-go-lib"
+	"github.com/notaryproject/notation-go"
 	"github.com/notaryproject/notation/internal/cmd"
 	"github.com/notaryproject/notation/internal/osutil"
 	"github.com/notaryproject/notation/pkg/config"

--- a/cmd/notation/verify.go
+++ b/cmd/notation/verify.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/notaryproject/notation-go-lib"
+	"github.com/notaryproject/notation-go"
 	"github.com/notaryproject/notation/internal/cmd"
 	"github.com/notaryproject/notation/pkg/cache"
 	"github.com/notaryproject/notation/pkg/config"

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/distribution/distribution/v3 v3.0.0-20210804104954-38ab4c606ee3
 	github.com/docker/cli v20.10.14+incompatible
-	github.com/notaryproject/notation-go-lib v0.7.0-alpha.1
+	github.com/notaryproject/notation-go v0.7.0-alpha.1
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2
 	github.com/oras-project/artifacts-spec v1.0.0-draft.1.1

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
 	github.com/docker/docker v20.10.8+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect
-	github.com/golang-jwt/jwt/v4 v4.1.0 // indirect
+	github.com/golang-jwt/jwt/v4 v4.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/distribution/distribution/v3 v3.0.0-20210804104954-38ab4c606ee3
 	github.com/docker/cli v20.10.14+incompatible
-	github.com/notaryproject/notation-go v0.7.0-alpha.1
+	github.com/notaryproject/notation-go v0.7.0-alpha.1.0.20220422005131-96df588f2f6d
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2
 	github.com/oras-project/artifacts-spec v1.0.0-draft.1.1

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
-github.com/notaryproject/notation-go v0.7.0-alpha.1 h1:DSyCcjb2w00qw69wnlQwR6ss6b9kW0pllNoFoCDCAY0=
-github.com/notaryproject/notation-go v0.7.0-alpha.1/go.mod h1:3G7xPzga5+8e0mRMhMKpx1gIikr5c7tnZaKT6JQnlmM=
+github.com/notaryproject/notation-go v0.7.0-alpha.1.0.20220422005131-96df588f2f6d h1:qIylQ35uMNA2ZSgppopKTAFGJj34UelBJj5iCH2PgTY=
+github.com/notaryproject/notation-go v0.7.0-alpha.1.0.20220422005131-96df588f2f6d/go.mod h1:B/JbgikwvLoD9gFeWYhFtxIEozRoFAs9q31mj3vz1i4=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
-github.com/notaryproject/notation-go-lib v0.7.0-alpha.1 h1:DSyCcjb2w00qw69wnlQwR6ss6b9kW0pllNoFoCDCAY0=
-github.com/notaryproject/notation-go-lib v0.7.0-alpha.1/go.mod h1:3G7xPzga5+8e0mRMhMKpx1gIikr5c7tnZaKT6JQnlmM=
+github.com/notaryproject/notation-go v0.7.0-alpha.1 h1:DSyCcjb2w00qw69wnlQwR6ss6b9kW0pllNoFoCDCAY0=
+github.com/notaryproject/notation-go v0.7.0-alpha.1/go.mod h1:3G7xPzga5+8e0mRMhMKpx1gIikr5c7tnZaKT6JQnlmM=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
-github.com/golang-jwt/jwt/v4 v4.1.0 h1:XUgk2Ex5veyVFVeLm0xhusUTQybEbexJXrvPNOKkSY0=
-github.com/golang-jwt/jwt/v4 v4.1.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
+github.com/golang-jwt/jwt/v4 v4.3.0 h1:kHL1vqdqWNfATmA0FNMdmZNMyZI1U6O31X4rlIPoBog=
+github.com/golang-jwt/jwt/v4 v4.3.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/cmd/signer.go
+++ b/internal/cmd/signer.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"time"
 
-	"github.com/notaryproject/notation-go-lib"
-	"github.com/notaryproject/notation-go-lib/crypto/timestamp"
+	"github.com/notaryproject/notation-go"
+	"github.com/notaryproject/notation-go/crypto/timestamp"
 	"github.com/notaryproject/notation/pkg/config"
 	"github.com/notaryproject/notation/pkg/signature"
 	"github.com/urfave/cli/v2"

--- a/pkg/registry/interface.go
+++ b/pkg/registry/interface.go
@@ -3,7 +3,7 @@ package registry
 import (
 	"context"
 
-	"github.com/notaryproject/notation-go-lib"
+	"github.com/notaryproject/notation-go"
 	"github.com/opencontainers/go-digest"
 )
 

--- a/pkg/registry/repository.go
+++ b/pkg/registry/repository.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/notaryproject/notation-go-lib"
+	"github.com/notaryproject/notation-go"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"

--- a/pkg/signature/jws.go
+++ b/pkg/signature/jws.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"os"
 
-	"github.com/notaryproject/notation-go-lib/crypto/cryptoutil"
-	"github.com/notaryproject/notation-go-lib/signature/jws"
+	"github.com/notaryproject/notation-go/crypto/cryptoutil"
+	"github.com/notaryproject/notation-go/signature/jws"
 )
 
 // NewSignerFromFiles creates a signer from key, certificate files


### PR DESCRIPTION
This is to allow the client to utilize the latest version of the now renamed notation-go library. It will need another release on main to finalize.