### PR TITLE
bump to go 1.18

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go-version: [1.17]
+        go-version: [1.18]
       fail-fast: true
     steps:
       - name: Set up Go ${{ matrix.go-version }}


### PR DESCRIPTION
This fixes the go-releaser to automatically attach the binaries.  It needs go 1.18 to understand slices.