### PR TITLE
feat: add config.json envelopeType support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/distribution/distribution/v3 v3.0.0-20220729163034-26163d82560f
 	github.com/docker/docker-credential-helpers v0.6.4
 	github.com/notaryproject/notation-core-go v0.0.0-20220901064119-7bf2b3e37c06
-	github.com/notaryproject/notation-go v0.10.0-alpha.3.0.20220902031024-9d20702738ae
+	github.com/notaryproject/notation-go v0.10.0-alpha.3.0.20220906053403-603af0988a52
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/notaryproject/notation-core-go v0.0.0-20220901064119-7bf2b3e37c06 h1:tvnxwHtQEACckbLYYoyCPkAawNJk1BAsGFLrDhou2U0=
 github.com/notaryproject/notation-core-go v0.0.0-20220901064119-7bf2b3e37c06/go.mod h1:vRFI64uedpKUChiadJ/2q8jJNdKtxHa7Er1JbSnm8AY=
-github.com/notaryproject/notation-go v0.10.0-alpha.3.0.20220902031024-9d20702738ae h1:ZO5CVjUF/kw1v27PL+YFJw5gtQAtsuyGA4IEae0L+/o=
-github.com/notaryproject/notation-go v0.10.0-alpha.3.0.20220902031024-9d20702738ae/go.mod h1:MmfBg6Nq9cpUqqOFiXww3/VHAyoVuXynzdYrwuY6qgs=
+github.com/notaryproject/notation-go v0.10.0-alpha.3.0.20220906053403-603af0988a52 h1:0DN9xzo70xvzpn+EwJ+HwvIKsFURr1fiPU+S2fylf38=
+github.com/notaryproject/notation-go v0.10.0-alpha.3.0.20220906053403-603af0988a52/go.mod h1:MmfBg6Nq9cpUqqOFiXww3/VHAyoVuXynzdYrwuY6qgs=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86 h1:Oumw+lPnO8qNLTY2mrqPJZMoGExLi/0h/DdikoLTXVU=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86/go.mod h1:aA4vdXRS8E1TG7pLZOz85InHi3BiPdErh8IpJN6E0x4=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/notaryproject/notation/pkg/configutil"
 	"github.com/spf13/pflag"
 )
 
@@ -42,7 +43,14 @@ var (
 		Usage: "signature envelope format, options: 'jws', 'cose'",
 	}
 	SetPflagSignatureFormat = func(fs *pflag.FlagSet, p *string) {
-		fs.StringVar(p, PflagEnvelopeType.Name, JwsFormat, PflagEnvelopeType.Usage)
+		defaultEnvelopeFormat := JwsFormat
+		// load config to get envelopeType
+		config, err := configutil.LoadConfigOnce()
+		if err == nil && config.EnvelopeType != "" {
+			defaultEnvelopeFormat = config.EnvelopeType
+		}
+
+		fs.StringVar(p, PflagEnvelopeType.Name, defaultEnvelopeFormat, PflagEnvelopeType.Usage)
 	}
 
 	PflagTimestamp = &pflag.Flag{


### PR DESCRIPTION
add config.json `envelopeType` argument support

Test:
1. config: no `envelopeType` or `envelopeType` = "" or `envelopeType` = "jws"  AND cli: notation sign -> JWS format
2. config: no `envelopeType` or `envelopeType` = "" or `envelopeType` = "jws"  AND cli: notation sign `--envelope-type cose` -> COSE format
3. config: `envelopeType` = "cose" AND cli: notation sign -> COSE format
4. config: `envelopeType` = "cose" AND cli: notation sign `--envelope-type jws`-> JWS format
5. config: `envelopeType` = "cosw" AND cli: notation sign -> `Error: signature format cosw not supported`
6. config: `envelopeType` = "cosw" AND cli: notation sign `--envelope-type jws`-> JWS format