### PR TITLE
Add issues to project action

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -12,5 +12,3 @@ jobs:
         with:
           project-url: https://github.com/orgs/notaryproject/projects/10
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
-          labeled: needs-triage
-          label-operator: OR

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,16 @@
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/notaryproject/projects/10
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labeled: needs-triage
+          label-operator: OR


### PR DESCRIPTION
This will make it so any time an issue is created in the repository that it will get automatically added with a `needs-triage` label and be added to the Notary-Planning project using the [Add To GitHub Projects Beta action](https://github.com/marketplace/actions/add-to-github-projects-beta).