### PR TITLE
fix: update notation-go

### DIFF
--- a/cmd/notation/cert_gen.go
+++ b/cmd/notation/cert_gen.go
@@ -43,14 +43,13 @@ func generateTestCert(opts *certGenerateTestOpts) error {
 	fmt.Println("generated certificates expiring on", rsaLeafCertTuple.Cert.NotAfter.Format(time.RFC3339))
 
 	// write private key
-	keyPath := dir.Path.Localkey(name, dir.KeyExtension)
+	keyPath, certPath := dir.Path.Localkey(name)
 	if err := osutil.WriteFileWithPermission(keyPath, keyBytes, 0600, false); err != nil {
 		return fmt.Errorf("failed to write key file: %v", err)
 	}
 	fmt.Println("wrote key:", keyPath)
 
 	// write self-signed certificate
-	certPath := dir.Path.Localkey(name, dir.CertificateExtension)
 	if err := osutil.WriteFileWithPermission(certPath, append(leafBytes, rootBytes...), 0644, false); err != nil {
 		return fmt.Errorf("failed to write certificate file: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.18
 require (
 	github.com/distribution/distribution/v3 v3.0.0-20220729163034-26163d82560f
 	github.com/docker/docker-credential-helpers v0.6.4
-	github.com/notaryproject/notation-core-go v0.0.0-20220728174113-1d963fd57141
-	github.com/notaryproject/notation-go v0.9.0-alpha.1.0.20220802200409-6312370a3526
+	github.com/notaryproject/notation-core-go v0.0.0-20220809210532-f0a54093ba32
+	github.com/notaryproject/notation-go v0.9.0-alpha.1.0.20220816013743-c350ef73e5f0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -9,10 +9,10 @@ github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQA
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/notaryproject/notation-core-go v0.0.0-20220728174113-1d963fd57141 h1:VtrElctZUBC9bJlvELU16v7BrElZm8lZYFY1F71rfRg=
-github.com/notaryproject/notation-core-go v0.0.0-20220728174113-1d963fd57141/go.mod h1:n+UjcUoYhvawO/JW5JfZerUUsGbHYTd4wH8ndGeeyas=
-github.com/notaryproject/notation-go v0.9.0-alpha.1.0.20220802200409-6312370a3526 h1:fS+KCElDiaIE8fJLS/gB9vN6bkiNoh9GOEoAIrKgTWU=
-github.com/notaryproject/notation-go v0.9.0-alpha.1.0.20220802200409-6312370a3526/go.mod h1:Rls6mRUjflVG0sVjVp6L9GpWFB/q0N3Aws7fI/Am0hc=
+github.com/notaryproject/notation-core-go v0.0.0-20220809210532-f0a54093ba32 h1:dMZIRt5CMjl9eLJFywlBDDps3AWjgyy6axFnYONak8g=
+github.com/notaryproject/notation-core-go v0.0.0-20220809210532-f0a54093ba32/go.mod h1:n+UjcUoYhvawO/JW5JfZerUUsGbHYTd4wH8ndGeeyas=
+github.com/notaryproject/notation-go v0.9.0-alpha.1.0.20220816013743-c350ef73e5f0 h1:YQS5UhcYc0O7vVoIE2kdeXbZKGVoxEiLJwnm6C8PgQo=
+github.com/notaryproject/notation-go v0.9.0-alpha.1.0.20220816013743-c350ef73e5f0/go.mod h1:crBca+qGBV39lmSnmyJM0L/2gAa/XlEWrID3rXYENXo=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86 h1:Oumw+lPnO8qNLTY2mrqPJZMoGExLi/0h/DdikoLTXVU=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86/go.mod h1:aA4vdXRS8E1TG7pLZOz85InHi3BiPdErh8IpJN6E0x4=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=


### PR DESCRIPTION
This PR updates notation-go to v0.0.0-20220809210532-f0a54093ba32.
1. update directory structure logic: if config file doesn't exist, create the file at user config directory instead of the system directory;
2. dir.Path.Localkey signature has been changed and we need to adapt our code.

Signed-off-by: Junjie Gao <junjiegao@microsoft.com>