### PR TITLE
ci: add weekly release

### DIFF
--- a/.dev.goreleaser.yml
+++ b/.dev.goreleaser.yml
@@ -1,0 +1,31 @@
+builds:
+  - main: ./cmd/notation
+    id: notation
+    binary: notation
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    ldflags:
+      - -s -w -X {{.ModulePath}}/internal/version.Version={{.Version}} -X {{.ModulePath}}/internal/version.BuildMetadata=
+archives:
+  - format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - LICENSE
+release:
+  prerelease: true
+  header: |
+    ## Notation Weekly Dev Build ({{ .Date }})
+
+    Welcome to this Weekly Dev Build!

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,0 +1,43 @@
+name: dev-release
+
+on:
+  schedule:
+    - cron: '0 16 * * 0'  # at 16:00 on Sunday (UTC)
+
+jobs:
+  build:
+    name: Weekly Release Notation Binaries
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        go-version: [1.18]
+      fail-fast: true
+    steps:
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set Git User
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+      - name: Create Version Tag
+        run: |
+          # get project version: <SemVer>.dev.<YYYYMMDD>
+          export TAG_VERSION=`cat ./internal/version/version.go | grep "Version = " | awk -F '"' '{print $2}'`.dev.`date +%Y%m%d`
+
+          # create new tag
+          git tag -af $TAG_VERSION -m "For weekly build"
+          git push origin $TAG_VERSION
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release -f ./.dev.goreleaser.yml --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -20,6 +20,12 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set GoReleaser Previous Tag To Be Last Non Weekly Release
+        run: |
+          pre_tag=`git tag --sort=-creatordate --list 'v*' | grep -v dev | head -2 | tail -1`
+          echo "GORELEASER_PREVIOUS_TAG=$pre_tag" >> $GITHUB_ENV
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:


### PR DESCRIPTION
1. At 16:00 on Sunday (UTC), the workflow creates a release tagged as `<SemVer>.dev.<YYYYMMDD>`, including all the change logs from last commit tagged by version.
2. Changed the release-github.yml workflow to include all the change logs from last non dev release to current state.