### PR TITLE
fix: allow empty credentials store config

### DIFF
--- a/cmd/notation/registry.go
+++ b/cmd/notation/registry.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"net"
 
 	notationregistry "github.com/notaryproject/notation-go/registry"
@@ -66,7 +67,9 @@ func getAuthClient(opts *SecureFlagOpts, ref registry.Reference) (*auth.Client, 
 	}
 	if cred == auth.EmptyCredential {
 		var err error
-		if cred, err = getSavedCreds(ref.Registry); err != nil {
+		cred, err = getSavedCreds(ref.Registry)
+		// local registry may not need credentials
+		if err != nil && !errors.Is(err, loginauth.ErrCredentialsConfigNotSet) {
 			return nil, false, err
 		}
 	}

--- a/pkg/auth/native_store.go
+++ b/pkg/auth/native_store.go
@@ -28,7 +28,7 @@ type nativeAuthStore struct {
 func GetCredentialsStore(registryHostname string) (CredentialStore, error) {
 	configFile, err := loadConfig()
 	if err != nil {
-		return nil, fmt.Errorf("failed to load config file, error: %v", err)
+		return nil, fmt.Errorf("failed to load config file, error: %w", err)
 	}
 	if helper := getConfiguredCredentialStore(configFile, registryHostname); helper != "" {
 		return newNativeAuthStore(helper), nil


### PR DESCRIPTION
Backgroud: according to previous design, credentials store config must exist in notation config.json or docker config.json, but you may not need a credentials store config to sign image for local registry. 

Fix: we need to allow empty credentials store config for local reigistry.

Test:
1. sign local registry
2. sign remote registry with username/password
3. sign remote registry without username/password
4. login with credential config
5. login without credential config
6. logout with credential config
7. logout without credential config

Resolves #284 
Signed-off-by: Junjie Gao <junjiegao@microsoft.com>