### PR TITLE
feat: implement plugin UX

### DIFF
--- a/cmd/notation/plugin.go
+++ b/cmd/notation/plugin.go
@@ -10,7 +10,7 @@ import (
 
 func pluginCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "plugin",
+		Use:   "plugin <command>",
 		Short: "Manage plugins",
 	}
 	cmd.AddCommand(pluginListCommand())
@@ -19,9 +19,9 @@ func pluginCommand() *cobra.Command {
 
 func pluginListCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:     "list",
+		Use:     "list [flags]",
 		Aliases: []string{"ls"},
-		Short:   "List registered plugins",
+		Short:   "List installed plugins",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listPlugins(cmd)
 		},

--- a/cmd/notation/plugin.go
+++ b/cmd/notation/plugin.go
@@ -10,7 +10,7 @@ import (
 
 func pluginCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "plugin [command]",
+		Use:   "plugin",
 		Short: "Manage plugins",
 	}
 	cmd.AddCommand(pluginListCommand())

--- a/cmd/notation/plugin.go
+++ b/cmd/notation/plugin.go
@@ -10,7 +10,7 @@ import (
 
 func pluginCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "plugin <command>",
+		Use:   "plugin [command]",
 		Short: "Manage plugins",
 	}
 	cmd.AddCommand(pluginListCommand())

--- a/specs/commandline/plugin.md
+++ b/specs/commandline/plugin.md
@@ -19,8 +19,6 @@ Available Commands:
 
 Flags:
   -h, --help          help for plugin
-
-Use 'notation plugin [command] --help' for more information about a command.
 ```
 
 ### notation plugin list

--- a/specs/commandline/plugin.md
+++ b/specs/commandline/plugin.md
@@ -12,7 +12,7 @@ Use `notation plugin` to manage plugins. See notation [plugin documentation](htt
 Manage plugins
 
 Usage:
-  notation plugin <command>
+  notation plugin [command]
 
 Available Commands:
   list        List installed plugins
@@ -20,7 +20,7 @@ Available Commands:
 Flags:
   -h, --help          help for plugin
 
-RUN 'notation plugin <command> --help' for more information on a command.
+Use 'notation plugin [command] --help' for more information about a command.
 ```
 
 ### notation plugin list


### PR DESCRIPTION
According https://github.com/notaryproject/notation/blob/main/specs/commandline/plugin.md.

Updated help message.
Updated spec: replace "\<command>"  with "[command]" because the format is defined in cobra template.

Signed-off-by: Junjie Gao <junjiegao@microsoft.com>