### PR TITLE
use cobra for notation cli

### DIFF
--- a/cmd/docker-notation/sign.go
+++ b/cmd/docker-notation/sign.go
@@ -34,7 +34,7 @@ var signCommand = &cli.Command{
 func signImage(ctx *cli.Context) error {
 	// TODO: make this change only to make sure the code can be compiled
 	// According to the https://github.com/notaryproject/notation/discussions/251,
-	//  we can update/deprecate it later
+	// we can update/deprecate it later
 	signerOpts := &cmd.SignerFlagOpts{
 		Key:      ctx.String(cmd.FlagKey.Name),
 		KeyFile:  ctx.String(cmd.FlagKeyFile.Name),

--- a/cmd/docker-notation/sign.go
+++ b/cmd/docker-notation/sign.go
@@ -32,7 +32,15 @@ var signCommand = &cli.Command{
 }
 
 func signImage(ctx *cli.Context) error {
-	signer, err := cmd.GetSigner(ctx)
+	// TODO: make this change only to make sure the code can be compiled
+	// According to the https://github.com/notaryproject/notation/discussions/251,
+	//  we can update/deprecate it later
+	signerOpts := &cmd.SignerFlagOpts{
+		Key:      ctx.String(cmd.FlagKey.Name),
+		KeyFile:  ctx.String(cmd.FlagKeyFile.Name),
+		CertFile: ctx.String(cmd.FlagCertFile.Name),
+	}
+	signer, err := cmd.GetSigner(signerOpts)
 	if err != nil {
 		return err
 	}
@@ -55,7 +63,7 @@ func signImage(ctx *cli.Context) error {
 		}
 	}
 	sig, err := signer.Sign(ctx.Context, desc, notation.SignOptions{
-		Expiry: cmd.GetExpiry(ctx),
+		Expiry: cmd.GetExpiry(ctx.Duration(cmd.FlagExpiry.Name)),
 	})
 	if err != nil {
 		return err

--- a/cmd/notation/cache.go
+++ b/cmd/notation/cache.go
@@ -60,7 +60,7 @@ func cacheListCommand(opts *cacheListOpts) *cobra.Command {
 			return listCachedSignatures(cmd, opts)
 		},
 	}
-	opts.ApplyFlag(command.Flags())
+	opts.ApplyFlags(command.Flags())
 	return command
 }
 
@@ -82,7 +82,7 @@ func cachePruneCommand(opts *cachePruneOpts) *cobra.Command {
 	command.Flags().BoolVarP(&opts.all, "all", "a", false, "prune all cached signatures")
 	command.Flags().BoolVar(&opts.purge, "purge", false, "remove the signature directory, combined with --all")
 	command.Flags().BoolVarP(&opts.force, "force", "f", false, "do not prompt for confirmation")
-	opts.ApplyFlag(command.Flags())
+	opts.ApplyFlags(command.Flags())
 	return command
 }
 
@@ -103,7 +103,7 @@ func cacheRemoveCommand(opts *cacheRemoveOpts) *cobra.Command {
 			return removeCachedSignatures(cmd, opts)
 		},
 	}
-	opts.ApplyFlag(command.Flags())
+	opts.ApplyFlags(command.Flags())
 	return command
 }
 

--- a/cmd/notation/cache.go
+++ b/cmd/notation/cache.go
@@ -20,6 +20,7 @@ type cacheListOpts struct {
 	RemoteFlagOpts
 	reference string
 }
+
 type cachePruneOpts struct {
 	RemoteFlagOpts
 	references []string

--- a/cmd/notation/cert.go
+++ b/cmd/notation/cert.go
@@ -11,86 +11,114 @@ import (
 	"github.com/notaryproject/notation/internal/ioutil"
 	"github.com/notaryproject/notation/internal/slices"
 	"github.com/notaryproject/notation/pkg/config"
-	"github.com/urfave/cli/v2"
+	"github.com/spf13/cobra"
 )
 
-var (
-	certCommand = &cli.Command{
-		Name:    "certificate",
+type certAddOpts struct {
+	path string
+	name string
+}
+
+type certRemoveOpts struct {
+	names []string
+}
+
+type certGenerateTestOpts struct {
+	name      string
+	bits      int
+	expiry    time.Duration
+	trust     bool
+	hosts     []string
+	isDefault bool
+}
+
+func certCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:     "certificate",
 		Aliases: []string{"cert"},
-		Usage:   "Manage certificates used for verification",
-		Subcommands: []*cli.Command{
-			certAddCommand,
-			certListCommand,
-			certRemoveCommand,
-			certGenerateTestCommand,
-		},
+		Short:   "Manage certificates used for verification",
 	}
 
-	certAddCommand = &cli.Command{
-		Name:      "add",
-		Usage:     "Add certificate to verification list",
-		ArgsUsage: "<path>",
-		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:    "name",
-				Aliases: []string{"n"},
-				Usage:   "certificate name",
-			},
-		},
-		Action: addCert,
-	}
+	command.AddCommand(certAddCommand(nil), certListCommand(), certRemoveCommand(nil), certGenerateTestCommand(nil))
+	return command
+}
 
-	certListCommand = &cli.Command{
-		Name:    "list",
-		Usage:   "List certificates used for verification",
+func certAddCommand(opts *certAddOpts) *cobra.Command {
+	if opts == nil {
+		opts = &certAddOpts{}
+	}
+	command := &cobra.Command{
+		Use:   "add [path]",
+		Short: "Add certificate to verification list",
+		Args:  cobra.ExactArgs(1),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			opts.path = args[0]
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return addCert(cmd, opts)
+		},
+	}
+	command.Flags().StringVarP(&opts.name, "name", "n", "", "certificate name")
+	return command
+}
+
+func certListCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:     "list",
 		Aliases: []string{"ls"},
-		Action:  listCerts,
-	}
-
-	certRemoveCommand = &cli.Command{
-		Name:      "remove",
-		Usage:     "Remove certificate from the verification list",
-		Aliases:   []string{"rm"},
-		ArgsUsage: "<name> ...",
-		Action:    removeCerts,
-	}
-
-	certGenerateTestCommand = &cli.Command{
-		Name:      "generate-test",
-		Usage:     "Generates a test RSA key and a corresponding self-signed certificate",
-		ArgsUsage: "<host> ...",
-		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:    "name",
-				Aliases: []string{"n"},
-				Usage:   "key and certificate name",
-			},
-			&cli.IntFlag{
-				Name:    "bits",
-				Usage:   "RSA key bits",
-				Aliases: []string{"b"},
-				Value:   2048,
-			},
-			&cli.DurationFlag{
-				Name:    "expiry",
-				Aliases: []string{"e"},
-				Usage:   "certificate expiry",
-				Value:   365 * 24 * time.Hour,
-			},
-			&cli.BoolFlag{
-				Name:  "trust",
-				Usage: "add the generated certificate to the verification list",
-			},
-			keyDefaultFlag,
+		Short:   "List certificates used for verification",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return listCerts(cmd)
 		},
-		Action: generateTestCert,
 	}
-)
+	return command
+}
+func certRemoveCommand(opts *certRemoveOpts) *cobra.Command {
+	if opts == nil {
+		opts = &certRemoveOpts{}
+	}
+	command := &cobra.Command{
+		Use:     "remove [name]...",
+		Aliases: []string{"rm"},
+		Short:   "Remove certificate from the verification list",
+		Args:    cobra.MinimumNArgs(1),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			opts.names = args
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return removeCerts(cmd, opts)
+		},
+	}
+	return command
+}
+func certGenerateTestCommand(opts *certGenerateTestOpts) *cobra.Command {
+	if opts == nil {
+		opts = &certGenerateTestOpts{}
+	}
+	command := &cobra.Command{
+		Use:   "generate-test [host]...",
+		Short: "Generates a test RSA key and a corresponding self-signed certificate",
+		Args:  cobra.MinimumNArgs(1),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			opts.hosts = args
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return generateTestCert(opts)
+		},
+	}
 
-func addCert(ctx *cli.Context) error {
+	command.Flags().StringVarP(&opts.name, "name", "n", "", "key and certificate name")
+	command.Flags().IntVarP(&opts.bits, "bits", "b", 2048, "RSA key bits")
+	command.Flags().DurationVarP(&opts.expiry, "expiry", "e", 365*24*time.Hour, "certificate expiry")
+	command.Flags().BoolVar(&opts.trust, "trust", false, "add the generated certificate to the verification list")
+	setKeyDefaultFlag(command.Flags(), &opts.isDefault)
+	return command
+}
+
+func addCert(command *cobra.Command, opts *certAddOpts) error {
 	// initialize
-	path := ctx.Args().First()
+
+	path := opts.path
 	if path == "" {
 		return errors.New("missing certificate path")
 	}
@@ -98,7 +126,7 @@ func addCert(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	name := ctx.String("name")
+	name := opts.name
 
 	// check if the target path is a cert
 	if _, err := x509.ReadCertificateFile(path); err != nil {
@@ -133,7 +161,7 @@ func addCertCore(cfg *config.File, name, path string) error {
 	return nil
 }
 
-func listCerts(ctx *cli.Context) error {
+func listCerts(command *cobra.Command) error {
 	// core process
 	cfg, err := config.LoadOrDefault()
 	if err != nil {
@@ -144,9 +172,9 @@ func listCerts(ctx *cli.Context) error {
 	return ioutil.PrintCertificateMap(os.Stdout, cfg.VerificationCertificates.Certificates)
 }
 
-func removeCerts(ctx *cli.Context) error {
+func removeCerts(command *cobra.Command, opts *certRemoveOpts) error {
 	// initialize
-	names := ctx.Args().Slice()
+	names := opts.names
 	if len(names) == 0 {
 		return errors.New("missing certificate names")
 	}

--- a/cmd/notation/cert_gen.go
+++ b/cmd/notation/cert_gen.go
@@ -15,22 +15,21 @@ import (
 
 	"github.com/notaryproject/notation/internal/osutil"
 	"github.com/notaryproject/notation/pkg/config"
-	"github.com/urfave/cli/v2"
 )
 
-func generateTestCert(ctx *cli.Context) error {
+func generateTestCert(opts *certGenerateTestOpts) error {
 	// initialize
-	hosts := ctx.Args().Slice()
+	hosts := opts.hosts
 	if len(hosts) == 0 {
 		return errors.New("missing certificate hosts")
 	}
-	name := ctx.String("name")
+	name := opts.name
 	if name == "" {
 		name = hosts[0]
 	}
 
 	// generate RSA private key
-	bits := ctx.Int("bits")
+	bits := opts.bits
 	fmt.Println("generating RSA Key with", bits, "bits")
 	key, keyBytes, err := generateTestKey(bits)
 	if err != nil {
@@ -38,7 +37,8 @@ func generateTestCert(ctx *cli.Context) error {
 	}
 
 	// generate self-signed certificate
-	cert, certBytes, err := generateTestSelfSignedCert(key, hosts, ctx.Duration("expiry"))
+	expiry := opts.expiry
+	cert, certBytes, err := generateTestSelfSignedCert(key, hosts, expiry)
 	if err != nil {
 		return err
 	}
@@ -63,7 +63,7 @@ func generateTestCert(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	isDefault := ctx.Bool(keyDefaultFlag.Name)
+	isDefault := opts.isDefault
 	keySuite := config.KeySuite{
 		Name: name,
 		X509KeyPair: &config.X509KeyPair{
@@ -71,11 +71,11 @@ func generateTestCert(ctx *cli.Context) error {
 			CertificatePath: certPath,
 		},
 	}
-	err = addKeyCore(cfg, keySuite, ctx.Bool(keyDefaultFlag.Name))
+	err = addKeyCore(cfg, keySuite, isDefault)
 	if err != nil {
 		return err
 	}
-	trust := ctx.Bool("trust")
+	trust := opts.trust
 	if trust {
 		if err := addCertCore(cfg, name, certPath); err != nil {
 			return err

--- a/cmd/notation/cert_gen.go
+++ b/cmd/notation/cert_gen.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"errors"
 	"fmt"
 	"math/big"
 	"net"
@@ -20,9 +19,6 @@ import (
 func generateTestCert(opts *certGenerateTestOpts) error {
 	// initialize
 	hosts := opts.hosts
-	if len(hosts) == 0 {
-		return errors.New("missing certificate hosts")
-	}
 	name := opts.name
 	if name == "" {
 		name = hosts[0]

--- a/cmd/notation/cert_gen.go
+++ b/cmd/notation/cert_gen.go
@@ -37,8 +37,7 @@ func generateTestCert(opts *certGenerateTestOpts) error {
 	}
 
 	// generate self-signed certificate
-	expiry := opts.expiry
-	cert, certBytes, err := generateTestSelfSignedCert(key, hosts, expiry)
+	cert, certBytes, err := generateTestSelfSignedCert(key, hosts, opts.expiry)
 	if err != nil {
 		return err
 	}

--- a/cmd/notation/common.go
+++ b/cmd/notation/common.go
@@ -93,22 +93,22 @@ func (opts *SecureFlagOpts) ApplyFlag(fs *pflag.FlagSet) {
 	opts.Password = os.Getenv(defaultPasswordEnv)
 }
 
-type CommanFlagOpts struct {
+type CommonFlagOpts struct {
 	Local     bool
 	MediaType string
 }
 
-func (opts *CommanFlagOpts) ApplyFlag(fs *pflag.FlagSet) {
+func (opts *CommonFlagOpts) ApplyFlag(fs *pflag.FlagSet) {
 	setFlagMediaType(fs, &opts.MediaType)
 	setFlagLocal(fs, &opts.Local)
 }
 
 type RemoteFlagOpts struct {
 	SecureFlagOpts
-	CommanFlagOpts
+	CommonFlagOpts
 }
 
 func (opts *RemoteFlagOpts) ApplyFlag(fs *pflag.FlagSet) {
 	opts.SecureFlagOpts.ApplyFlag(fs)
-	opts.CommanFlagOpts.ApplyFlag(fs)
+	opts.CommonFlagOpts.ApplyFlag(fs)
 }

--- a/cmd/notation/common.go
+++ b/cmd/notation/common.go
@@ -84,7 +84,8 @@ type SecureFlagOpts struct {
 	PlainHTTP bool
 }
 
-func (opts *SecureFlagOpts) ApplyFlag(fs *pflag.FlagSet) {
+// ApplyFlags set flags and their default values for the FlagSet
+func (opts *SecureFlagOpts) ApplyFlags(fs *pflag.FlagSet) {
 	setflagUsername(fs, &opts.Username)
 	setFlagPassword(fs, &opts.Password)
 	setFlagPlainHTTP(fs, &opts.PlainHTTP)
@@ -97,7 +98,8 @@ type CommonFlagOpts struct {
 	MediaType string
 }
 
-func (opts *CommonFlagOpts) ApplyFlag(fs *pflag.FlagSet) {
+// ApplyFlags set flags and their default values for the FlagSet
+func (opts *CommonFlagOpts) ApplyFlags(fs *pflag.FlagSet) {
 	setFlagMediaType(fs, &opts.MediaType)
 	setFlagLocal(fs, &opts.Local)
 }
@@ -107,7 +109,8 @@ type RemoteFlagOpts struct {
 	CommonFlagOpts
 }
 
-func (opts *RemoteFlagOpts) ApplyFlag(fs *pflag.FlagSet) {
-	opts.SecureFlagOpts.ApplyFlag(fs)
-	opts.CommonFlagOpts.ApplyFlag(fs)
+// ApplyFlags set flags and their default values for the FlagSet
+func (opts *RemoteFlagOpts) ApplyFlags(fs *pflag.FlagSet) {
+	opts.SecureFlagOpts.ApplyFlags(fs)
+	opts.CommonFlagOpts.ApplyFlags(fs)
 }

--- a/cmd/notation/common.go
+++ b/cmd/notation/common.go
@@ -87,7 +87,6 @@ type SecureFlagOpts struct {
 func (opts *SecureFlagOpts) ApplyFlag(fs *pflag.FlagSet) {
 	setflagUsername(fs, &opts.Username)
 	setFlagPassword(fs, &opts.Password)
-
 	setFlagPlainHTTP(fs, &opts.PlainHTTP)
 	opts.Username = os.Getenv(defaultUsernameEnv)
 	opts.Password = os.Getenv(defaultPasswordEnv)

--- a/cmd/notation/key.go
+++ b/cmd/notation/key.go
@@ -112,7 +112,7 @@ func keyListCommand() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List keys used for signing",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return listKeys(cmd)
+			return listKeys()
 		},
 	}
 }
@@ -266,7 +266,7 @@ func updateKey(command *cobra.Command, opts *keyUpdateOpts) error {
 	return nil
 }
 
-func listKeys(command *cobra.Command) error {
+func listKeys() error {
 	// core process
 	cfg, err := config.LoadOrDefault()
 	if err != nil {

--- a/cmd/notation/list.go
+++ b/cmd/notation/list.go
@@ -1,43 +1,51 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 
-	"github.com/urfave/cli/v2"
+	"github.com/spf13/cobra"
 )
 
-var listCommand = &cli.Command{
-	Name:      "list",
-	Usage:     "List signatures from remote",
-	Aliases:   []string{"ls"},
-	ArgsUsage: "<reference>",
-	Flags: []cli.Flag{
-		flagUsername,
-		flagPassword,
-	},
-	Action: runList,
+type listOpts struct {
+	SecureFlagOpts
+	reference string
 }
 
-func runList(ctx *cli.Context) error {
-	// initialize
-	if !ctx.Args().Present() {
-		return errors.New("no reference specified")
+func listCommand(opts *listOpts) *cobra.Command {
+	if opts == nil {
+		opts = &listOpts{}
 	}
+	cmd := &cobra.Command{
+		Use:     "list [reference]",
+		Aliases: []string{"ls"},
+		Short:   "List signatures from remote",
+		Args:    cobra.ExactArgs(1),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			opts.reference = args[0]
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runList(cmd, opts)
+		},
+	}
+	opts.ApplyFlag(cmd.Flags())
+	return cmd
+}
 
-	reference := ctx.Args().First()
-	sigRepo, err := getSignatureRepository(ctx, reference)
+func runList(command *cobra.Command, opts *listOpts) error {
+	// initialize
+	reference := opts.reference
+	sigRepo, err := getSignatureRepository(&opts.SecureFlagOpts, reference)
 	if err != nil {
 		return err
 	}
 
 	// core process
-	manifestDesc, err := getManifestDescriptorFromReference(ctx, reference)
+	manifestDesc, err := getManifestDescriptorFromReference(command.Context(), &opts.SecureFlagOpts, reference)
 	if err != nil {
 		return err
 	}
 
-	sigManifests, err := sigRepo.ListSignatureManifests(ctx.Context, manifestDesc.Digest)
+	sigManifests, err := sigRepo.ListSignatureManifests(command.Context(), manifestDesc.Digest)
 	if err != nil {
 		return fmt.Errorf("lookup signature failure: %v", err)
 	}

--- a/cmd/notation/list.go
+++ b/cmd/notation/list.go
@@ -27,7 +27,7 @@ func listCommand(opts *listOpts) *cobra.Command {
 			return runList(cmd, opts)
 		},
 	}
-	opts.ApplyFlag(cmd.Flags())
+	opts.ApplyFlags(cmd.Flags())
 	return cmd
 }
 

--- a/cmd/notation/list.go
+++ b/cmd/notation/list.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -19,9 +20,12 @@ func listCommand(opts *listOpts) *cobra.Command {
 		Use:     "list [reference]",
 		Aliases: []string{"ls"},
 		Short:   "List signatures from remote",
-		Args:    cobra.ExactArgs(1),
-		PreRun: func(cmd *cobra.Command, args []string) {
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return errors.New("no reference specified")
+			}
 			opts.reference = args[0]
+			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runList(cmd, opts)

--- a/cmd/notation/login.go
+++ b/cmd/notation/login.go
@@ -27,12 +27,12 @@ func loginCommand(opts *loginOpts) *cobra.Command {
 		Use:   "login [options] [server]",
 		Short: "Provides credentials for authenticated registry operations",
 		Long: `notation login [options] [server]
-	
+
 Example - Login with provided username and password:
-  notation login -u <user> -p <password> registry.example.com
-		
+	notation login -u <user> -p <password> registry.example.com
+
 Example - Login using $NOTATION_USERNAME $NOTATION_PASSWORD variables:
-  notation login registry.example.com`,
+	notation login registry.example.com`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return errors.New("no hostname specified")

--- a/cmd/notation/login.go
+++ b/cmd/notation/login.go
@@ -46,7 +46,7 @@ Example - Login using $NOTATION_USERNAME $NOTATION_PASSWORD variables:
 		},
 	}
 	command.Flags().BoolVar(&opts.passwordStdin, "password-stdin", false, "Take the password from stdin")
-	opts.ApplyFlag(command.Flags())
+	opts.ApplyFlags(command.Flags())
 	return command
 }
 

--- a/cmd/notation/login.go
+++ b/cmd/notation/login.go
@@ -45,7 +45,7 @@ func loginCommand(opts *loginOpts) *cobra.Command {
 			return runLogin(cmd, opts)
 		},
 	}
-	command.Flags().BoolVar(&opts.passwordStdin, "passowrd-stdin", false, "Take the password from stdin")
+	command.Flags().BoolVar(&opts.passwordStdin, "password-stdin", false, "Take the password from stdin")
 	opts.ApplyFlag(command.Flags())
 	return command
 }

--- a/cmd/notation/login.go
+++ b/cmd/notation/login.go
@@ -28,11 +28,11 @@ func loginCommand(opts *loginOpts) *cobra.Command {
 		Short: "Provides credentials for authenticated registry operations",
 		Long: `notation login [options] [server]
 	
-		Example - Login with provided username and password:
-			notation login -u <user> -p <password> registry.example.com
+Example - Login with provided username and password:
+  notation login -u <user> -p <password> registry.example.com
 		
-		Example - Login using $NOTATION_USERNAME $NOTATION_PASSWORD variables:
-			notation login registry.example.com`,
+Example - Login using $NOTATION_USERNAME $NOTATION_PASSWORD variables:
+  notation login registry.example.com`,
 		Args: cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := readPassword(opts); err != nil {

--- a/cmd/notation/login.go
+++ b/cmd/notation/login.go
@@ -33,12 +33,17 @@ Example - Login with provided username and password:
 		
 Example - Login using $NOTATION_USERNAME $NOTATION_PASSWORD variables:
   notation login registry.example.com`,
-		Args: cobra.ExactArgs(1),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return errors.New("no hostname specified")
+			}
+			opts.server = args[0]
+			return nil
+		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := readPassword(opts); err != nil {
 				return err
 			}
-			opts.server = args[0]
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -52,9 +57,6 @@ Example - Login using $NOTATION_USERNAME $NOTATION_PASSWORD variables:
 
 func runLogin(cmd *cobra.Command, opts *loginOpts) error {
 	// initialize
-	if opts.server == "" {
-		return errors.New("no hostname specified")
-	}
 	serverAddress := opts.server
 
 	if err := validateAuthConfig(cmd.Context(), opts, serverAddress); err != nil {

--- a/cmd/notation/login.go
+++ b/cmd/notation/login.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -8,41 +9,55 @@ import (
 	"strings"
 
 	"github.com/notaryproject/notation/pkg/auth"
-	"github.com/urfave/cli/v2"
+	"github.com/spf13/cobra"
 	orasauth "oras.land/oras-go/v2/registry/remote/auth"
 )
 
-var loginCommand = &cli.Command{
-	Name:  "login",
-	Usage: "Provides credentials for authenticated registry operations",
-	UsageText: `notation login [options] [server]
-	
-Example - Login with provided username and password:
-	notation login -u <user> -p <password> registry.example.com
-
-Example - Login using $NOTATION_USERNAME $NOTATION_PASSWORD variables:
-	notation login registry.example.com`,
-	ArgsUsage: "[server]",
-	Flags: []cli.Flag{
-		flagUsername,
-		flagPassword,
-		&cli.BoolFlag{
-			Name:  "password-stdin",
-			Usage: "Take the password from stdin",
-		},
-	},
-	Before: readPassword,
-	Action: runLogin,
+type loginOpts struct {
+	SecureFlagOpts
+	passwordStdin bool
+	server        string
 }
 
-func runLogin(ctx *cli.Context) error {
+func loginCommand(opts *loginOpts) *cobra.Command {
+	if opts == nil {
+		opts = &loginOpts{}
+	}
+	command := &cobra.Command{
+		Use:   "login [options] [server]",
+		Short: "Provides credentials for authenticated registry operations",
+		Long: `notation login [options] [server]
+	
+		Example - Login with provided username and password:
+			notation login -u <user> -p <password> registry.example.com
+		
+		Example - Login using $NOTATION_USERNAME $NOTATION_PASSWORD variables:
+			notation login registry.example.com`,
+		Args: cobra.ExactArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := readPassword(opts); err != nil {
+				return err
+			}
+			opts.server = args[0]
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLogin(cmd, opts)
+		},
+	}
+	command.Flags().BoolVar(&opts.passwordStdin, "passowrd-stdin", false, "Take the password from stdin")
+	opts.ApplyFlag(command.Flags())
+	return command
+}
+
+func runLogin(cmd *cobra.Command, opts *loginOpts) error {
 	// initialize
-	if !ctx.Args().Present() {
+	if opts.server == "" {
 		return errors.New("no hostname specified")
 	}
-	serverAddress := ctx.Args().First()
+	serverAddress := opts.server
 
-	if err := validateAuthConfig(ctx, serverAddress); err != nil {
+	if err := validateAuthConfig(cmd.Context(), opts, serverAddress); err != nil {
 		return err
 	}
 
@@ -52,8 +67,8 @@ func runLogin(ctx *cli.Context) error {
 	}
 	// init creds
 	creds := newCredentialFromInput(
-		ctx.String(flagUsername.Name),
-		ctx.String(flagPassword.Name),
+		opts.Username,
+		opts.Password,
 	)
 	if err = nativeStore.Store(serverAddress, creds); err != nil {
 		return fmt.Errorf("failed to store credentials: %v", err)
@@ -61,12 +76,12 @@ func runLogin(ctx *cli.Context) error {
 	return nil
 }
 
-func validateAuthConfig(ctx *cli.Context, serverAddress string) error {
-	registry, err := getRegistryClient(ctx, serverAddress)
+func validateAuthConfig(ctx context.Context, opts *loginOpts, serverAddress string) error {
+	registry, err := getRegistryClient(&opts.SecureFlagOpts, serverAddress)
 	if err != nil {
 		return err
 	}
-	return registry.Ping(ctx.Context)
+	return registry.Ping(ctx)
 }
 
 func newCredentialFromInput(username, password string) orasauth.Credential {
@@ -80,13 +95,13 @@ func newCredentialFromInput(username, password string) orasauth.Credential {
 	return c
 }
 
-func readPassword(ctx *cli.Context) error {
-	if ctx.Bool("password-stdin") {
+func readPassword(opts *loginOpts) error {
+	if opts.passwordStdin {
 		password, err := readLine()
 		if err != nil {
 			return err
 		}
-		ctx.Set(flagPassword.Name, password)
+		opts.Password = password
 	}
 	return nil
 }

--- a/cmd/notation/logout.go
+++ b/cmd/notation/logout.go
@@ -4,22 +4,36 @@ import (
 	"errors"
 
 	"github.com/notaryproject/notation/pkg/auth"
-	"github.com/urfave/cli/v2"
+	"github.com/spf13/cobra"
 )
 
-var logoutCommand = &cli.Command{
-	Name:      "logout",
-	Usage:     "Log out the specified registry hostname",
-	ArgsUsage: "[server]",
-	Action:    runLogout,
+type logoutOpts struct {
+	server string
 }
 
-func runLogout(ctx *cli.Context) error {
+func logoutCommand(opts *logoutOpts) *cobra.Command {
+	if opts == nil {
+		opts = &logoutOpts{}
+	}
+	return &cobra.Command{
+		Use:   "logout [server]",
+		Short: "Log out the specified registry hostname",
+		Args:  cobra.ExactArgs(1),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			opts.server = args[0]
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLogout(cmd, opts)
+		},
+	}
+}
+
+func runLogout(cmd *cobra.Command, opts *logoutOpts) error {
 	// initialize
-	if !ctx.Args().Present() {
+	if opts.server == "" {
 		return errors.New("no hostname specified")
 	}
-	serverAddress := ctx.Args().First()
+	serverAddress := opts.server
 	nativeStore, err := auth.GetCredentialsStore(serverAddress)
 	if err != nil {
 		return err

--- a/cmd/notation/logout.go
+++ b/cmd/notation/logout.go
@@ -18,9 +18,12 @@ func logoutCommand(opts *logoutOpts) *cobra.Command {
 	return &cobra.Command{
 		Use:   "logout [server]",
 		Short: "Log out the specified registry hostname",
-		Args:  cobra.ExactArgs(1),
-		PreRun: func(cmd *cobra.Command, args []string) {
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return errors.New("no hostname specified")
+			}
 			opts.server = args[0]
+			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runLogout(cmd, opts)
@@ -30,9 +33,6 @@ func logoutCommand(opts *logoutOpts) *cobra.Command {
 
 func runLogout(cmd *cobra.Command, opts *logoutOpts) error {
 	// initialize
-	if opts.server == "" {
-		return errors.New("no hostname specified")
-	}
 	serverAddress := opts.server
 	nativeStore, err := auth.GetCredentialsStore(serverAddress)
 	if err != nil {

--- a/cmd/notation/main.go
+++ b/cmd/notation/main.go
@@ -2,40 +2,32 @@ package main
 
 import (
 	"log"
-	"os"
 
 	"github.com/notaryproject/notation/internal/version"
-	"github.com/urfave/cli/v2"
+	"github.com/spf13/cobra"
 )
 
 func main() {
-	app := &cli.App{
-		Name:    "notation",
-		Usage:   "Notation - Notary V2",
-		Version: version.GetVersion(),
-		Authors: []*cli.Author{
-			{
-				Name: "CNCF Notary Project",
-			},
-		},
-		Flags: []cli.Flag{
-			flagPlainHTTP,
-		},
-		Commands: []*cli.Command{
-			signCommand,
-			verifyCommand,
-			pushCommand,
-			pullCommand,
-			listCommand,
-			certCommand,
-			keyCommand,
-			cacheCommand,
-			pluginCommand,
-			loginCommand,
-			logoutCommand,
-		},
+	cmd := &cobra.Command{
+		Use:          "notation",
+		Short:        "Notation - Notary V2",
+		Version:      version.GetVersion(),
+		SilenceUsage: true,
 	}
-	if err := app.Run(os.Args); err != nil {
+	cmd.AddCommand(
+		signCommand(nil),
+		verifyCommand(nil),
+		pushCommand(nil),
+		pullCommand(nil),
+		listCommand(nil),
+		certCommand(),
+		keyCommand(),
+		cacheCommand(),
+		pluginCommand(),
+		loginCommand(nil),
+		logoutCommand(nil))
+	cmd.PersistentFlags().Bool(flagPlainHTTP.Name, false, flagPlainHTTP.Usage)
+	if err := cmd.Execute(); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/notation/plugin.go
+++ b/cmd/notation/plugin.go
@@ -6,29 +6,32 @@ import (
 	"github.com/notaryproject/notation-go/plugin/manager"
 	"github.com/notaryproject/notation/internal/ioutil"
 	"github.com/notaryproject/notation/pkg/config"
-	"github.com/urfave/cli/v2"
+	"github.com/spf13/cobra"
 )
 
-var (
-	pluginCommand = &cli.Command{
-		Name:  "plugin",
-		Usage: "Manage plugins",
-		Subcommands: []*cli.Command{
-			pluginListCommand,
+func pluginCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "plugin",
+		Short: "Manage plugins",
+	}
+	cmd.AddCommand(pluginListCommand())
+	return cmd
+}
+
+func pluginListCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List registered plugins",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return listPlugins(cmd)
 		},
 	}
+}
 
-	pluginListCommand = &cli.Command{
-		Name:    "list",
-		Usage:   "List registered plugins",
-		Aliases: []string{"ls"},
-		Action:  listPlugins,
-	}
-)
-
-func listPlugins(ctx *cli.Context) error {
+func listPlugins(command *cobra.Command) error {
 	mgr := manager.New(config.PluginDirPath)
-	plugins, err := mgr.List(ctx.Context)
+	plugins, err := mgr.List(command.Context())
 	if err != nil {
 		return err
 	}

--- a/cmd/notation/pull.go
+++ b/cmd/notation/pull.go
@@ -39,7 +39,7 @@ func pullCommand(opts *pullOpts) *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&opts.strict, "strict", false, "pull the signature without lookup the manifest")
 	setFlagOutput(cmd.Flags(), &opts.output)
-	opts.ApplyFlag(cmd.Flags())
+	opts.ApplyFlags(cmd.Flags())
 	return cmd
 }
 

--- a/cmd/notation/pull.go
+++ b/cmd/notation/pull.go
@@ -29,9 +29,12 @@ func pullCommand(opts *pullOpts) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pull [reference]",
 		Short: "Pull signatures from remote",
-		Args:  cobra.ExactArgs(1),
-		PreRun: func(cmd *cobra.Command, args []string) {
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return errors.New("no reference specified")
+			}
 			opts.reference = args[0]
+			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runPull(cmd, opts)
@@ -45,10 +48,6 @@ func pullCommand(opts *pullOpts) *cobra.Command {
 
 func runPull(command *cobra.Command, opts *pullOpts) error {
 	// initialize
-	if opts.reference == "" {
-		return errors.New("no reference specified")
-	}
-
 	reference := opts.reference
 	sigRepo, err := getSignatureRepository(&opts.SecureFlagOpts, reference)
 	if err != nil {

--- a/cmd/notation/push.go
+++ b/cmd/notation/push.go
@@ -25,9 +25,12 @@ func pushCommand(opts *pushOpts) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "push [reference]",
 		Short: "Push signature to remote",
-		Args:  cobra.ExactArgs(1),
-		PreRun: func(cmd *cobra.Command, args []string) {
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return errors.New("no reference specified")
+			}
 			opts.reference = args[0]
+			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runPush(cmd, opts)
@@ -40,9 +43,6 @@ func pushCommand(opts *pushOpts) *cobra.Command {
 
 func runPush(command *cobra.Command, opts *pushOpts) error {
 	// initialize
-	if opts.reference == "" {
-		return errors.New("no reference specified")
-	}
 	ref := opts.reference
 	manifestDesc, err := getManifestDescriptorFromReference(command.Context(), &opts.SecureFlagOpts, ref)
 	if err != nil {

--- a/cmd/notation/push.go
+++ b/cmd/notation/push.go
@@ -34,7 +34,7 @@ func pushCommand(opts *pushOpts) *cobra.Command {
 		},
 	}
 	setFlagSignature(cmd.Flags(), &opts.signatures)
-	opts.ApplyFlag(cmd.Flags())
+	opts.ApplyFlags(cmd.Flags())
 	return cmd
 }
 

--- a/cmd/notation/sign.go
+++ b/cmd/notation/sign.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -34,9 +35,12 @@ func signCommand(opts *signOpts) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "sign [reference]",
 		Short: "Signs artifacts",
-		Args:  cobra.ExactArgs(1),
-		PreRun: func(cmd *cobra.Command, args []string) {
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return errors.New("missing reference")
+			}
 			opts.reference = args[0]
+			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSign(cmd, opts)

--- a/cmd/notation/sign.go
+++ b/cmd/notation/sign.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/notaryproject/notation-go"
 	"github.com/notaryproject/notation-go/crypto/timestamp"
@@ -9,58 +11,71 @@ import (
 	"github.com/notaryproject/notation/internal/osutil"
 	"github.com/notaryproject/notation/pkg/config"
 	"github.com/opencontainers/go-digest"
-	"github.com/urfave/cli/v2"
+	"github.com/spf13/cobra"
 )
 
-var signCommand = &cli.Command{
-	Name:      "sign",
-	Usage:     "Signs artifacts",
-	ArgsUsage: "<reference>",
-	Flags: []cli.Flag{
-		cmd.FlagKey,
-		cmd.FlagKeyFile,
-		cmd.FlagCertFile,
-		cmd.FlagTimestamp,
-		cmd.FlagExpiry,
-		cmd.FlagReference,
-		flagLocal,
-		flagOutput,
-		&cli.BoolFlag{
-			Name:  "push",
-			Usage: "push after successful signing",
-			Value: true,
-		},
-		&cli.StringFlag{
-			Name:  "push-reference",
-			Usage: "different remote to store signature",
-		},
-		flagUsername,
-		flagPassword,
-		flagMediaType,
-		cmd.FlagPluginConfig,
-	},
-	Action: runSign,
+type signOpts struct {
+	cmd.SignerFlagOpts
+	RemoteFlagOpts
+	timestamp       string
+	expiry          time.Duration
+	originReference string
+	output          string
+	push            bool
+	pushReference   string
+	pluginConfig    string
+	reference       string
 }
 
-func runSign(ctx *cli.Context) error {
+func signCommand(opts *signOpts) *cobra.Command {
+	if opts == nil {
+		opts = &signOpts{}
+	}
+	command := &cobra.Command{
+		Use:   "sign [reference]",
+		Short: "Signs artifacts",
+		Args:  cobra.ExactArgs(1),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			opts.reference = args[0]
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSign(cmd, opts)
+		},
+	}
+	opts.SignerFlagOpts.ApplyFlag(command.Flags())
+	opts.RemoteFlagOpts.ApplyFlag(command.Flags())
+
+	cmd.SetPflagTimestamp(command.Flags(), &opts.timestamp)
+	cmd.SetPflagExpiry(command.Flags(), &opts.expiry)
+	cmd.SetPflagReference(command.Flags(), &opts.originReference)
+	setFlagOutput(command.Flags(), &opts.output)
+
+	command.Flags().BoolVar(&opts.push, "push", true, "push after successful signing")
+	command.Flags().StringVar(&opts.pushReference, "push-reference", "", "different remote to store signature")
+
+	cmd.SetPflagPluginConfig(command.Flags(), &opts.pluginConfig)
+	return command
+}
+
+func runSign(command *cobra.Command, cmdOpts *signOpts) error {
 	// initialize
-	signer, err := cmd.GetSigner(ctx)
+	signer, err := cmd.GetSigner(&cmdOpts.SignerFlagOpts)
 	if err != nil {
 		return err
 	}
 
 	// core process
-	desc, opts, err := prepareSigningContent(ctx)
+	desc, opts, err := prepareSigningContent(command.Context(), cmdOpts)
 	if err != nil {
 		return err
 	}
-	sig, err := signer.Sign(ctx.Context, desc, opts)
+	sig, err := signer.Sign(command.Context(), desc, opts)
 	if err != nil {
 		return err
 	}
 
 	// write out
-	path := ctx.String(flagOutput.Name)
+	path := cmdOpts.output
 	if path == "" {
 		path = config.SignaturePath(digest.Digest(desc.Digest), digest.FromBytes(sig))
 	}
@@ -68,11 +83,11 @@ func runSign(ctx *cli.Context) error {
 		return err
 	}
 
-	if ref := ctx.String("push-reference"); ctx.Bool("push") && !(ctx.Bool(flagLocal.Name) && ref == "") {
+	if ref := cmdOpts.pushReference; cmdOpts.push && !(cmdOpts.Local && ref == "") {
 		if ref == "" {
-			ref = ctx.Args().First()
+			ref = cmdOpts.reference
 		}
-		if _, err := pushSignature(ctx, ref, sig); err != nil {
+		if _, err := pushSignature(command.Context(), &cmdOpts.SecureFlagOpts, ref, sig); err != nil {
 			return fmt.Errorf("fail to push signature to %q: %v: %v",
 				ref,
 				desc.Digest,
@@ -85,28 +100,28 @@ func runSign(ctx *cli.Context) error {
 	return nil
 }
 
-func prepareSigningContent(ctx *cli.Context) (notation.Descriptor, notation.SignOptions, error) {
-	manifestDesc, err := getManifestDescriptorFromContext(ctx)
+func prepareSigningContent(ctx context.Context, opts *signOpts) (notation.Descriptor, notation.SignOptions, error) {
+	manifestDesc, err := getManifestDescriptorFromContext(ctx, &opts.RemoteFlagOpts, opts.reference)
 	if err != nil {
 		return notation.Descriptor{}, notation.SignOptions{}, err
 	}
-	if identity := ctx.String(cmd.FlagReference.Name); identity != "" {
+	if identity := opts.originReference; identity != "" {
 		manifestDesc.Annotations = map[string]string{
 			"identity": identity,
 		}
 	}
 	var tsa timestamp.Timestamper
-	if endpoint := ctx.String(cmd.FlagTimestamp.Name); endpoint != "" {
+	if endpoint := opts.timestamp; endpoint != "" {
 		if tsa, err = timestamp.NewHTTPTimestamper(nil, endpoint); err != nil {
 			return notation.Descriptor{}, notation.SignOptions{}, err
 		}
 	}
-	pluginConfig, err := cmd.ParseFlagPluginConfig(ctx)
+	pluginConfig, err := cmd.ParseFlagPluginConfig(opts.pluginConfig)
 	if err != nil {
 		return notation.Descriptor{}, notation.SignOptions{}, err
 	}
 	return manifestDesc, notation.SignOptions{
-		Expiry:       cmd.GetExpiry(ctx),
+		Expiry:       cmd.GetExpiry(opts.expiry),
 		TSA:          tsa,
 		PluginConfig: pluginConfig,
 	}, nil

--- a/cmd/notation/sign.go
+++ b/cmd/notation/sign.go
@@ -42,8 +42,8 @@ func signCommand(opts *signOpts) *cobra.Command {
 			return runSign(cmd, opts)
 		},
 	}
-	opts.SignerFlagOpts.ApplyFlag(command.Flags())
-	opts.RemoteFlagOpts.ApplyFlag(command.Flags())
+	opts.SignerFlagOpts.ApplyFlags(command.Flags())
+	opts.RemoteFlagOpts.ApplyFlags(command.Flags())
 
 	cmd.SetPflagTimestamp(command.Flags(), &opts.timestamp)
 	cmd.SetPflagExpiry(command.Flags(), &opts.expiry)

--- a/cmd/notation/verify.go
+++ b/cmd/notation/verify.go
@@ -45,7 +45,7 @@ func verifyCommand(opts *verifyOpts) *cobra.Command {
 	command.Flags().StringSliceVarP(&opts.certs, "cert", "c", []string{}, "certificate names for verification")
 	command.Flags().StringSliceVar(&opts.certFiles, cmd.PflagCertFile.Name, []string{}, "certificate files for verification")
 	command.Flags().BoolVar(&opts.pull, "pull", true, "pull remote signatures before verification")
-	opts.ApplyFlag(command.Flags())
+	opts.ApplyFlags(command.Flags())
 	return command
 }
 

--- a/cmd/notation/verify.go
+++ b/cmd/notation/verify.go
@@ -13,53 +13,57 @@ import (
 	"github.com/notaryproject/notation/pkg/cache"
 	"github.com/notaryproject/notation/pkg/config"
 	"github.com/opencontainers/go-digest"
-	"github.com/urfave/cli/v2"
+	"github.com/spf13/cobra"
 )
 
-var verifyCommand = &cli.Command{
-	Name:      "verify",
-	Usage:     "Verifies OCI Artifacts",
-	ArgsUsage: "<reference>",
-	Flags: []cli.Flag{
-		flagSignature,
-		&cli.StringSliceFlag{
-			Name:    "cert",
-			Aliases: []string{"c"},
-			Usage:   "certificate names for verification",
-		},
-		&cli.StringSliceFlag{
-			Name:      cmd.FlagCertFile.Name,
-			Usage:     "certificate files for verification",
-			TakesFile: true,
-		},
-		&cli.BoolFlag{
-			Name:  "pull",
-			Usage: "pull remote signatures before verification",
-			Value: true,
-		},
-		flagLocal,
-		flagUsername,
-		flagPassword,
-		flagMediaType,
-	},
-	Action: runVerify,
+type verifyOpts struct {
+	RemoteFlagOpts
+	signatures []string
+	certs      []string
+	certFiles  []string
+	pull       bool
+	reference  string
 }
 
-func runVerify(ctx *cli.Context) error {
+func verifyCommand(opts *verifyOpts) *cobra.Command {
+	if opts == nil {
+		opts = &verifyOpts{}
+	}
+	command := &cobra.Command{
+		Use:   "verify [reference]",
+		Short: "Verifies OCI Artifacts",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			if len(args) > 0 {
+				opts.reference = args[0]
+			}
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runVerify(cmd, opts)
+		},
+	}
+	setFlagSignature(command.Flags(), &opts.signatures)
+	command.Flags().StringSliceVarP(&opts.certs, "cert", "c", []string{}, "certificate names for verification")
+	command.Flags().StringSliceVar(&opts.certFiles, cmd.PflagCertFile.Name, []string{}, "certificate files for verification")
+	command.Flags().BoolVar(&opts.pull, "pull", true, "pull remote signatures before verification")
+	opts.ApplyFlag(command.Flags())
+	return command
+}
+
+func runVerify(command *cobra.Command, opts *verifyOpts) error {
 	// initialize
-	verifier, err := getVerifier(ctx)
+	verifier, err := getVerifier(opts)
 	if err != nil {
 		return err
 	}
-	manifestDesc, err := getManifestDescriptorFromContext(ctx)
+	manifestDesc, err := getManifestDescriptorFromContext(command.Context(), &opts.RemoteFlagOpts, opts.reference)
 	if err != nil {
 		return err
 	}
 
-	sigPaths := ctx.StringSlice(flagSignature.Name)
+	sigPaths := opts.signatures
 	if len(sigPaths) == 0 {
-		if !ctx.Bool(flagLocal.Name) && ctx.Bool("pull") {
-			if err := pullSignatures(ctx, digest.Digest(manifestDesc.Digest)); err != nil {
+		if !opts.Local && opts.pull {
+			if err := pullSignatures(command, opts.reference, &opts.SecureFlagOpts, digest.Digest(manifestDesc.Digest)); err != nil {
 				return err
 			}
 		}
@@ -74,7 +78,7 @@ func runVerify(ctx *cli.Context) error {
 	}
 
 	// core process
-	if err := verifySignatures(ctx.Context, verifier, manifestDesc, sigPaths); err != nil {
+	if err := verifySignatures(command.Context(), verifier, manifestDesc, sigPaths); err != nil {
 		return err
 	}
 
@@ -110,9 +114,8 @@ func verifySignatures(ctx context.Context, verifier notation.Verifier, manifestD
 	return lastErr
 }
 
-func getVerifier(ctx *cli.Context) (notation.Verifier, error) {
-	certPaths := ctx.StringSlice(cmd.FlagCertFile.Name)
-	certPaths, err := appendCertPathFromName(certPaths, ctx.StringSlice("cert"))
+func getVerifier(opts *verifyOpts) (notation.Verifier, error) {
+	certPaths, err := appendCertPathFromName(opts.certFiles, opts.certs)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/notation/verify.go
+++ b/cmd/notation/verify.go
@@ -32,10 +32,12 @@ func verifyCommand(opts *verifyOpts) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "verify [reference]",
 		Short: "Verifies OCI Artifacts",
-		PreRun: func(cmd *cobra.Command, args []string) {
-			if len(args) > 0 {
-				opts.reference = args[0]
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return errors.New("missing reference")
 			}
+			opts.reference = args[0]
+			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runVerify(cmd, opts)

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -108,7 +108,6 @@ var (
 		fs.StringVarP(p, PflagReference.Name, PflagReference.Shorthand, "", PflagReference.Usage)
 	}
 
-	// TODO: cobra does not support letter shorthand
 	PflagPluginConfig = &pflag.Flag{
 		Name:      "pluginConfig",
 		Shorthand: "c",

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/urfave/cli/v2"
 )
@@ -62,24 +61,24 @@ var (
 		Shorthand: "k",
 		Usage:     "signing key name",
 	}
-	SetPflagKey = func(cmd *cobra.Command, p *string) {
-		cmd.Flags().StringVarP(p, PflagKey.Name, PflagKey.Shorthand, "", PflagKey.Usage)
+	SetPflagKey = func(fs *pflag.FlagSet, p *string) {
+		fs.StringVarP(p, PflagKey.Name, PflagKey.Shorthand, "", PflagKey.Usage)
 	}
 
 	PflagKeyFile = &pflag.Flag{
 		Name:  "key-file",
 		Usage: "signing key file",
 	}
-	SetPflagKeyFile = func(cmd *cobra.Command, p *string) {
-		cmd.Flags().StringVar(p, PflagKeyFile.Name, "", PflagKeyFile.Usage)
+	SetPflagKeyFile = func(fs *pflag.FlagSet, p *string) {
+		fs.StringVar(p, PflagKeyFile.Name, "", PflagKeyFile.Usage)
 	}
 
 	PflagCertFile = &pflag.Flag{
 		Name:  "cert-file",
 		Usage: "signing certificate file",
 	}
-	SetPflagCertFile = func(cmd *cobra.Command, p *string) {
-		cmd.Flags().StringVar(p, PflagCertFile.Name, "", PflagCertFile.Usage)
+	SetPflagCertFile = func(fs *pflag.FlagSet, p *string) {
+		fs.StringVar(p, PflagCertFile.Name, "", PflagCertFile.Usage)
 	}
 
 	PflagTimestamp = &pflag.Flag{
@@ -87,8 +86,8 @@ var (
 		Shorthand: "t",
 		Usage:     "timestamp the signed signature via the remote TSA",
 	}
-	SetPflagTimestamp = func(cmd *cobra.Command, p *string) {
-		cmd.Flags().StringVarP(p, PflagTimestamp.Name, PflagTimestamp.Shorthand, "", PflagTimestamp.Usage)
+	SetPflagTimestamp = func(fs *pflag.FlagSet, p *string) {
+		fs.StringVarP(p, PflagTimestamp.Name, PflagTimestamp.Shorthand, "", PflagTimestamp.Usage)
 	}
 
 	PflagExpiry = &pflag.Flag{
@@ -96,8 +95,8 @@ var (
 		Shorthand: "e",
 		Usage:     "expire duration",
 	}
-	SetPflagExpiry = func(cmd *cobra.Command, p *time.Duration) {
-		cmd.Flags().DurationVarP(p, PflagExpiry.Name, PflagExpiry.Shorthand, time.Duration(0), PflagExpiry.Usage)
+	SetPflagExpiry = func(fs *pflag.FlagSet, p *time.Duration) {
+		fs.DurationVarP(p, PflagExpiry.Name, PflagExpiry.Shorthand, time.Duration(0), PflagExpiry.Usage)
 	}
 
 	PflagReference = &pflag.Flag{
@@ -105,8 +104,8 @@ var (
 		Shorthand: "r",
 		Usage:     "original reference",
 	}
-	SetPflagReference = func(cmd *cobra.Command, p *string) {
-		cmd.Flags().StringVarP(p, PflagReference.Name, PflagReference.Shorthand, "", PflagReference.Usage)
+	SetPflagReference = func(fs *pflag.FlagSet, p *string) {
+		fs.StringVarP(p, PflagReference.Name, PflagReference.Shorthand, "", PflagReference.Usage)
 	}
 
 	// TODO: cobra does not support letter shorthand
@@ -115,8 +114,8 @@ var (
 		Shorthand: "c",
 		Usage:     "list of comma-separated {key}={value} pairs that are passed as is to the plugin, refer plugin documentation to set appropriate values",
 	}
-	SetPflagPluginConfig = func(cmd *cobra.Command, p *string) {
-		cmd.Flags().StringVarP(p, PflagPluginConfig.Name, PflagPluginConfig.Shorthand, "", PflagPluginConfig.Usage)
+	SetPflagPluginConfig = func(fs *pflag.FlagSet, p *string) {
+		fs.StringVarP(p, PflagPluginConfig.Name, PflagPluginConfig.Shorthand, "", PflagPluginConfig.Usage)
 	}
 )
 
@@ -126,11 +125,10 @@ type KeyValueSlice interface {
 	String() string
 }
 
-func ParseFlagPluginConfig(ctx *cli.Context) (map[string]string, error) {
-	val := ctx.String(FlagPluginConfig.Name)
-	pluginConfig, err := ParseKeyValueListFlag(val)
+func ParseFlagPluginConfig(config string) (map[string]string, error) {
+	pluginConfig, err := ParseKeyValueListFlag(config)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse %q as value for flag %s: %s", val, FlagPluginConfig.Name, err)
+		return nil, fmt.Errorf("could not parse %q as value for flag %s: %s", pluginConfig, FlagPluginConfig.Name, err)
 	}
 	return pluginConfig, nil
 }

--- a/internal/cmd/options.go
+++ b/internal/cmd/options.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/spf13/pflag"
+)
+
+// SignerFlagOpts cmd opts for using cmd.GetSigner
+type SignerFlagOpts struct {
+	Key      string
+	KeyFile  string
+	CertFile string
+}
+
+func (opts *SignerFlagOpts) ApplyFlag(fs *pflag.FlagSet) {
+	SetPflagKey(fs, &opts.Key)
+	SetPflagKeyFile(fs, &opts.KeyFile)
+	SetPflagCertFile(fs, &opts.CertFile)
+}

--- a/internal/cmd/options.go
+++ b/internal/cmd/options.go
@@ -11,7 +11,8 @@ type SignerFlagOpts struct {
 	CertFile string
 }
 
-func (opts *SignerFlagOpts) ApplyFlag(fs *pflag.FlagSet) {
+// ApplyFlags set flags and their default values for the FlagSet
+func (opts *SignerFlagOpts) ApplyFlags(fs *pflag.FlagSet) {
 	SetPflagKey(fs, &opts.Key)
 	SetPflagKeyFile(fs, &opts.KeyFile)
 	SetPflagCertFile(fs, &opts.CertFile)

--- a/internal/cmd/signer.go
+++ b/internal/cmd/signer.go
@@ -8,19 +8,18 @@ import (
 	"github.com/notaryproject/notation-go/plugin/manager"
 	"github.com/notaryproject/notation-go/signature"
 	"github.com/notaryproject/notation/pkg/config"
-	"github.com/urfave/cli/v2"
 )
 
 // GetSigner returns a signer according to the CLI context.
-func GetSigner(ctx *cli.Context) (notation.Signer, error) {
+func GetSigner(opts *SignerFlagOpts) (notation.Signer, error) {
 	// Construct a signer from key and cert file if provided as CLI arguments
-	if keyPath := ctx.String(FlagKeyFile.Name); keyPath != "" {
-		certPath := ctx.String(FlagCertFile.Name)
+	if keyPath := opts.KeyFile; keyPath != "" {
+		certPath := opts.CertFile
 		return signature.NewSignerFromFiles(keyPath, certPath)
 	}
 	// Construct a signer from preconfigured key pair in config.json
 	// if key name is provided as the CLI argument
-	key, err := config.ResolveKey(ctx.String(FlagKey.Name))
+	key, err := config.ResolveKey(opts.Key)
 	if err != nil {
 		return nil, err
 	}
@@ -41,8 +40,7 @@ func GetSigner(ctx *cli.Context) (notation.Signer, error) {
 }
 
 // GetExpiry returns the signature expiry according to the CLI context.
-func GetExpiry(ctx *cli.Context) time.Time {
-	expiry := ctx.Duration(FlagExpiry.Name)
+func GetExpiry(expiry time.Duration) time.Time {
 	if expiry == 0 {
 		return time.Time{}
 	}


### PR DESCRIPTION
Signed-off-by: zaihaoyin <zaihaoyin@microsoft.com>

### What
This PR fixes https://github.com/notaryproject/notation/issues/183 by using `github.com/spf13/cobra` to replace github.com/urfave/cli/v2, which is a cli package also used by [oras-cli](https://github.com/oras-project/oras).
This PR also fixed https://github.com/notaryproject/notation/issues/211, which is caused by `urfave`.

### Notice
According to the statement from previous PR(https://github.com/notaryproject/notation/pull/250), this is the second PR of the whole series, which updates `cmd/notation`.
As we have discussed in the https://github.com/notaryproject/notation/discussions/251, `docker-notation` may be moved to another repo, so I will left most of the code unchanged.  
Though, I changed `signImage` function of the `docker-notation` cmd only to make sure the code can be compiled.
I will add unit test in the next PR.
