### PR TITLE
feat: write envelopeType default value to config.json

### DIFF
--- a/cmd/notation/sign_test.go
+++ b/cmd/notation/sign_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/notaryproject/notation/internal/cmd"
+	"github.com/notaryproject/notation/internal/envelope"
 )
 
 func TestSignCommand_BasicArgs(t *testing.T) {
@@ -26,7 +27,7 @@ func TestSignCommand_BasicArgs(t *testing.T) {
 			Key:          "key",
 			KeyFile:      "keyfile",
 			CertFile:     "certfile",
-			EnvelopeType: cmd.JwsFormat,
+			EnvelopeType: envelope.Jws,
 		},
 		push: true,
 	}
@@ -67,7 +68,7 @@ func TestSignCommand_MoreArgs(t *testing.T) {
 			Key:          "key",
 			KeyFile:      "keyfile",
 			CertFile:     "certfile",
-			EnvelopeType: cmd.CoseFormat,
+			EnvelopeType: envelope.Cose,
 		},
 		output: "outputfile",
 		push:   false,
@@ -112,7 +113,7 @@ func TestSignCommand_CorrectConfig(t *testing.T) {
 			Key:          "key",
 			KeyFile:      "keyfile",
 			CertFile:     "certfile",
-			EnvelopeType: cmd.JwsFormat,
+			EnvelopeType: envelope.Jws,
 		},
 		push:            true,
 		expiry:          365 * 24 * time.Hour,

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/notaryproject/notation/internal/envelope"
 	"github.com/notaryproject/notation/pkg/configutil"
 	"github.com/spf13/pflag"
 )
@@ -43,7 +44,7 @@ var (
 		Usage: "signature envelope format, options: 'jws', 'cose'",
 	}
 	SetPflagSignatureFormat = func(fs *pflag.FlagSet, p *string) {
-		defaultEnvelopeFormat := JwsFormat
+		defaultEnvelopeFormat := envelope.Jws
 		// load config to get envelopeType
 		config, err := configutil.LoadConfigOnce()
 		if err == nil && config.EnvelopeType != "" {

--- a/internal/cmd/signer.go
+++ b/internal/cmd/signer.go
@@ -10,13 +10,8 @@ import (
 	"github.com/notaryproject/notation-go"
 	"github.com/notaryproject/notation-go/plugin/manager"
 	"github.com/notaryproject/notation-go/signature"
+	"github.com/notaryproject/notation/internal/envelope"
 	"github.com/notaryproject/notation/pkg/configutil"
-)
-
-// Supported envelope format.
-const (
-	CoseFormat = "cose"
-	JwsFormat  = "jws"
 )
 
 // GetSigner returns a signer according to the CLI context.
@@ -62,9 +57,9 @@ func GetExpiry(expiry time.Duration) time.Time {
 
 func GetEnvelopeMediaType(sigFormat string) (string, error) {
 	switch sigFormat {
-	case JwsFormat:
+	case envelope.Jws:
 		return jws.MediaTypeEnvelope, nil
-	case CoseFormat:
+	case envelope.Cose:
 		return cose.MediaTypeEnvelope, nil
 	}
 	return "", fmt.Errorf("signature format %s not supported", sigFormat)

--- a/internal/envelope/envelope.go
+++ b/internal/envelope/envelope.go
@@ -1,0 +1,7 @@
+package envelope
+
+// Supported envelope format.
+const (
+	Cose = "cose"
+	Jws  = "jws"
+)

--- a/pkg/configutil/once.go
+++ b/pkg/configutil/once.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/notaryproject/notation-go/config"
+	"github.com/notaryproject/notation/internal/envelope"
 )
 
 var (
@@ -24,6 +25,10 @@ func LoadConfigOnce() (*config.Config, error) {
 	var err error
 	configOnce.Do(func() {
 		configInfo, err = config.LoadConfig()
+		// set default value
+		if configInfo.EnvelopeType == "" {
+			configInfo.EnvelopeType = envelope.Jws
+		}
 	})
 	return configInfo, err
 }


### PR DESCRIPTION
1. move the envelope format name definition to ./internal/envelope/
2. add default value envelopeType = jws to config.json

Signed-off-by: Junjie Gao <junjiegao@microsoft.com>