### PR TITLE
feat: support tagged reference

### DIFF
--- a/cmd/notation/verify.go
+++ b/cmd/notation/verify.go
@@ -2,12 +2,11 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"os"
-	"strings"
 
 	"github.com/notaryproject/notation-go/registry"
 	"github.com/notaryproject/notation-go/verification"
+	"github.com/notaryproject/notation/internal/cmd"
 	"github.com/notaryproject/notation/internal/ioutil"
 
 	orasregistry "oras.land/oras-go/v2/registry"
@@ -18,7 +17,7 @@ import (
 type verifyOpts struct {
 	SecureFlagOpts
 	reference string
-	config    []string
+	config    string
 }
 
 func verifyCommand(opts *verifyOpts) *cobra.Command {
@@ -26,10 +25,10 @@ func verifyCommand(opts *verifyOpts) *cobra.Command {
 		opts = &verifyOpts{}
 	}
 	command := &cobra.Command{
-		Use:   "verify <reference>",
+		Use:   "verify [flags] <reference>",
 		Short: "Verifies OCI Artifacts",
 		Long: `Verifies OCI Artifacts:
-  notation verify [--config <key>=<value>] [--username <username>] [--password <password>] <reference>`,
+  notation verify [--config <key>=<value>,...] [--username <username>] [--password <password>] <reference>`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return errors.New("missing reference")
@@ -42,21 +41,16 @@ func verifyCommand(opts *verifyOpts) *cobra.Command {
 		},
 	}
 	opts.ApplyFlags(command.Flags())
-	command.Flags().StringSliceVar(&opts.config, "config", nil, "verification plugin config (accepts multiple inputs)")
+	command.Flags().StringVarP(&opts.config, "config", "c", "", "list of comma-separated {key}={value} pairs that are passed as is to the plugin")
 	return command
 }
 
 func runVerify(command *cobra.Command, opts *verifyOpts) error {
 	// resolve the given reference and set the digest.
-	manifestDesc, err := getManifestDescriptorFromReference(command.Context(), &opts.SecureFlagOpts, opts.reference)
+	ref, err := resolveReference(command, opts)
 	if err != nil {
 		return err
 	}
-	ref, err := orasregistry.ParseReference(opts.reference)
-	if err != nil {
-		return err
-	}
-	ref.Reference = manifestDesc.Digest.String()
 
 	// initialize verifier.
 	verifier, err := getVerifier(opts, ref)
@@ -65,17 +59,13 @@ func runVerify(command *cobra.Command, opts *verifyOpts) error {
 	}
 
 	// set up verification plugin config.
-	configs := make(map[string]string)
-	for _, c := range opts.config {
-		parts := strings.Split(c, "=")
-		if len(parts) != 2 {
-			return fmt.Errorf("invalid config option: %s", c)
-		}
-		configs[parts[0]] = parts[1]
+	configs, err := cmd.ParseFlagPluginConfig(opts.config)
+	if err != nil {
+		return err
 	}
-	ctx := verification.WithPluginConfig(command.Context(), configs)
 
 	// core verify process.
+	ctx := verification.WithPluginConfig(command.Context(), configs)
 	outcomes, err := verifier.Verify(ctx, ref.String())
 
 	// write out.
@@ -91,4 +81,19 @@ func getVerifier(opts *verifyOpts, ref orasregistry.Reference) (*verification.Ve
 	repo := registry.NewRepositoryClient(authClient, ref, plainHTTP)
 
 	return verification.NewVerifier(repo)
+}
+
+func resolveReference(command *cobra.Command, opts *verifyOpts) (orasregistry.Reference, error) {
+	ref, err := orasregistry.ParseReference(opts.reference)
+	if err != nil {
+		return orasregistry.Reference{}, err
+	}
+
+	manifestDesc, err := getManifestDescriptorFromReference(command.Context(), &opts.SecureFlagOpts, opts.reference)
+	if err != nil {
+		return orasregistry.Reference{}, err
+	}
+
+	ref.Reference = manifestDesc.Digest.String()
+	return ref, nil
 }

--- a/cmd/notation/verify_test.go
+++ b/cmd/notation/verify_test.go
@@ -37,13 +37,12 @@ func TestVerifyCommand_MoreArgs(t *testing.T) {
 		SecureFlagOpts: SecureFlagOpts{
 			PlainHTTP: true,
 		},
-		config: []string{"key1=val1", "key2=val2"},
+		config: "key1=val1,key2=val2",
 	}
 	if err := command.ParseFlags([]string{
 		expected.reference,
 		"--plain-http",
-		"--config", expected.config[0],
-		"--config", expected.config[1]}); err != nil {
+		"--config", expected.config}); err != nil {
 		t.Fatalf("Parse Flag failed: %v", err)
 	}
 	if err := command.Args(command, command.Flags().Args()); err != nil {

--- a/internal/ioutil/print.go
+++ b/internal/ioutil/print.go
@@ -54,28 +54,29 @@ func PrintCertificateMap(w io.Writer, v []config.CertificateReference) error {
 	return tw.Flush()
 }
 
-func PrintVerificationResults(w io.Writer, v []*verification.SignatureVerificationOutcome, resultErr error) error {
+func PrintVerificationResults(w io.Writer, v []*verification.SignatureVerificationOutcome, resultErr error, digest string) error {
 	tw := newTabWriter(w)
 
-	overallResult := "success"
-	if resultErr != nil {
-		overallResult = "failure"
+	if resultErr == nil {
+		fmt.Fprintf(tw, "%s\n", digest)
+		return nil
 	}
-	fmt.Fprintf(tw, "OVERALL RESULT: %s\n", overallResult)
 
-	if resultErr != nil {
-		fmt.Fprintf(tw, "ERROR: %s\n", resultErr.Error())
-		printOutcomes(tw, v)
-	}
+	fmt.Fprintf(tw, "ERROR: %s\n\n", resultErr.Error())
+	printOutcomes(tw, v)
 
 	return tw.Flush()
 }
 
 func printOutcomes(tw *tabwriter.Writer, outcomes []*verification.SignatureVerificationOutcome) {
-	if len(outcomes) > 0 {
-		fmt.Fprintln(tw, "DETAILED ERRORS:")
-		for _, outcome := range outcomes {
-			fmt.Println(outcome.Error)
-		}
+	if len(outcomes) == 1 {
+		fmt.Println("1 signature failed verification, error is listed as below:")
+	} else {
+		fmt.Printf("%d signatures failed verification, errors are listed as below:\n", len(outcomes))
+	}
+
+	for _, outcome := range outcomes {
+		// TODO: print out the signature digest once the outcome contains it.
+		fmt.Printf("%s\n\n", outcome.Error.Error())
 	}
 }


### PR DESCRIPTION
### What?

1. Support passing in a reference in the format: registry/repository:v1. Before that, only a reference with digest tag is supported.
2. Refactor the print out format to be more readable.

### Test
Success case:
<img width="415" alt="image" src="https://user-images.githubusercontent.com/6919333/192679726-0893b997-a9fa-41f2-9833-3774ad97138e.png">


Failure case:
![failure](https://user-images.githubusercontent.com/6919333/192674014-add262d5-f155-4120-9741-e89c736bc428.jpg)

Signed-off-by: Binbin Li <libinbin@microsoft.com>