### PR TITLE
feat: add signatureFormat config field

### DIFF
--- a/cmd/notation/sign_test.go
+++ b/cmd/notation/sign_test.go
@@ -20,8 +20,8 @@ func TestSignCommand_BasicArgs(t *testing.T) {
 			Password: "password",
 		},
 		SignerFlagOpts: cmd.SignerFlagOpts{
-			Key:          "key",
-			EnvelopeType: envelope.JWS,
+			Key:             "key",
+			SignatureFormat: envelope.JWS,
 		},
 	}
 	if err := command.ParseFlags([]string{
@@ -50,8 +50,8 @@ func TestSignCommand_MoreArgs(t *testing.T) {
 			PlainHTTP: true,
 		},
 		SignerFlagOpts: cmd.SignerFlagOpts{
-			Key:          "key",
-			EnvelopeType: envelope.COSE,
+			Key:             "key",
+			SignatureFormat: envelope.COSE,
 		},
 		expiry: 24 * time.Hour,
 	}
@@ -61,7 +61,7 @@ func TestSignCommand_MoreArgs(t *testing.T) {
 		"-p", expected.Password,
 		"--key", expected.Key,
 		"--plain-http",
-		"--signature-format", expected.SignerFlagOpts.EnvelopeType,
+		"--signature-format", expected.SignerFlagOpts.SignatureFormat,
 		"--expiry", expected.expiry.String()}); err != nil {
 		t.Fatalf("Parse Flag failed: %v", err)
 	}
@@ -79,8 +79,8 @@ func TestSignCommand_CorrectConfig(t *testing.T) {
 	expected := &signOpts{
 		reference: "ref",
 		SignerFlagOpts: cmd.SignerFlagOpts{
-			Key:          "key",
-			EnvelopeType: envelope.JWS,
+			Key:             "key",
+			SignatureFormat: envelope.JWS,
 		},
 		expiry:       365 * 24 * time.Hour,
 		pluginConfig: []string{"key0=val0", "key1=val1"},
@@ -88,7 +88,7 @@ func TestSignCommand_CorrectConfig(t *testing.T) {
 	if err := command.ParseFlags([]string{
 		expected.reference,
 		"--key", expected.Key,
-		"--signature-format", expected.SignerFlagOpts.EnvelopeType,
+		"--signature-format", expected.SignerFlagOpts.SignatureFormat,
 		"--expiry", expected.expiry.String(),
 		"--plugin-config", "key0=val0",
 		"--plugin-config", "key1=val1"}); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/distribution/distribution/v3 v3.0.0-20220729163034-26163d82560f
 	github.com/docker/docker-credential-helpers v0.7.0
 	github.com/notaryproject/notation-core-go v0.1.0-alpha.4.0.20221017041709-56bd40a80d26
-	github.com/notaryproject/notation-go v0.11.0-alpha.4.0.20221025011337-7ad4eca1a568
+	github.com/notaryproject/notation-go v0.11.0-alpha.4.0.20221031015031-bccecbc83094
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -17,12 +17,8 @@ github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQA
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/notaryproject/notation-core-go v0.1.0-alpha.4 h1:0OhA2PjwT0TAouHOrU4K+8H9YM6E/e4/ocoq+JiHeOw=
-github.com/notaryproject/notation-core-go v0.1.0-alpha.4/go.mod h1:s8DZptmN1rZS0tBLTPt/w+d4o6eAcGWTYYJlXaJhQ4U=
 github.com/notaryproject/notation-core-go v0.1.0-alpha.4.0.20221017041709-56bd40a80d26 h1:tAM+m4MocXBXdRBr8GDWABWHw3XiO3PE9+L38aEECLc=
 github.com/notaryproject/notation-core-go v0.1.0-alpha.4.0.20221017041709-56bd40a80d26/go.mod h1:s8DZptmN1rZS0tBLTPt/w+d4o6eAcGWTYYJlXaJhQ4U=
-github.com/notaryproject/notation-go v0.11.0-alpha.4 h1:PNptLtrhW0jyw10hUWU+KNzvzeuBBZmg+/1IUaGYE10=
-github.com/notaryproject/notation-go v0.11.0-alpha.4/go.mod h1:4xYTcW4wfsXkXw3piUA53uSW82RwdXyipSEtiiRVrCw=
 github.com/notaryproject/notation-go v0.11.0-alpha.4.0.20221025011337-7ad4eca1a568 h1:omjj1Ssrf85KFLyFP4pC50G9xqb7jUhy6RvBjJZ0tgY=
 github.com/notaryproject/notation-go v0.11.0-alpha.4.0.20221025011337-7ad4eca1a568/go.mod h1:pTGrgvkitZClSoQY31P4LgBExtRRXg1AD/9tkFmxaS0=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86 h1:Oumw+lPnO8qNLTY2mrqPJZMoGExLi/0h/DdikoLTXVU=

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7P
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/notaryproject/notation-core-go v0.1.0-alpha.4.0.20221017041709-56bd40a80d26 h1:tAM+m4MocXBXdRBr8GDWABWHw3XiO3PE9+L38aEECLc=
 github.com/notaryproject/notation-core-go v0.1.0-alpha.4.0.20221017041709-56bd40a80d26/go.mod h1:s8DZptmN1rZS0tBLTPt/w+d4o6eAcGWTYYJlXaJhQ4U=
-github.com/notaryproject/notation-go v0.11.0-alpha.4.0.20221025011337-7ad4eca1a568 h1:omjj1Ssrf85KFLyFP4pC50G9xqb7jUhy6RvBjJZ0tgY=
-github.com/notaryproject/notation-go v0.11.0-alpha.4.0.20221025011337-7ad4eca1a568/go.mod h1:pTGrgvkitZClSoQY31P4LgBExtRRXg1AD/9tkFmxaS0=
+github.com/notaryproject/notation-go v0.11.0-alpha.4.0.20221031015031-bccecbc83094 h1:eFMBtU74186k5sB0mXtD1Ekhk4YjMjhHLWCeKJwpkbQ=
+github.com/notaryproject/notation-go v0.11.0-alpha.4.0.20221031015031-bccecbc83094/go.mod h1:pTGrgvkitZClSoQY31P4LgBExtRRXg1AD/9tkFmxaS0=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86 h1:Oumw+lPnO8qNLTY2mrqPJZMoGExLi/0h/DdikoLTXVU=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86/go.mod h1:aA4vdXRS8E1TG7pLZOz85InHi3BiPdErh8IpJN6E0x4=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -21,19 +21,19 @@ var (
 		fs.StringVarP(p, PflagKey.Name, PflagKey.Shorthand, "", PflagKey.Usage)
 	}
 
-	PflagEnvelopeType = &pflag.Flag{
+	PflagSignatureFormat = &pflag.Flag{
 		Name:  "signature-format",
 		Usage: "signature envelope format, options: 'jws', 'cose'",
 	}
 	SetPflagSignatureFormat = func(fs *pflag.FlagSet, p *string) {
-		defaultEnvelopeFormat := envelope.JWS
-		// load config to get envelopeType
+		defaultSignatureFormat := envelope.JWS
+		// load config to get signatureFormat
 		config, err := configutil.LoadConfigOnce()
-		if err == nil && config.EnvelopeType != "" {
-			defaultEnvelopeFormat = config.EnvelopeType
+		if err == nil && config.SignatureFormat != "" {
+			defaultSignatureFormat = config.SignatureFormat
 		}
 
-		fs.StringVar(p, PflagEnvelopeType.Name, defaultEnvelopeFormat, PflagEnvelopeType.Usage)
+		fs.StringVar(p, PflagSignatureFormat.Name, defaultSignatureFormat, PflagSignatureFormat.Usage)
 	}
 
 	PflagTimestamp = &pflag.Flag{

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/notaryproject/notation/internal/envelope"
+	"github.com/notaryproject/notation/pkg/configutil"
 	"github.com/spf13/pflag"
 )
 
@@ -25,7 +26,14 @@ var (
 		Usage: "signature envelope format, options: 'jws', 'cose'",
 	}
 	SetPflagSignatureFormat = func(fs *pflag.FlagSet, p *string) {
-		fs.StringVar(p, PflagEnvelopeType.Name, envelope.JWS, PflagEnvelopeType.Usage)
+		defaultEnvelopeFormat := envelope.JWS
+		// load config to get envelopeType
+		config, err := configutil.LoadConfigOnce()
+		if err == nil && config.EnvelopeType != "" {
+			defaultEnvelopeFormat = config.EnvelopeType
+		}
+
+		fs.StringVar(p, PflagEnvelopeType.Name, defaultEnvelopeFormat, PflagEnvelopeType.Usage)
 	}
 
 	PflagTimestamp = &pflag.Flag{

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -29,6 +29,9 @@ var (
 		defaultEnvelopeFormat := envelope.JWS
 		// load config to get envelopeType
 		config, err := configutil.LoadConfigOnce()
+		if err != nil {
+			fmt.Printf("Warning: %v, `envelopeType` of config.json will be overwritten by command line flag `--envelope-type`", err)
+		}
 		if err == nil && config.EnvelopeType != "" {
 			defaultEnvelopeFormat = config.EnvelopeType
 		}

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -29,9 +29,6 @@ var (
 		defaultEnvelopeFormat := envelope.JWS
 		// load config to get envelopeType
 		config, err := configutil.LoadConfigOnce()
-		if err != nil {
-			fmt.Printf("Warning: %v, `envelopeType` of config.json will be overwritten by command line flag `--envelope-type`", err)
-		}
 		if err == nil && config.EnvelopeType != "" {
 			defaultEnvelopeFormat = config.EnvelopeType
 		}

--- a/internal/cmd/options.go
+++ b/internal/cmd/options.go
@@ -6,12 +6,12 @@ import (
 
 // SignerFlagOpts cmd opts for using cmd.GetSigner
 type SignerFlagOpts struct {
-	Key          string
-	EnvelopeType string
+	Key             string
+	SignatureFormat string
 }
 
 // ApplyFlags set flags and their default values for the FlagSet
 func (opts *SignerFlagOpts) ApplyFlags(fs *pflag.FlagSet) {
 	SetPflagKey(fs, &opts.Key)
-	SetPflagSignatureFormat(fs, &opts.EnvelopeType)
+	SetPflagSignatureFormat(fs, &opts.SignatureFormat)
 }

--- a/internal/cmd/signer.go
+++ b/internal/cmd/signer.go
@@ -14,7 +14,7 @@ import (
 // GetSigner returns a signer according to the CLI context.
 func GetSigner(opts *SignerFlagOpts) (notation.Signer, error) {
 	// Construct a signer from key and cert file if provided as CLI arguments
-	mediaType, err := envelope.GetEnvelopeMediaType(opts.EnvelopeType)
+	mediaType, err := envelope.GetEnvelopeMediaType(opts.SignatureFormat)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/signer.go
+++ b/internal/cmd/signer.go
@@ -2,11 +2,8 @@ package cmd
 
 import (
 	"errors"
-	"fmt"
 	"time"
 
-	"github.com/notaryproject/notation-core-go/signature/cose"
-	"github.com/notaryproject/notation-core-go/signature/jws"
 	"github.com/notaryproject/notation-go"
 	"github.com/notaryproject/notation-go/plugin/manager"
 	"github.com/notaryproject/notation-go/signature"
@@ -17,7 +14,7 @@ import (
 // GetSigner returns a signer according to the CLI context.
 func GetSigner(opts *SignerFlagOpts) (notation.Signer, error) {
 	// Construct a signer from key and cert file if provided as CLI arguments
-	mediaType, err := GetEnvelopeMediaType(opts.EnvelopeType)
+	mediaType, err := envelope.GetEnvelopeMediaType(opts.EnvelopeType)
 	if err != nil {
 		return nil, err
 	}
@@ -49,14 +46,4 @@ func GetExpiry(expiry time.Duration) time.Time {
 		return time.Time{}
 	}
 	return time.Now().Add(expiry)
-}
-
-func GetEnvelopeMediaType(sigFormat string) (string, error) {
-	switch sigFormat {
-	case envelope.JWS:
-		return jws.MediaTypeEnvelope, nil
-	case envelope.COSE:
-		return cose.MediaTypeEnvelope, nil
-	}
-	return "", fmt.Errorf("signature format %s not supported", sigFormat)
 }

--- a/internal/envelope/envelope.go
+++ b/internal/envelope/envelope.go
@@ -2,6 +2,7 @@ package envelope
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/notaryproject/notation-core-go/signature/cose"
 	"github.com/notaryproject/notation-core-go/signature/jws"
@@ -27,4 +28,14 @@ func SpeculateSignatureEnvelopeFormat(raw []byte) (string, error) {
 		return "", errors.New("unsupported signature format")
 	}
 	return jws.MediaTypeEnvelope, nil
+}
+
+func GetEnvelopeMediaType(sigFormat string) (string, error) {
+	switch sigFormat {
+	case JWS:
+		return jws.MediaTypeEnvelope, nil
+	case COSE:
+		return cose.MediaTypeEnvelope, nil
+	}
+	return "", fmt.Errorf("signature format %s not supported", sigFormat)
 }

--- a/internal/envelope/envelope.go
+++ b/internal/envelope/envelope.go
@@ -30,6 +30,7 @@ func SpeculateSignatureEnvelopeFormat(raw []byte) (string, error) {
 	return jws.MediaTypeEnvelope, nil
 }
 
+// GetEnvelopeMediaType converts the envelope type to mediaType name.
 func GetEnvelopeMediaType(sigFormat string) (string, error) {
 	switch sigFormat {
 	case JWS:

--- a/internal/envelope/envelope.go
+++ b/internal/envelope/envelope.go
@@ -38,5 +38,5 @@ func GetEnvelopeMediaType(sigFormat string) (string, error) {
 	case COSE:
 		return cose.MediaTypeEnvelope, nil
 	}
-	return "", fmt.Errorf("signature format %s not supported", sigFormat)
+	return "", fmt.Errorf("signature format %q not supported", sigFormat)
 }

--- a/internal/envelope/envelope_test.go
+++ b/internal/envelope/envelope_test.go
@@ -68,7 +68,7 @@ func TestSpeculateSignatureEnvelopeFormat(t *testing.T) {
 				t.Fatalf("expected speculate signature envelope format err: %v, got: %v", tt.expectedErr, err)
 			}
 			if eType != tt.expectedType {
-				t.Fatalf("expected signature envelopeType: %v, got: %v", tt.expectedType, eType)
+				t.Fatalf("expected signatureFormat: %v, got: %v", tt.expectedType, eType)
 			}
 		})
 	}

--- a/internal/envelope/envelope_test.go
+++ b/internal/envelope/envelope_test.go
@@ -73,3 +73,46 @@ func TestSpeculateSignatureEnvelopeFormat(t *testing.T) {
 		})
 	}
 }
+
+func TestGetEnvelopeMediaType(t *testing.T) {
+	type args struct {
+		sigFormat string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "jws",
+			args:    args{"jws"},
+			want:    "application/jose+json",
+			wantErr: false,
+		},
+		{
+			name:    "cose",
+			args:    args{"cose"},
+			want:    "application/cose",
+			wantErr: false,
+		},
+		{
+			name:    "unsupported",
+			args:    args{"unsupported"},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetEnvelopeMediaType(tt.args.sigFormat)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetEnvelopeMediaType() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetEnvelopeMediaType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/configutil/once.go
+++ b/pkg/configutil/once.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/notaryproject/notation-go/config"
+	"github.com/notaryproject/notation/internal/envelope"
 )
 
 var (
@@ -24,6 +25,10 @@ func LoadConfigOnce() (*config.Config, error) {
 	var err error
 	configOnce.Do(func() {
 		configInfo, err = config.LoadConfig()
+		// set default value
+		if configInfo.EnvelopeType == "" {
+			configInfo.EnvelopeType = envelope.JWS
+		}
 	})
 	return configInfo, err
 }

--- a/pkg/configutil/once.go
+++ b/pkg/configutil/once.go
@@ -1,6 +1,7 @@
 package configutil
 
 import (
+	"strings"
 	"sync"
 
 	"github.com/notaryproject/notation-go/config"
@@ -26,6 +27,7 @@ func LoadConfigOnce() (*config.Config, error) {
 	configOnce.Do(func() {
 		configInfo, err = config.LoadConfig()
 		// set default value
+		configInfo.EnvelopeType = strings.ToLower(configInfo.EnvelopeType)
 		if configInfo.EnvelopeType == "" {
 			configInfo.EnvelopeType = envelope.JWS
 		}

--- a/pkg/configutil/once.go
+++ b/pkg/configutil/once.go
@@ -27,9 +27,9 @@ func LoadConfigOnce() (*config.Config, error) {
 	configOnce.Do(func() {
 		configInfo, err = config.LoadConfig()
 		// set default value
-		configInfo.EnvelopeType = strings.ToLower(configInfo.EnvelopeType)
-		if configInfo.EnvelopeType == "" {
-			configInfo.EnvelopeType = envelope.JWS
+		configInfo.SignatureFormat = strings.ToLower(configInfo.SignatureFormat)
+		if configInfo.SignatureFormat == "" {
+			configInfo.SignatureFormat = envelope.JWS
 		}
 	})
 	return configInfo, err

--- a/specs/notation-config.md
+++ b/specs/notation-config.md
@@ -15,7 +15,7 @@ The default location and file will be stored at: `~/.config/notation/config.json
 | Property                  | Type     | Value                                                                                                                                                     |
 | ------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `insecureRegistries`      | _array_  | a list of registries that may be used without https                                                                                                       |
-| `envelopeType`            | _string_ | `jws` is the default value, available type includes `jws` and `cose`                                                                                      |
+| `signatureFormat`            | _string_ | `jws` is the default value, available type includes `jws` and `cose`                                                                                      |
 
 ## Samples
 
@@ -26,7 +26,7 @@ The default location and file will be stored at: `~/.config/notation/config.json
     "insecureRegistries": [
         "registry.wabbit-networks.io"
     ],
-    "envelopeType": "jws"
+    "signatureFormat": "jws"
 }
 ```
 

--- a/specs/notation-config.md
+++ b/specs/notation-config.md
@@ -14,15 +14,8 @@ The default location and file will be stored at: `~/.config/notation/config.json
 
 | Property                  | Type     | Value                                                                                                                                                     |
 | ------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `verificationCerts.certs` | _array_  | collection of name/value pairs for a collection of public certs that are used for verification. These may be replaced with a future policy configuration. |
-| `cert.name`               | _string_ | a named reference to the certificate                                                                                                                      |
-| `cert.path`               | _string_ | a location by which the certificate can be found by the notation cli or notation libraries                                                                |
-| `signingKeys.default`     | _string_ | the signing key to be used when `notation sign` is called without `--name`                                                                                |
-| `signingKeys.keys`        | _array_  | a collection of name/value pairs of signing keys.                                                                                                         |
-| `key.name`                | _string_ | a named reference to the key                                                                                                                              |
-| `key.keyPath`             | _string_ | a location by which the key can be found by the notation cli or notation libraries                                                                        |
-| `key.certPath`            | _string_ | a location by which the paired certificate can be found by the notation cli or notation libraries                                                         |
 | `insecureRegistries`      | _array_  | a list of registries that may be used without https                                                                                                       |
+| `envelopeType`            | _string_ | `jws` is the default value, available type includes `jws` and `cose`                                                                                      |
 
 ## Samples
 
@@ -30,21 +23,10 @@ The default location and file will be stored at: `~/.config/notation/config.json
 
 ```json
 {
-    "verificationCerts": {
-        "certs": [
-            {
-                "name": "wabbit-networks",
-                "path": "/home/demo/.config/notation/localkeys/wabbit-networks.crt"
-            },
-            {
-                "name": "import.acme-rockets",
-                "path": "/home/demo/.config/notation/localkeys/import.acme-rockets.crt"
-            }
-        ]
-    },
     "insecureRegistries": [
         "registry.wabbit-networks.io"
-    ]
+    ],
+    "envelopeType": "jws"
 }
 ```
 


### PR DESCRIPTION
1. Add signatureFormat field providing the default value for --signature-format flag in config.json.
2. move GetEnvelopeMediaType() from internal/cmd/signer.go to internal/envelope/envelope.go


Test:
1. signatureFormat = jws, OK
3. signatureFormat = cose, OK
4. signatureFormat = jws, --signature-format=cose, OK
5. signatureFormat = cose, --signature-format=jws, OK
6. signatureFormat  = cose2, cause an `Error: signature format cose2 not supported`
7. signatureFormat = cose2, --signature-format=jws, OK

Signed-off-by: Junjie Gao <junjiegao@microsoft.com>