### PR TITLE
fix: deprecated the expiry flag of notation cert generate-test

### DIFF
--- a/cmd/notation/cert.go
+++ b/cmd/notation/cert.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/notaryproject/notation-core-go/x509"
 	"github.com/notaryproject/notation-go/config"
@@ -27,7 +26,6 @@ type certRemoveOpts struct {
 type certGenerateTestOpts struct {
 	name      string
 	bits      int
-	expiry    time.Duration
 	trust     bool
 	hosts     []string
 	isDefault bool
@@ -119,7 +117,6 @@ func certGenerateTestCommand(opts *certGenerateTestOpts) *cobra.Command {
 
 	command.Flags().StringVarP(&opts.name, "name", "n", "", "key and certificate name")
 	command.Flags().IntVarP(&opts.bits, "bits", "b", 2048, "RSA key bits")
-	command.Flags().DurationVarP(&opts.expiry, "expiry", "e", 365*24*time.Hour, "certificate expiry")
 	command.Flags().BoolVar(&opts.trust, "trust", false, "add the generated certificate to the verification list")
 	setKeyDefaultFlag(command.Flags(), &opts.isDefault)
 	return command

--- a/cmd/notation/cert_test.go
+++ b/cmd/notation/cert_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
-	"time"
 )
 
 func TestCertAddCommand_BasicArgs(t *testing.T) {
@@ -64,7 +63,7 @@ func TestCertRemoveCommand_MissingArgs(t *testing.T) {
 	}
 }
 
-func TestCertGenerateCommand_WithExpiry(t *testing.T) {
+func TestCertGenerateCommand(t *testing.T) {
 	opts := &certGenerateTestOpts{}
 	cmd := certGenerateTestCommand(opts)
 	expected := &certGenerateTestOpts{
@@ -72,7 +71,6 @@ func TestCertGenerateCommand_WithExpiry(t *testing.T) {
 		name:      "name",
 		bits:      2048,
 		isDefault: true,
-		expiry:    365 * 24 * time.Hour,
 	}
 	if err := cmd.ParseFlags([]string{
 		"host0", "host1",


### PR DESCRIPTION
removed the expiry flag of 'notation cert generate-test' command

Resolves #312 

Signed-off-by: Patrick Zheng <patrickzheng@microsoft.com>