### PR TITLE
Fix pluginConfig parsing

### DIFF
--- a/cmd/notation/key.go
+++ b/cmd/notation/key.go
@@ -135,7 +135,7 @@ func addExternalKey(ctx *cli.Context, pluginName, keyName string) (config.KeySui
 	if p.Err != nil {
 		return config.KeySuite{}, fmt.Errorf("invalid plugin: %w", p.Err)
 	}
-	pluginConfig, err := cmd.ParseFlagPluginConfig(ctx.StringSlice(cmd.FlagPluginConfig.Name))
+	pluginConfig, err := cmd.ParseFlagPluginConfig(ctx.String(cmd.FlagPluginConfig.Name))
 	if err != nil {
 		return config.KeySuite{}, err
 	}

--- a/cmd/notation/sign.go
+++ b/cmd/notation/sign.go
@@ -102,7 +102,7 @@ func prepareSigningContent(ctx *cli.Context) (notation.Descriptor, notation.Sign
 			return notation.Descriptor{}, notation.SignOptions{}, err
 		}
 	}
-	pluginConfig, err := cmd.ParseFlagPluginConfig(ctx.StringSlice(cmd.FlagPluginConfig.Name))
+	pluginConfig, err := cmd.ParseFlagPluginConfig(ctx.String(cmd.FlagPluginConfig.Name))
 	if err != nil {
 		return notation.Descriptor{}, notation.SignOptions{}, err
 	}

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -45,17 +45,18 @@ var (
 		Usage:   "original reference",
 	}
 
-	FlagPluginConfig = &cli.StringSliceFlag{
+	FlagPluginConfig = &cli.StringFlag{
 		Name:    "pluginConfig",
 		Aliases: []string{"pc"},
 		Usage:   "list of comma-separated {key}={value} pairs that are passed as is to the plugin, refer plugin documentation to set appropriate values",
 	}
 )
 
-func ParseFlagPluginConfig(pluginConfigSlice []string) (map[string]string, error) {
-	if len(pluginConfigSlice) == 0 {
+func ParseFlagPluginConfig(v string) (map[string]string, error) {
+	if v == "" {
 		return nil, nil
 	}
+	pluginConfigSlice := strings.Split(v, ",")
 	m := make(map[string]string, len(pluginConfigSlice))
 	for _, c := range pluginConfigSlice {
 		if k, v, ok := strings.Cut(c, "="); ok {

--- a/internal/cmd/flags_test.go
+++ b/internal/cmd/flags_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestParseFlagPluginConfig(t *testing.T) {
 	type args struct {
-		s []string
+		s string
 	}
 	tests := []struct {
 		name    string
@@ -16,13 +16,12 @@ func TestParseFlagPluginConfig(t *testing.T) {
 		want    map[string]string
 		wantErr bool
 	}{
-		{"nil", args{nil}, nil, false},
-		{"empty", args{[]string{}}, nil, false},
-		{"single", args{[]string{"a=b"}}, map[string]string{"a": "b"}, false},
-		{"multiple", args{[]string{"a=b", "c=d"}}, map[string]string{"a": "b", "c": "d"}, false},
-		{"quoted", args{[]string{"a=b", "\"c\"=d"}}, map[string]string{"a": "b", "\"c\"": "d"}, false},
-		{"duplicated", args{[]string{"a=b", "a=d"}}, nil, true},
-		{"malformed", args{[]string{"a=b", "c:d"}}, nil, true},
+		{"empty", args{""}, nil, false},
+		{"single", args{"a=b"}, map[string]string{"a": "b"}, false},
+		{"multiple", args{"a=b,c=d"}, map[string]string{"a": "b", "c": "d"}, false},
+		{"quoted", args{"a=b,\"c\"=d"}, map[string]string{"a": "b", "\"c\"": "d"}, false},
+		{"duplicated", args{"a=b,a=d"}, nil, true},
+		{"malformed", args{"a=b,c:d"}, nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
`--pluginConfig` flag is currently not being split by `,` when there are multiple entries.

This PR fixes the parsing of the `--pluginConfig` flag to correctly account for multiple entries. 

Signed-off-by: qmuntal <qmuntaldiaz@microsoft.com>