### PR TITLE
add unit test for cli

### DIFF
--- a/cmd/notation/cache_test.go
+++ b/cmd/notation/cache_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestCacheListCommand(t *testing.T) {
+func TestCacheListCommand_BasicArgs(t *testing.T) {
 	opts := &cacheListOpts{}
 	cmd := cacheListCommand(opts)
 	expected := &cacheListOpts{
@@ -34,7 +34,7 @@ func TestCacheListCommand(t *testing.T) {
 	}
 }
 
-func TestCachePruneCommand(t *testing.T) {
+func TestCachePruneCommand_BasicArgs(t *testing.T) {
 	opts := &cachePruneOpts{}
 	cmd := cachePruneCommand(opts)
 	expected := &cachePruneOpts{
@@ -46,12 +46,12 @@ func TestCachePruneCommand(t *testing.T) {
 		all:        true,
 		force:      true,
 		purge:      true,
-		references: []string{"ref0", "ref1", "ref2"},
+		references: []string{"ref0", "ref1", "ref2", "ref3"},
 	}
 	if err := cmd.ParseFlags([]string{
 		"-a",
 		"--purge",
-		"ref0", "ref1", "ref2",
+		"ref0", "ref1", "ref2", "ref3",
 		"-f"}); err != nil {
 		t.Fatalf("Parse Flag failed: %v", err)
 	}
@@ -63,7 +63,7 @@ func TestCachePruneCommand(t *testing.T) {
 	}
 }
 
-func TestCachePruneCommand_MissinArgs(t *testing.T) {
+func TestCachePruneCommand_MissingArgs(t *testing.T) {
 	cmd := cachePruneCommand(nil)
 	if err := cmd.ParseFlags([]string{}); err != nil {
 		t.Fatalf("Parse Flag failed: %v", err)
@@ -73,7 +73,7 @@ func TestCachePruneCommand_MissinArgs(t *testing.T) {
 	}
 }
 
-func TestCacheRemoveCommand(t *testing.T) {
+func TestCacheRemoveCommand_BasicArgs(t *testing.T) {
 	opts := &cacheRemoveOpts{}
 	cmd := cacheRemoveCommand(opts)
 	expected := &cacheRemoveOpts{
@@ -104,7 +104,7 @@ func TestCacheRemoveCommand(t *testing.T) {
 	}
 }
 
-func TestCacheRemoveCommand_MissinArgs(t *testing.T) {
+func TestCacheRemoveCommand_MissingArgs(t *testing.T) {
 	cmd := cacheRemoveCommand(nil)
 	if err := cmd.ParseFlags([]string{"reference"}); err != nil {
 		t.Fatalf("Parse Flag failed: %v", err)

--- a/cmd/notation/cache_test.go
+++ b/cmd/notation/cache_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCacheListCommand(t *testing.T) {
+	opts := &cacheListOpts{}
+	cmd := cacheListCommand(opts)
+	expected := &cacheListOpts{
+		RemoteFlagOpts: RemoteFlagOpts{
+			SecureFlagOpts: SecureFlagOpts{
+				Username: "user",
+			},
+			CommonFlagOpts: CommonFlagOpts{
+				Local:     true,
+				MediaType: defaultMediaType,
+			},
+		},
+		reference: "ref",
+	}
+	if err := cmd.ParseFlags([]string{
+		"-l",
+		expected.reference,
+		"-u", expected.Username}); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err != nil {
+		t.Fatalf("Parse Args failed: %v", err)
+	}
+	if *expected != *opts {
+		t.Fatalf("Expect cache list opts: %v, got: %v", expected, opts)
+	}
+}
+
+func TestCachePruneCommand(t *testing.T) {
+	opts := &cachePruneOpts{}
+	cmd := cachePruneCommand(opts)
+	expected := &cachePruneOpts{
+		RemoteFlagOpts: RemoteFlagOpts{
+			CommonFlagOpts: CommonFlagOpts{
+				MediaType: defaultMediaType,
+			},
+		},
+		all:        true,
+		force:      true,
+		purge:      true,
+		references: []string{"ref0", "ref1", "ref2"},
+	}
+	if err := cmd.ParseFlags([]string{
+		"-a",
+		"--purge",
+		"ref0", "ref1", "ref2",
+		"-f"}); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err != nil {
+		t.Fatalf("Parse Args failed: %v", err)
+	}
+	if !reflect.DeepEqual(*expected, *opts) {
+		t.Fatalf("Expect cache prune opts: %v, got: %v", expected, opts)
+	}
+}
+
+func TestCachePruneCommand_MissinArgs(t *testing.T) {
+	cmd := cachePruneCommand(nil)
+	if err := cmd.ParseFlags([]string{}); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err == nil {
+		t.Fatal("Parse Args expected error, but ok")
+	}
+}
+
+func TestCacheRemoveCommand(t *testing.T) {
+	opts := &cacheRemoveOpts{}
+	cmd := cacheRemoveCommand(opts)
+	expected := &cacheRemoveOpts{
+		RemoteFlagOpts: RemoteFlagOpts{
+			CommonFlagOpts: CommonFlagOpts{
+				MediaType: defaultMediaType,
+			},
+			SecureFlagOpts: SecureFlagOpts{
+				Password:  "password",
+				PlainHTTP: true,
+			},
+		},
+		reference:  "ref",
+		sigDigests: []string{"digest0", "digest1"},
+	}
+	if err := cmd.ParseFlags([]string{
+		"--plain-http",
+		"ref",
+		"digest0", "digest1",
+		"--password", expected.Password}); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err != nil {
+		t.Fatalf("Parse Args failed: %v", err)
+	}
+	if !reflect.DeepEqual(*expected, *opts) {
+		t.Fatalf("Expect cache remove opts: %v, got: %v", expected, opts)
+	}
+}
+
+func TestCacheRemoveCommand_MissinArgs(t *testing.T) {
+	cmd := cacheRemoveCommand(nil)
+	if err := cmd.ParseFlags([]string{"reference"}); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err == nil {
+		t.Fatal("Parse Args expected error, but ok")
+	}
+}

--- a/cmd/notation/cert_test.go
+++ b/cmd/notation/cert_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestCertAddCommand(t *testing.T) {
+	opts := &certAddOpts{}
+	cmd := certAddCommand(opts)
+	expected := &certAddOpts{
+		path: "path",
+		name: "cert",
+	}
+	if err := cmd.ParseFlags([]string{
+		expected.path,
+		"-n", expected.name}); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err != nil {
+		t.Fatalf("Parse Args failed: %v", err)
+	}
+	if *expected != *opts {
+		t.Fatalf("Expect cert add opts: %v, got: %v", expected, opts)
+	}
+}
+
+func TestCertAddCommand_MissinArgs(t *testing.T) {
+	cmd := certAddCommand(nil)
+	if err := cmd.ParseFlags([]string{}); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err == nil {
+		t.Fatal("Parse Args expected error, but ok")
+	}
+}
+
+func TestCertRemoveCommand(t *testing.T) {
+	opts := &certRemoveOpts{}
+	cmd := certRemoveCommand(opts)
+	expected := &certRemoveOpts{
+		names: []string{"cert0", "cert1", "cert2"},
+	}
+	if err := cmd.ParseFlags(expected.names); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err != nil {
+		t.Fatalf("Parse Args failed: %v", err)
+	}
+	if !reflect.DeepEqual(*expected, *opts) {
+		t.Fatalf("Expect cert remove opts: %v, got: %v", expected, opts)
+	}
+}
+
+func TestCertRemoveCommand_MissinArgs(t *testing.T) {
+	cmd := certRemoveCommand(nil)
+	if err := cmd.ParseFlags([]string{}); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err == nil {
+		t.Fatal("Parse Args expected error, but ok")
+	}
+}
+
+func TestCertGenerateCommand(t *testing.T) {
+	opts := &certGenerateTestOpts{}
+	cmd := certGenerateTestCommand(opts)
+	expected := &certGenerateTestOpts{
+		hosts:     []string{"host0", "host1", "host2"},
+		name:      "name",
+		bits:      2048,
+		isDefault: true,
+		expiry:    365 * 24 * time.Hour,
+	}
+	if err := cmd.ParseFlags([]string{
+		"host0", "host1",
+		"-n", expected.name,
+		"--bits", fmt.Sprint(expected.bits),
+		"host2",
+		"--default"}); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err != nil {
+		t.Fatalf("Parse Args failed: %v", err)
+	}
+	if !reflect.DeepEqual(*expected, *opts) {
+		t.Fatalf("Expect cert generate test opts: %v, got: %v", expected, opts)
+	}
+}
+
+func TestCertGenerateTestCommand_MissinArgs(t *testing.T) {
+	cmd := certGenerateTestCommand(nil)
+	if err := cmd.ParseFlags(nil); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err == nil {
+		t.Fatal("Parse Args expected error, but ok")
+	}
+}

--- a/cmd/notation/cert_test.go
+++ b/cmd/notation/cert_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func TestCertAddCommand(t *testing.T) {
+func TestCertAddCommand_BasicArgs(t *testing.T) {
 	opts := &certAddOpts{}
 	cmd := certAddCommand(opts)
 	expected := &certAddOpts{
@@ -27,7 +27,7 @@ func TestCertAddCommand(t *testing.T) {
 	}
 }
 
-func TestCertAddCommand_MissinArgs(t *testing.T) {
+func TestCertAddCommand_MissingArgs(t *testing.T) {
 	cmd := certAddCommand(nil)
 	if err := cmd.ParseFlags([]string{}); err != nil {
 		t.Fatalf("Parse Flag failed: %v", err)
@@ -37,7 +37,7 @@ func TestCertAddCommand_MissinArgs(t *testing.T) {
 	}
 }
 
-func TestCertRemoveCommand(t *testing.T) {
+func TestCertRemoveCommand_BasicArgs(t *testing.T) {
 	opts := &certRemoveOpts{}
 	cmd := certRemoveCommand(opts)
 	expected := &certRemoveOpts{
@@ -54,7 +54,7 @@ func TestCertRemoveCommand(t *testing.T) {
 	}
 }
 
-func TestCertRemoveCommand_MissinArgs(t *testing.T) {
+func TestCertRemoveCommand_MissingArgs(t *testing.T) {
 	cmd := certRemoveCommand(nil)
 	if err := cmd.ParseFlags([]string{}); err != nil {
 		t.Fatalf("Parse Flag failed: %v", err)
@@ -64,7 +64,7 @@ func TestCertRemoveCommand_MissinArgs(t *testing.T) {
 	}
 }
 
-func TestCertGenerateCommand(t *testing.T) {
+func TestCertGenerateCommand_WithExpiry(t *testing.T) {
 	opts := &certGenerateTestOpts{}
 	cmd := certGenerateTestCommand(opts)
 	expected := &certGenerateTestOpts{
@@ -90,7 +90,7 @@ func TestCertGenerateCommand(t *testing.T) {
 	}
 }
 
-func TestCertGenerateTestCommand_MissinArgs(t *testing.T) {
+func TestCertGenerateTestCommand_MissingArgs(t *testing.T) {
 	cmd := certGenerateTestCommand(nil)
 	if err := cmd.ParseFlags(nil); err != nil {
 		t.Fatalf("Parse Flag failed: %v", err)

--- a/cmd/notation/key_test.go
+++ b/cmd/notation/key_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestKeyAddCommand(t *testing.T) {
+	opts := &keyAddOpts{}
+	cmd := keyAddCommand(opts)
+	expected := &keyAddOpts{
+		name:         "name",
+		plugin:       "pluginname",
+		id:           "pluginid",
+		keyPath:      "keypath",
+		certPath:     "certpath",
+		pluginConfig: "pluginconfig",
+	}
+	if err := cmd.ParseFlags([]string{
+		"-n", expected.name,
+		"--plugin", expected.plugin,
+		"--id", expected.id,
+		"-c", expected.pluginConfig,
+		expected.keyPath, expected.certPath}); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err != nil {
+		t.Fatalf("Parse Args failed: %v", err)
+	}
+	if *expected != *opts {
+		t.Fatalf("Expect key add opts: %v, got: %v", expected, opts)
+	}
+}
+
+func TestKeyUpdateCommand(t *testing.T) {
+	opts := &keyUpdateOpts{}
+	cmd := keyUpdateCommand(opts)
+	expected := &keyUpdateOpts{
+		name:      "name",
+		isDefault: true,
+	}
+	if err := cmd.ParseFlags([]string{
+		expected.name,
+		"--default"}); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err != nil {
+		t.Fatalf("Parse Args failed: %v", err)
+	}
+	if *expected != *opts {
+		t.Fatalf("Expect key update opts: %v, got: %v", expected, opts)
+	}
+}
+
+func TestKeyUpdateCommand_MissinArgs(t *testing.T) {
+	cmd := keyUpdateCommand(nil)
+	if err := cmd.ParseFlags(nil); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err == nil {
+		t.Fatal("Parse Args expected error, but ok")
+	}
+}
+
+func TestKeyRemoveCommand(t *testing.T) {
+	opts := &keyRemoveOpts{}
+	cmd := keyRemoveCommand(opts)
+	expected := &keyRemoveOpts{
+		names: []string{"key0", "key1", "key2"},
+	}
+	if err := cmd.ParseFlags(expected.names); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err != nil {
+		t.Fatalf("Parse Args failed: %v", err)
+	}
+	if !reflect.DeepEqual(*expected, *opts) {
+		t.Fatalf("Expect key remove opts: %v, got: %v", expected, opts)
+	}
+}
+
+func TestKeyRemoveCommand_MissinArgs(t *testing.T) {
+	cmd := keyRemoveCommand(nil)
+	if err := cmd.ParseFlags(nil); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err == nil {
+		t.Fatal("Parse Args expected error, but ok")
+	}
+}

--- a/cmd/notation/key_test.go
+++ b/cmd/notation/key_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestKeyAddCommand(t *testing.T) {
+func TestKeyAddCommand_BasicArgs(t *testing.T) {
 	opts := &keyAddOpts{}
 	cmd := keyAddCommand(opts)
 	expected := &keyAddOpts{
@@ -32,7 +32,7 @@ func TestKeyAddCommand(t *testing.T) {
 	}
 }
 
-func TestKeyUpdateCommand(t *testing.T) {
+func TestKeyUpdateCommand_BasicArgs(t *testing.T) {
 	opts := &keyUpdateOpts{}
 	cmd := keyUpdateCommand(opts)
 	expected := &keyUpdateOpts{
@@ -52,7 +52,7 @@ func TestKeyUpdateCommand(t *testing.T) {
 	}
 }
 
-func TestKeyUpdateCommand_MissinArgs(t *testing.T) {
+func TestKeyUpdateCommand_MissingArgs(t *testing.T) {
 	cmd := keyUpdateCommand(nil)
 	if err := cmd.ParseFlags(nil); err != nil {
 		t.Fatalf("Parse Flag failed: %v", err)
@@ -62,7 +62,7 @@ func TestKeyUpdateCommand_MissinArgs(t *testing.T) {
 	}
 }
 
-func TestKeyRemoveCommand(t *testing.T) {
+func TestKeyRemoveCommand_BasicArgs(t *testing.T) {
 	opts := &keyRemoveOpts{}
 	cmd := keyRemoveCommand(opts)
 	expected := &keyRemoveOpts{
@@ -79,7 +79,7 @@ func TestKeyRemoveCommand(t *testing.T) {
 	}
 }
 
-func TestKeyRemoveCommand_MissinArgs(t *testing.T) {
+func TestKeyRemoveCommand_MissingArgs(t *testing.T) {
 	cmd := keyRemoveCommand(nil)
 	if err := cmd.ParseFlags(nil); err != nil {
 		t.Fatalf("Parse Flag failed: %v", err)

--- a/cmd/notation/list_test.go
+++ b/cmd/notation/list_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestListCommand(t *testing.T) {
+	opts := &listOpts{}
+	cmd := listCommand(opts)
+	expected := &listOpts{
+		reference: "ref",
+		SecureFlagOpts: SecureFlagOpts{
+			Password:  "password",
+			PlainHTTP: true,
+			Username:  "user",
+		},
+	}
+	if err := cmd.ParseFlags([]string{
+		"--password", expected.Password,
+		expected.reference,
+		"-u", expected.Username,
+		"--plain-http"}); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err != nil {
+		t.Fatalf("Parse Args failed: %v", err)
+	}
+	if *opts != *expected {
+		t.Fatalf("Expect list opts: %v, got: %v", expected, opts)
+	}
+}
+
+func TestListCommand_SecretFromEnv(t *testing.T) {
+	t.Setenv(defaultUsernameEnv, "user")
+	t.Setenv(defaultPasswordEnv, "password")
+	opts := &listOpts{}
+	expected := &listOpts{
+		reference: "ref",
+		SecureFlagOpts: SecureFlagOpts{
+			Password: "password",
+			Username: "user",
+		},
+	}
+	cmd := listCommand(opts)
+	if err := cmd.ParseFlags([]string{
+		expected.reference}); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err != nil {
+		t.Fatalf("Parse Args failed: %v", err)
+	}
+	if *opts != *expected {
+		t.Fatalf("Expect list opts: %v, got: %v", expected, opts)
+	}
+}
+
+func TestListCommand_MissingArgs(t *testing.T) {
+	cmd := listCommand(nil)
+	if err := cmd.ParseFlags(nil); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err == nil {
+		t.Fatal("Parse Args expected error, but ok")
+	}
+}

--- a/cmd/notation/list_test.go
+++ b/cmd/notation/list_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestListCommand(t *testing.T) {
+func TestListCommand_SecretsFromArgs(t *testing.T) {
 	opts := &listOpts{}
 	cmd := listCommand(opts)
 	expected := &listOpts{
@@ -30,7 +30,7 @@ func TestListCommand(t *testing.T) {
 	}
 }
 
-func TestListCommand_SecretFromEnv(t *testing.T) {
+func TestListCommand_SecretsFromEnv(t *testing.T) {
 	t.Setenv(defaultUsernameEnv, "user")
 	t.Setenv(defaultPasswordEnv, "password")
 	opts := &listOpts{}

--- a/cmd/notation/login_test.go
+++ b/cmd/notation/login_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestLoginCommand(t *testing.T) {
+func TestLoginCommand_PasswordFromArgs(t *testing.T) {
 	t.Setenv(defaultUsernameEnv, "user")
 	opts := &loginOpts{}
 	cmd := loginCommand(opts)

--- a/cmd/notation/login_test.go
+++ b/cmd/notation/login_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLoginCommand(t *testing.T) {
+	t.Setenv(defaultUsernameEnv, "user")
+	opts := &loginOpts{}
+	cmd := loginCommand(opts)
+	expected := &loginOpts{
+		SecureFlagOpts: SecureFlagOpts{
+			Username: "user",
+			Password: "password",
+		},
+		server: "server",
+	}
+	if err := cmd.ParseFlags([]string{
+		expected.server,
+		"-u", expected.Username,
+		"-p", expected.Password,
+	}); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err != nil {
+		t.Fatalf("Parse args failed: %v", err)
+	}
+	if err := cmd.PreRunE(cmd, cmd.Flags().Args()); err != nil {
+		t.Fatalf("Get password failed: %v", err)
+	}
+	if *opts != *expected {
+		t.Fatalf("Expect login opts: %v, got: %v", expected, opts)
+	}
+}
+
+func TestLogin_PasswordFromStdin(t *testing.T) {
+	t.Setenv(defaultUsernameEnv, "user")
+	opts := &loginOpts{}
+	cmd := loginCommand(opts)
+	expected := &loginOpts{
+		passwordStdin: true,
+		SecureFlagOpts: SecureFlagOpts{
+			Username: "user",
+			Password: "password",
+		},
+		server: "server",
+	}
+	if err := cmd.ParseFlags([]string{
+		expected.server,
+		"--password-stdin",
+		"-u", expected.Username,
+		"-p", expected.Password,
+	}); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err != nil {
+		t.Fatalf("Parse Args failed: %v", err)
+	}
+
+	r, w, err := os.Pipe()
+	w.Write([]byte("password"))
+	w.Close()
+	oldStdin := os.Stdin
+
+	defer func() {
+		os.Stdin = oldStdin
+	}()
+	os.Stdin = r
+	if err != nil {
+		t.Fatalf("Create test pipe for login cmd failed: %v", err)
+	}
+	if err := cmd.PreRunE(cmd, cmd.Flags().Args()); err != nil {
+		t.Fatalf("Read password from stdin failed: %v", err)
+	}
+	if *opts != *expected {
+		t.Fatalf("Expect login opts: %+v, got: %+v", expected, opts)
+	}
+}
+
+func TestLoginCommand_MissingArgs(t *testing.T) {
+	cmd := loginCommand(nil)
+	if err := cmd.ParseFlags(nil); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err == nil {
+		t.Fatal("Parse Args expected error, but ok")
+	}
+}

--- a/cmd/notation/logout_test.go
+++ b/cmd/notation/logout_test.go
@@ -1,0 +1,32 @@
+package main
+
+import "testing"
+
+func TestLogoutCommand(t *testing.T) {
+	opts := &logoutOpts{}
+	cmd := logoutCommand(opts)
+	expected := &logoutOpts{
+		server: "server",
+	}
+	if err := cmd.ParseFlags([]string{
+		expected.server,
+	}); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err != nil {
+		t.Fatalf("Parse Args failed: %v", err)
+	}
+	if *opts != *expected {
+		t.Fatalf("Expect logout opts: %v, got: %v", expected, opts)
+	}
+}
+
+func TestLogOutCommand_MissinArgs(t *testing.T) {
+	cmd := logoutCommand(nil)
+	if err := cmd.ParseFlags([]string{}); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err == nil {
+		t.Fatal("Parse Args expected error, but ok")
+	}
+}

--- a/cmd/notation/logout_test.go
+++ b/cmd/notation/logout_test.go
@@ -2,7 +2,7 @@ package main
 
 import "testing"
 
-func TestLogoutCommand(t *testing.T) {
+func TestLogoutCommand_BasicArgs(t *testing.T) {
 	opts := &logoutOpts{}
 	cmd := logoutCommand(opts)
 	expected := &logoutOpts{
@@ -21,7 +21,7 @@ func TestLogoutCommand(t *testing.T) {
 	}
 }
 
-func TestLogOutCommand_MissinArgs(t *testing.T) {
+func TestLogOutCommand_MissingArgs(t *testing.T) {
 	cmd := logoutCommand(nil)
 	if err := cmd.ParseFlags([]string{}); err != nil {
 		t.Fatalf("Parse Flag failed: %v", err)

--- a/cmd/notation/pull_test.go
+++ b/cmd/notation/pull_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestPullCommand(t *testing.T) {
+func TestPullCommand_BasicArgs(t *testing.T) {
 	t.Setenv(defaultUsernameEnv, "user")
 	t.Setenv(defaultPasswordEnv, "password")
 

--- a/cmd/notation/pull_test.go
+++ b/cmd/notation/pull_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestPullCommand(t *testing.T) {
+	t.Setenv(defaultUsernameEnv, "user")
+	t.Setenv(defaultPasswordEnv, "password")
+
+	opts := &pullOpts{}
+	cmd := pullCommand(opts)
+	expected := &pullOpts{
+		reference: "ref",
+		strict:    true,
+		SecureFlagOpts: SecureFlagOpts{
+			Username: "user2",
+			Password: "password",
+		},
+	}
+	if err := cmd.ParseFlags([]string{
+		expected.reference,
+		"-u", expected.Username,
+		"--strict"}); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err != nil {
+		t.Fatalf("Parse args failed: %v", err)
+	}
+	if *expected != *opts {
+		t.Fatalf("Expect pull opts: %v, got: %v", expected, opts)
+	}
+}
+
+func TestPullCommand_MissingArgs(t *testing.T) {
+	cmd := pullCommand(nil)
+	if err := cmd.ParseFlags(nil); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err == nil {
+		t.Fatal("Parse Args expected error, but ok")
+	}
+}

--- a/cmd/notation/push_test.go
+++ b/cmd/notation/push_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPushCommand(t *testing.T) {
+	t.Setenv(defaultUsernameEnv, "user")
+	t.Setenv(defaultPasswordEnv, "password")
+
+	opts := &pushOpts{}
+	cmd := pushCommand(opts)
+	expected := &pushOpts{
+		reference: "ref",
+		SecureFlagOpts: SecureFlagOpts{
+			Username: "user",
+			Password: "password2",
+		},
+		signatures: []string{"s0", "s1"},
+	}
+	if err := cmd.ParseFlags([]string{
+		expected.reference,
+		"-p", expected.Password,
+		"--signature", expected.signatures[0],
+		"-s", expected.signatures[1]}); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err != nil {
+		t.Fatalf("Parse args failed: %v", err)
+	}
+	if !reflect.DeepEqual(*expected, *opts) {
+		t.Fatalf("Expect key remove opts: %v, got: %v", expected, opts)
+	}
+}
+
+func TestPushCommand_MissingArgs(t *testing.T) {
+	cmd := pushCommand(nil)
+	if err := cmd.ParseFlags(nil); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err == nil {
+		t.Fatal("Parse Args expected error, but ok")
+	}
+}

--- a/cmd/notation/push_test.go
+++ b/cmd/notation/push_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestPushCommand(t *testing.T) {
+func TestPushCommand_BasicArgs(t *testing.T) {
 	t.Setenv(defaultUsernameEnv, "user")
 	t.Setenv(defaultPasswordEnv, "password")
 

--- a/cmd/notation/sign_test.go
+++ b/cmd/notation/sign_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/notaryproject/notation/internal/cmd"
+)
+
+func TestSignCommand(t *testing.T) {
+	opts := &signOpts{}
+	command := signCommand(opts)
+	expected := &signOpts{
+		reference: "ref",
+		RemoteFlagOpts: RemoteFlagOpts{
+			SecureFlagOpts: SecureFlagOpts{
+				Username: "user",
+				Password: "password",
+			},
+			CommonFlagOpts: CommonFlagOpts{
+				MediaType: defaultMediaType,
+			},
+		},
+		SignerFlagOpts: cmd.SignerFlagOpts{
+			Key:      "key",
+			KeyFile:  "keyfile",
+			CertFile: "certfile",
+		},
+		push: true,
+	}
+	if err := command.ParseFlags([]string{
+		expected.reference,
+		"-u", expected.Username,
+		"--password", expected.Password,
+		"--key", expected.Key,
+		"--key-file", expected.KeyFile,
+		"--cert-file", expected.CertFile}); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := command.Args(command, command.Flags().Args()); err != nil {
+		t.Fatalf("Parse args failed: %v", err)
+	}
+	if *expected != *opts {
+		t.Fatalf("Expect sign opts: %v, got: %v", expected, opts)
+	}
+}
+
+func TestSignCommand_MoreFlags(t *testing.T) {
+	opts := &signOpts{}
+	command := signCommand(opts)
+	expected := &signOpts{
+		reference: "ref",
+		RemoteFlagOpts: RemoteFlagOpts{
+			SecureFlagOpts: SecureFlagOpts{
+				Username:  "user",
+				Password:  "password",
+				PlainHTTP: true,
+			},
+			CommonFlagOpts: CommonFlagOpts{
+				MediaType: "mediaT",
+				Local:     true,
+			},
+		},
+		SignerFlagOpts: cmd.SignerFlagOpts{
+			Key:      "key",
+			KeyFile:  "keyfile",
+			CertFile: "certfile",
+		},
+		output: "outputfile",
+		push:   false,
+		expiry: 24 * time.Hour,
+	}
+	if err := command.ParseFlags([]string{
+		expected.reference,
+		"-u", expected.Username,
+		"-p", expected.Password,
+		"--key", expected.Key,
+		"--key-file", expected.KeyFile,
+		"--cert-file", expected.CertFile,
+		"--plain-http",
+		"--push=false",
+		"--media-type", expected.MediaType,
+		"-l",
+		"--output", expected.output,
+		"--expiry", expected.expiry.String()}); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := command.Args(command, command.Flags().Args()); err != nil {
+		t.Fatalf("Parse args failed: %v", err)
+	}
+	if *expected != *opts {
+		t.Fatalf("Expect sign opts: %v, got: %v", expected, opts)
+	}
+}
+
+func TestSignCommand_CorrectConfig(t *testing.T) {
+	opts := &signOpts{}
+	command := signCommand(opts)
+	expected := &signOpts{
+		reference: "ref",
+		RemoteFlagOpts: RemoteFlagOpts{
+			CommonFlagOpts: CommonFlagOpts{
+				MediaType: "mediaT",
+				Local:     true,
+			},
+		},
+		SignerFlagOpts: cmd.SignerFlagOpts{
+			Key:      "key",
+			KeyFile:  "keyfile",
+			CertFile: "certfile",
+		},
+		push:            true,
+		expiry:          365 * 24 * time.Hour,
+		pluginConfig:    "key0=val0,key1=val1,key2=val2",
+		originReference: "originref",
+		pushReference:   "pushref",
+	}
+	if err := command.ParseFlags([]string{
+		expected.reference,
+		"--key", expected.Key,
+		"--key-file", expected.KeyFile,
+		"--cert-file", expected.CertFile,
+		"--push",
+		"--media-type", expected.MediaType,
+		"--push-reference", expected.pushReference,
+		"-r", expected.originReference,
+		"--local",
+		"--expiry", expected.expiry.String(),
+		"--pluginConfig", expected.pluginConfig}); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := command.Args(command, command.Flags().Args()); err != nil {
+		t.Fatalf("Parse args failed: %v", err)
+	}
+	if *expected != *opts {
+		t.Fatalf("Expect sign opts: %v, got: %v", expected, opts)
+	}
+	config, err := cmd.ParseFlagPluginConfig(opts.pluginConfig)
+	if err != nil {
+		t.Fatalf("Parse plugin Config flag failed: %v", err)
+	}
+	if len(config) != 3 {
+		t.Fatalf("Expect plugin config number: %v, got: %v ", 3, len(config))
+	}
+	for i := 0; i < 3; i++ {
+		key, val := fmt.Sprintf("key%v", i), fmt.Sprintf("val%v", i)
+		configVal, ok := config[key]
+		if !ok {
+			t.Fatalf("Key: %v not in config", key)
+		}
+		if val != configVal {
+			t.Fatalf("Value for key: %v error, got: %v, expect: %v", key, configVal, val)
+		}
+	}
+}
+
+func TestSignCommand_MissingArgs(t *testing.T) {
+	cmd := signCommand(nil)
+	if err := cmd.ParseFlags(nil); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err == nil {
+		t.Fatal("Parse Args expected error, but ok")
+	}
+}

--- a/cmd/notation/sign_test.go
+++ b/cmd/notation/sign_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/notaryproject/notation/internal/cmd"
 )
 
-func TestSignCommand(t *testing.T) {
+func TestSignCommand_BasicArgs(t *testing.T) {
 	opts := &signOpts{}
 	command := signCommand(opts)
 	expected := &signOpts{
@@ -46,7 +46,7 @@ func TestSignCommand(t *testing.T) {
 	}
 }
 
-func TestSignCommand_MoreFlags(t *testing.T) {
+func TestSignCommand_MoreArgs(t *testing.T) {
 	opts := &signOpts{}
 	command := signCommand(opts)
 	expected := &signOpts{

--- a/cmd/notation/verify_test.go
+++ b/cmd/notation/verify_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestVerifyCommand(t *testing.T) {
+func TestVerifyCommand_BasicArgs(t *testing.T) {
 	opts := &verifyOpts{}
 	command := verifyCommand(opts)
 	expected := &verifyOpts{
@@ -44,7 +44,7 @@ func TestVerifyCommand(t *testing.T) {
 	}
 }
 
-func TestVerifyCommand_MoreFlags(t *testing.T) {
+func TestVerifyCommand_MoreArgs(t *testing.T) {
 	opts := &verifyOpts{}
 	command := verifyCommand(opts)
 	expected := &verifyOpts{

--- a/cmd/notation/verify_test.go
+++ b/cmd/notation/verify_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestVerifyCommand(t *testing.T) {
+	opts := &verifyOpts{}
+	command := verifyCommand(opts)
+	expected := &verifyOpts{
+		reference: "ref",
+		RemoteFlagOpts: RemoteFlagOpts{
+			SecureFlagOpts: SecureFlagOpts{
+				Username: "user",
+				Password: "password",
+			},
+			CommonFlagOpts: CommonFlagOpts{
+				MediaType: defaultMediaType,
+			},
+		},
+		certs:      []string{"cert0", "cert1"},
+		certFiles:  []string{"certfile0", "certfile1"},
+		signatures: []string{"sig0", "sig1"},
+		pull:       true,
+	}
+	if err := command.ParseFlags([]string{
+		expected.reference,
+		"--username", expected.Username,
+		"--password", expected.Password,
+		"-c", expected.certs[0],
+		"--cert", expected.certs[1],
+		"--cert-file", expected.certFiles[0],
+		"--cert-file", expected.certFiles[1],
+		"--signature", expected.signatures[0],
+		"-s", expected.signatures[1]}); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := command.Args(command, command.Flags().Args()); err != nil {
+		t.Fatalf("Parse args failed: %v", err)
+	}
+	if !reflect.DeepEqual(*expected, *opts) {
+		t.Fatalf("Expect verify opts: %v, got: %v", expected, opts)
+	}
+}
+
+func TestVerifyCommand_MoreFlags(t *testing.T) {
+	opts := &verifyOpts{}
+	command := verifyCommand(opts)
+	expected := &verifyOpts{
+		reference: "ref",
+		RemoteFlagOpts: RemoteFlagOpts{
+			SecureFlagOpts: SecureFlagOpts{
+				PlainHTTP: true,
+			},
+			CommonFlagOpts: CommonFlagOpts{
+				MediaType: "mediaT",
+			},
+		},
+		certs:      []string{},
+		certFiles:  []string{},
+		signatures: []string{},
+		pull:       false,
+	}
+	if err := command.ParseFlags([]string{
+		expected.reference,
+		"--plain-http",
+		"--pull=false",
+		"--media-type=mediaT"}); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := command.Args(command, command.Flags().Args()); err != nil {
+		t.Fatalf("Parse args failed: %v", err)
+	}
+	if !reflect.DeepEqual(*expected, *opts) {
+		t.Fatalf("Expect verify opts: %v, got: %v", expected, opts)
+	}
+}
+
+func TestVerifyCommand_MissingArgs(t *testing.T) {
+	cmd := verifyCommand(nil)
+	if err := cmd.ParseFlags(nil); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := cmd.Args(cmd, cmd.Flags().Args()); err == nil {
+		t.Fatal("Parse Args expected error, but ok")
+	}
+}


### PR DESCRIPTION
Signed-off-by: zaihaoyin <zaihaoyin@microsoft.com>

This PR adds unit test for some cli commands, only to make sure the flags are parsed correctly.
This is the last PR of the whole series(https://github.com/notaryproject/notation/pull/255).