### PR TITLE
feat:updating go.mod dependencies for alpha4

### DIFF
--- a/cmd/notation/verify.go
+++ b/cmd/notation/verify.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/notaryproject/notation-core-go/signature/jws"
 	"github.com/notaryproject/notation-go"
 	"github.com/notaryproject/notation-go/dir"
 	"github.com/notaryproject/notation-go/signature"
@@ -95,7 +96,10 @@ func verifySignatures(ctx context.Context, verifier notation.Verifier, manifestD
 		return errors.New("verification failure: no signatures found")
 	}
 
-	var opts notation.VerifyOptions
+	// TODO: support cose media type
+	opts := notation.VerifyOptions{
+		SignatureMediaType: jws.MediaTypeEnvelope,
+	}
 	var lastErr error
 	for _, path := range sigPaths {
 		sig, err := os.ReadFile(path)

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.19
 require (
 	github.com/distribution/distribution/v3 v3.0.0-20220729163034-26163d82560f
 	github.com/docker/docker-credential-helpers v0.7.0
-	github.com/notaryproject/notation-core-go v0.1.0-alpha.3
-	github.com/notaryproject/notation-go v0.10.0-alpha.3
+	github.com/notaryproject/notation-core-go v0.1.0-alpha.3.0.20220921054535-009c09a9628e
+	github.com/notaryproject/notation-go v0.10.0-alpha.3.0.20220927020950-2bcfd343f974
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -7,10 +7,10 @@ github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQA
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/notaryproject/notation-core-go v0.1.0-alpha.3 h1:gzB+h5TGzuocWiJxuYZgE/FwUIbJyKAHfk2hWSBbCGg=
-github.com/notaryproject/notation-core-go v0.1.0-alpha.3/go.mod h1:Wfyh5SrQ718JegKPhTs7y74rXg86tWd5NfOx2uHK1nI=
-github.com/notaryproject/notation-go v0.10.0-alpha.3 h1:jDIwUzGHsxwXuIFYLwQ1pPzpO5GFcoaA1X78EixIBo4=
-github.com/notaryproject/notation-go v0.10.0-alpha.3/go.mod h1:PQuu7OZweVU5erEyqriguCvK7CCGF+X5psDj63iEvGk=
+github.com/notaryproject/notation-core-go v0.1.0-alpha.3.0.20220921054535-009c09a9628e h1:n3wJRhIVbEGg497rtKV3IMaZJv2hFKYHCOtNIOAyLYw=
+github.com/notaryproject/notation-core-go v0.1.0-alpha.3.0.20220921054535-009c09a9628e/go.mod h1:mM4M9wPdu0CGgh8f3wOcu0XMiXwEKWQurjBG4nmqQ4g=
+github.com/notaryproject/notation-go v0.10.0-alpha.3.0.20220927020950-2bcfd343f974 h1:aJ5p4zydKHoyXVK62H50fmj5czcxXpSG5a24EgoZH5E=
+github.com/notaryproject/notation-go v0.10.0-alpha.3.0.20220927020950-2bcfd343f974/go.mod h1:TeQIoxMetPFqJSDzcHnGZ6x9kKzglfSmgxYrWt9/viA=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86 h1:Oumw+lPnO8qNLTY2mrqPJZMoGExLi/0h/DdikoLTXVU=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86/go.mod h1:aA4vdXRS8E1TG7pLZOz85InHi3BiPdErh8IpJN6E0x4=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/internal/cmd/signer.go
+++ b/internal/cmd/signer.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/notaryproject/notation-core-go/signature/jws"
 	"github.com/notaryproject/notation-go"
 	"github.com/notaryproject/notation-go/plugin/manager"
 	"github.com/notaryproject/notation-go/signature"
@@ -13,9 +14,11 @@ import (
 // GetSigner returns a signer according to the CLI context.
 func GetSigner(opts *SignerFlagOpts) (notation.Signer, error) {
 	// Construct a signer from key and cert file if provided as CLI arguments
+	// TODO: support cose media type
+	envelopeType := jws.MediaTypeEnvelope
 	if keyPath := opts.KeyFile; keyPath != "" {
 		certPath := opts.CertFile
-		return signature.NewSignerFromFiles(keyPath, certPath)
+		return signature.NewSignerFromFiles(keyPath, certPath, envelopeType)
 	}
 	// Construct a signer from preconfigured key pair in config.json
 	// if key name is provided as the CLI argument
@@ -24,7 +27,7 @@ func GetSigner(opts *SignerFlagOpts) (notation.Signer, error) {
 		return nil, err
 	}
 	if key.X509KeyPair != nil {
-		return signature.NewSignerFromFiles(key.X509KeyPair.KeyPath, key.X509KeyPair.CertificatePath)
+		return signature.NewSignerFromFiles(key.X509KeyPair.KeyPath, key.X509KeyPair.CertificatePath, envelopeType)
 	}
 	// Construct a plugin signer if key name provided as the CLI argument
 	// corresponds to an external key
@@ -34,7 +37,7 @@ func GetSigner(opts *SignerFlagOpts) (notation.Signer, error) {
 		if err != nil {
 			return nil, err
 		}
-		return signature.NewSignerPlugin(runner, key.ExternalKey.ID, key.PluginConfig)
+		return signature.NewSignerPlugin(runner, key.ExternalKey.ID, key.PluginConfig, envelopeType)
 	}
 	return nil, errors.New("unsupported key, either provide a local key and certificate file paths, or a key name in config.json, check [DOC_PLACEHOLDER] for details")
 }


### PR DESCRIPTION
This PR updates notation cli with the main branch of `notation-core-go` and `notation-go`.
After all PRs merged, I will update go.mod to use main branch.
Test manually on virtual machine.
Now I hard code envelope type to be jws. I will add more envelope types after cose merged.
Signed-off-by: zaihaoyin <zaihaoyin@microsoft.com>