### PR TITLE
feat: implement login/logout UX

### DIFF
--- a/cmd/notation/login.go
+++ b/cmd/notation/login.go
@@ -47,7 +47,7 @@ Example - Login using $NOTATION_USERNAME $NOTATION_PASSWORD variables:
 
 			// check username
 			if opts.Username == "" {
-				return errors.New("username was not set.")
+				return errors.New("username is not set.")
 			}
 			return nil
 		},

--- a/cmd/notation/login.go
+++ b/cmd/notation/login.go
@@ -44,11 +44,6 @@ Example - Login using $NOTATION_USERNAME $NOTATION_PASSWORD variables:
 			if err := readPassword(opts); err != nil {
 				return err
 			}
-
-			// check username
-			if opts.Username == "" {
-				return errors.New("username is not set.")
-			}
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -82,9 +77,7 @@ func runLogin(cmd *cobra.Command, opts *loginOpts) error {
 		return fmt.Errorf("failed to store credentials: %v", err)
 	}
 
-	if err == nil {
-		fmt.Println("Login Succeeded")
-	}
+	fmt.Println("Login Succeeded")
 	return nil
 }
 

--- a/cmd/notation/login.go
+++ b/cmd/notation/login.go
@@ -25,7 +25,7 @@ func loginCommand(opts *loginOpts) *cobra.Command {
 	}
 	command := &cobra.Command{
 		Use:   "login [flags] <server>",
-		Short: "Provides credentials for authenticated registry operations",
+		Short: "Login to registry",
 		Long: `Log in to an OCI registry
 
 Example - Login with provided username and password:

--- a/cmd/notation/login.go
+++ b/cmd/notation/login.go
@@ -24,9 +24,9 @@ func loginCommand(opts *loginOpts) *cobra.Command {
 		opts = &loginOpts{}
 	}
 	command := &cobra.Command{
-		Use:   "login [options] [server]",
+		Use:   "login [flags] <server>",
 		Short: "Provides credentials for authenticated registry operations",
-		Long: `notation login [options] [server]
+		Long: `Log in to an OCI registry
 
 Example - Login with provided username and password:
 	notation login -u <user> -p <password> registry.example.com
@@ -44,13 +44,18 @@ Example - Login using $NOTATION_USERNAME $NOTATION_PASSWORD variables:
 			if err := readPassword(opts); err != nil {
 				return err
 			}
+
+			// check username
+			if opts.Username == "" {
+				return errors.New("username was not set.")
+			}
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runLogin(cmd, opts)
 		},
 	}
-	command.Flags().BoolVar(&opts.passwordStdin, "password-stdin", false, "Take the password from stdin")
+	command.Flags().BoolVar(&opts.passwordStdin, "password-stdin", false, "take the password from stdin")
 	opts.ApplyFlags(command.Flags())
 	return command
 }
@@ -67,6 +72,7 @@ func runLogin(cmd *cobra.Command, opts *loginOpts) error {
 	if err != nil {
 		return fmt.Errorf("could not get the credentials store: %v", err)
 	}
+
 	// init creds
 	creds := newCredentialFromInput(
 		opts.Username,
@@ -74,6 +80,10 @@ func runLogin(cmd *cobra.Command, opts *loginOpts) error {
 	)
 	if err = nativeStore.Store(serverAddress, creds); err != nil {
 		return fmt.Errorf("failed to store credentials: %v", err)
+	}
+
+	if err == nil {
+		fmt.Println("Login Succeeded")
 	}
 	return nil
 }

--- a/cmd/notation/logout.go
+++ b/cmd/notation/logout.go
@@ -16,8 +16,8 @@ func logoutCommand(opts *logoutOpts) *cobra.Command {
 		opts = &logoutOpts{}
 	}
 	return &cobra.Command{
-		Use:   "logout [flags] [server]",
-		Short: "Log out the specified registry hostname",
+		Use:   "logout [flags] <server>",
+		Short: "Log out from the logged in registries",
 		Long:  "Log out from an OCI registry",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {

--- a/cmd/notation/logout.go
+++ b/cmd/notation/logout.go
@@ -16,8 +16,9 @@ func logoutCommand(opts *logoutOpts) *cobra.Command {
 		opts = &logoutOpts{}
 	}
 	return &cobra.Command{
-		Use:   "logout [server]",
+		Use:   "logout [flags] [server]",
 		Short: "Log out the specified registry hostname",
+		Long:  "Log out from an OCI registry",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return errors.New("no hostname specified")

--- a/cmd/notation/logout.go
+++ b/cmd/notation/logout.go
@@ -18,7 +18,6 @@ func logoutCommand(opts *logoutOpts) *cobra.Command {
 	return &cobra.Command{
 		Use:   "logout [flags] <server>",
 		Short: "Log out from the logged in registries",
-		Long:  "Log out from an OCI registry",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return errors.New("no hostname specified")

--- a/cmd/notation/main.go
+++ b/cmd/notation/main.go
@@ -21,7 +21,6 @@ func main() {
 		pluginCommand(),
 		loginCommand(nil),
 		logoutCommand(nil))
-
 	if err := cmd.Execute(); err != nil {
 		log.Fatal(err)
 	}

--- a/specs/commandline/logout.md
+++ b/specs/commandline/logout.md
@@ -13,9 +13,7 @@ Usage:
   notation logout [flags] [server]
 
 Flags:
-      --all           log out from all logged in registries
   -h, --help          help for logout
-      --plain-http    registry access via plain HTTP
 ```
 
 ## Usage

--- a/specs/commandline/logout.md
+++ b/specs/commandline/logout.md
@@ -10,7 +10,7 @@ Use `notation logout` to log out from an OCI registry.
 Log out from an OCI registry
 
 Usage:
-  notation logout [flags] [server]
+  notation logout [flags] <server>
 
 Flags:
   -h, --help          help for logout

--- a/specs/commandline/logout.md
+++ b/specs/commandline/logout.md
@@ -7,7 +7,7 @@ Use `notation logout` to log out from an OCI registry.
 ## Outline
 
 ```text
-Log out from an OCI registry
+Log out from the logged in registries
 
 Usage:
   notation logout [flags] <server>


### PR DESCRIPTION
implemnt login UI based on https://github.com/notaryproject/notation/blob/main/specs/commandline/login.md fix:
1. added `Login Succeeded` message when login succeeded
2. added username parameter validation
3. removed --plain-http global flag
4. updated spec: removed logout --plain-http & --all flag

Test:
1. login with -u -p flags
2. login with $NOTATION_USERNAME $NOTATION_PASSWORD
3. login with --password-stdin
5. login without username -> `username was not set.`

Signed-off-by: Junjie Gao <junjiegao@microsoft.com>