### PR TITLE
doc: add missing username/password options to commands

### DIFF
--- a/specs/notation-cli.md
+++ b/specs/notation-cli.md
@@ -67,7 +67,12 @@ COMMANDS:
    help, h     Shows a list of commands or help for one command
 
 OPTIONS:
+   --username value, -u value    Username for registry operations [$NOTATION_USERNAME]
+   --password value, -p value    Password for registry operations [$NOTATION_PASSWORD]
    --help, -h  show help (default: false)
+
+GLOBAL ARGUMENTS
+   --plain-http                  Registry access via plain HTTP (default: false)
 ```
 
 ## certificate
@@ -123,7 +128,12 @@ USAGE:
    notation list [command options] <reference>
 
 OPTIONS:
+   --username value, -u value    Username for registry operations [$NOTATION_USERNAME]
+   --password value, -p value    Password for registry operations [$NOTATION_PASSWORD]
    --help, -h                  show help (default: false)
+
+GLOBAL ARGUMENTS
+   --plain-http                  Registry access via plain HTTP (default: false)
 ```
 
 ## login
@@ -185,9 +195,14 @@ USAGE:
    notation pull [command options] <reference>
 
 OPTIONS:
+   --username value, -u value    Username for registry operations [$NOTATION_USERNAME]
+   --password value, -p value    Password for registry operations [$NOTATION_PASSWORD]
    --strict                    Pull the signature without lookup the manifest (default: false)
    --output value, -o value    Write signature to a specific path
    --help, -h                  Show help (default: false)
+
+GLOBAL ARGUMENTS
+   --plain-http                  Registry access via plain HTTP (default: false)
 ```
 
 ## push
@@ -201,8 +216,13 @@ USAGE:
    notation push [command options] <reference>
 
 OPTIONS:
+   --username value, -u value    Username for registry operations [$NOTATION_USERNAME]
+   --password value, -p value    Password for registry operations [$NOTATION_PASSWORD]
    --signature value, -s value, -f value  signature files  (accepts multiple inputs)
    --help, -h                             show help (default: false)
+
+GLOBAL ARGUMENTS
+   --plain-http                  Registry access via plain HTTP (default: false)
 ```
 
 ## sign
@@ -227,7 +247,12 @@ OPTIONS:
    --push                       push after successful signing (default: true)
    --push-reference value       different remote to store signature
    --media-type value           specify the media type of the manifest read from file or stdin (default: "application/vnd.docker.distribution.manifest.v2+json")
+   --username value, -u value    Username for registry operations [$NOTATION_USERNAME]
+   --password value, -p value    Password for registry operations [$NOTATION_PASSWORD]
    --help, -h                   show help (default: false)
+
+GLOBAL ARGUMENTS
+   --plain-http                  Registry access via plain HTTP (default: false)
 ```
 
 ## verify
@@ -247,5 +272,10 @@ OPTIONS:
    --pull                                 pull remote signatures before verification (default: true)
    --local, -l                            reference is a local file (default: false)
    --media-type value                     specify the media type of the manifest read from file or stdin (default: "application/vnd.docker.distribution.manifest.v2+json")
+   --username value, -u value    Username for registry operations [$NOTATION_USERNAME]
+   --password value, -p value    Password for registry operations [$NOTATION_PASSWORD]
    --help, -h                             show help (default: false)
+
+GLOBAL ARGUMENTS
+   --plain-http                  Registry access via plain HTTP (default: false)
 ```

--- a/specs/notation-cli.md
+++ b/specs/notation-cli.md
@@ -69,7 +69,7 @@ COMMANDS:
 OPTIONS:
    --username value, -u value    Username for registry operations [$NOTATION_USERNAME]
    --password value, -p value    Password for registry operations [$NOTATION_PASSWORD]
-   --help, -h  show help (default: false)
+   --help, -h                    show help (default: false)
 
 GLOBAL ARGUMENTS
    --plain-http                  Registry access via plain HTTP (default: false)
@@ -130,7 +130,7 @@ USAGE:
 OPTIONS:
    --username value, -u value    Username for registry operations [$NOTATION_USERNAME]
    --password value, -p value    Password for registry operations [$NOTATION_PASSWORD]
-   --help, -h                  show help (default: false)
+   --help, -h                    show help (default: false)
 
 GLOBAL ARGUMENTS
    --plain-http                  Registry access via plain HTTP (default: false)
@@ -141,7 +141,7 @@ GLOBAL ARGUMENTS
 ```console
 notation login --help
 NAME:
-   notation login - Provides credentials for authenticated registry operations.
+   notation login - Provides credentials for authenticated registry operations
 
 USAGE:
    notation login [options] [server]
@@ -198,14 +198,14 @@ USAGE:
    notation pull [command options] <reference>
 
 OPTIONS:
-   --username value, -u value    Username for registry operations [$NOTATION_USERNAME]
-   --password value, -p value    Password for registry operations [$NOTATION_PASSWORD]
+   --username value, -u value  Username for registry operations [$NOTATION_USERNAME]
+   --password value, -p value  Password for registry operations [$NOTATION_PASSWORD]
    --strict                    Pull the signature without lookup the manifest (default: false)
    --output value, -o value    Write signature to a specific path
    --help, -h                  Show help (default: false)
 
 GLOBAL ARGUMENTS
-   --plain-http                  Registry access via plain HTTP (default: false)
+   --plain-http                Registry access via plain HTTP (default: false)
 ```
 
 ## push
@@ -219,13 +219,13 @@ USAGE:
    notation push [command options] <reference>
 
 OPTIONS:
-   --username value, -u value    Username for registry operations [$NOTATION_USERNAME]
-   --password value, -p value    Password for registry operations [$NOTATION_PASSWORD]
+   --username value, -u value             Username for registry operations [$NOTATION_USERNAME]
+   --password value, -p value             Password for registry operations [$NOTATION_PASSWORD]
    --signature value, -s value, -f value  signature files  (accepts multiple inputs)
    --help, -h                             show help (default: false)
 
 GLOBAL ARGUMENTS
-   --plain-http                  Registry access via plain HTTP (default: false)
+   --plain-http                           Registry access via plain HTTP (default: false)
 ```
 
 ## sign
@@ -250,12 +250,12 @@ OPTIONS:
    --push                       push after successful signing (default: true)
    --push-reference value       different remote to store signature
    --media-type value           specify the media type of the manifest read from file or stdin (default: "application/vnd.docker.distribution.manifest.v2+json")
-   --username value, -u value    Username for registry operations [$NOTATION_USERNAME]
-   --password value, -p value    Password for registry operations [$NOTATION_PASSWORD]
+   --username value, -u value   Username for registry operations [$NOTATION_USERNAME]
+   --password value, -p value   Password for registry operations [$NOTATION_PASSWORD]
    --help, -h                   show help (default: false)
 
 GLOBAL ARGUMENTS
-   --plain-http                  Registry access via plain HTTP (default: false)
+   --plain-http                 Registry access via plain HTTP (default: false)
 ```
 
 ## verify
@@ -275,10 +275,10 @@ OPTIONS:
    --pull                                 pull remote signatures before verification (default: true)
    --local, -l                            reference is a local file (default: false)
    --media-type value                     specify the media type of the manifest read from file or stdin (default: "application/vnd.docker.distribution.manifest.v2+json")
-   --username value, -u value    Username for registry operations [$NOTATION_USERNAME]
-   --password value, -p value    Password for registry operations [$NOTATION_PASSWORD]
+   --username value, -u value             Username for registry operations [$NOTATION_USERNAME]
+   --password value, -p value             Password for registry operations [$NOTATION_PASSWORD]
    --help, -h                             show help (default: false)
 
 GLOBAL ARGUMENTS
-   --plain-http                  Registry access via plain HTTP (default: false)
+   --plain-http                           Registry access via plain HTTP (default: false)
 ```

--- a/specs/notation-cli.md
+++ b/specs/notation-cli.md
@@ -141,7 +141,7 @@ GLOBAL ARGUMENTS
 ```console
 notation login --help
 NAME:
-   notation login - Provides credentials for authenticated registry operations
+   notation login - Provides credentials for authenticated registry operations.
 
 USAGE:
    notation login [options] [server]
@@ -164,6 +164,9 @@ notation login -u <user> -p <password> registry.example.com
 
 # Login using $NOTATION_USERNAME $NOTATION_PASSWORD variables
 notation login registry.example.com
+
+NOTES
+Once login is completed, then -u -p is no longer required for any notation commands against the registry server authenticated.
 ```
 
 ## plugin


### PR DESCRIPTION
### What?

Resovles https://github.com/notaryproject/notation/issues/276

For commands other than `notation login`, we should allow them support `username/password` options even without first-time logging.
Since the `login` command requires `credentialsStore` set up which might be missing for users. So we cannot force users always use `login` to save credentials. Other commands should be able to use the credentials directly from input without `credentialsStore` set up.

Updated commands:
1. sign
2. push
3. pull
4. list
5. cache
6. verify

Signed-off-by: Binbin Li <libinbin@microsoft.com>