### PR TITLE
feat: implement version command

### DIFF
--- a/.dev.goreleaser.yml
+++ b/.dev.goreleaser.yml
@@ -15,7 +15,7 @@ builds:
       - goos: windows
         goarch: arm64
     ldflags:
-      - -s -w -X {{.ModulePath}}/internal/version.Version={{.Version}} -X {{.ModulePath}}/internal/version.BuildMetadata=
+      - -s -w -X {{.ModulePath}}/internal/version.Version={{.Version}} -X {{.ModulePath}}/internal/version.GitCommit={{.FullCommit}} -X {{.ModulePath}}/internal/version.BuildMetadata=
 archives:
   - format: tar.gz
     format_overrides:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ builds:
       - goos: windows
         goarch: arm64
     ldflags:
-      - -s -w -X {{.ModulePath}}/internal/version.Version={{.Version}} -X {{.ModulePath}}/internal/version.BuildMetadata=
+      - -s -w -X {{.ModulePath}}/internal/version.Version={{.Version}} -X {{.ModulePath}}/internal/version.GitCommit={{.FullCommit}} -X {{.ModulePath}}/internal/version.BuildMetadata=
 archives:
   - format: tar.gz
     format_overrides:

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ GIT_TAG        = $(shell git describe --tags --abbrev=0 --exact-match 2>/dev/nul
 GIT_COMMIT     = $(shell git rev-parse HEAD)
 
 # if the commit was tagged, BuildMetadata is empty.
+ifndef BUILD_METADATA
+	BUILD_METADATA := unreleased
+endif
+
 ifneq ($(GIT_TAG),)
 	BUILD_METADATA := 
 endif

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,18 @@
 MODULE         = github.com/notaryproject/notation
 COMMANDS       = notation
 GIT_TAG        = $(shell git describe --tags --abbrev=0 --exact-match 2>/dev/null)
-BUILD_METADATA =
-ifeq ($(GIT_TAG),) # unreleased build
-    GIT_COMMIT     = $(shell git rev-parse HEAD)
-    GIT_STATUS     = $(shell test -n "`git status --porcelain`" && echo "dirty" || echo "unreleased")
-	BUILD_METADATA = $(GIT_COMMIT).$(GIT_STATUS)
+GIT_COMMIT     = $(shell git rev-parse HEAD)
+
+# if the commit was tagged, BuildMetadata is empty.
+ifneq ($(GIT_TAG),)
+	BUILD_METADATA := 
 endif
-LDFLAGS        = -X $(MODULE)/internal/version.BuildMetadata=$(BUILD_METADATA)
+
+# set flags
+LDFLAGS := -w \
+ -X $(MODULE)/internal/version.GitCommit=$(GIT_COMMIT) \
+ -X $(MODULE)/internal/version.BuildMetadata=$(BUILD_METADATA)
+
 GO_BUILD_FLAGS = --ldflags="$(LDFLAGS)"
 
 .PHONY: help

--- a/cmd/notation/main.go
+++ b/cmd/notation/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"log"
 
-	"github.com/notaryproject/notation/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -11,7 +10,6 @@ func main() {
 	cmd := &cobra.Command{
 		Use:          "notation",
 		Short:        "Notation - Notary V2",
-		Version:      version.GetVersion(),
 		SilenceUsage: true,
 	}
 	cmd.AddCommand(
@@ -22,7 +20,9 @@ func main() {
 		keyCommand(),
 		pluginCommand(),
 		loginCommand(nil),
-		logoutCommand(nil))
+		logoutCommand(nil),
+		versionCommand(),
+	)
 	cmd.PersistentFlags().Bool(flagPlainHTTP.Name, false, flagPlainHTTP.Usage)
 	if err := cmd.Execute(); err != nil {
 		log.Fatal(err)

--- a/cmd/notation/version.go
+++ b/cmd/notation/version.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/notaryproject/notation/internal/version"
+	"github.com/spf13/cobra"
+)
+
+func versionCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Show the notation version information",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			runVersion()
+		},
+	}
+	return cmd
+}
+
+func runVersion() {
+	fmt.Printf("Notation: Notary v2, A tool to sign, store, and verify artifacts.\n\n")
+
+	fmt.Printf("Version:     %s\n", version.GetVersion())
+	fmt.Printf("Go version:  %s\n", runtime.Version())
+
+	if version.GitCommit != "" {
+		fmt.Printf("Git commit:  %s\n", version.GitCommit)
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -5,7 +5,14 @@ var (
 	Version = "v0.11.0-alpha.4"
 
 	// BuildMetadata stores the build metadata.
+	//
+	// When execute `make build` command, it will be overridden by
+	// environment variable `BUILD_METADATA`. If commit tag was set,
+	// BuildMetadata will be empty.
 	BuildMetadata = "unreleased"
+
+	// GitCommit stores the git HEAD commit id
+	GitCommit = ""
 )
 
 // GetVersion returns the version string in SemVer 2.


### PR DESCRIPTION
- Added version command
- Removed --version flag
- Update Makefile to set GitCommit value by ldflags
- Update the BuildMetadata definition and allow user to override the value by environment variable

Please build it by`make build` command to include git commit information

Example

```
$ ./bin/notation version
Notation: Notary v2, A tool to sign, store, and verify artifacts.

Version:     v0.11.0-alpha.4
Go version:  go1.19
Git commit:  f747031135a6010d92c737ea611276b18f4188d7
```

If it does `not` build by `make build` command, the output will be

```
$ ./bin/notation version
Notation: Notary v2, A tool to sign, store, and verify artifacts.

Version:     v0.11.0-alpha.4
Go version:  go1.19
```
Signed-off-by: Junjie Gao <junjiegao@microsoft.com>