### PR TITLE
Fix demo docker pull step

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Notation is a CLI project to add signatures as standard items in the registry ec
 - Run a local instance of the [CNCF Distribution Registry][cncf-distribution], with [ORAS Artifacts][artifact-manifest] support:
   
   ```bash
-  docker run -d -p 5000:5000 ghcr.io/oras-project/registry:v1.0.0-rc2
+  docker run -d -p 5000:5000 ghcr.io/oras-project/registry:v1.0.0-rc.2
   ```
 
 - Build, push, sign, verify the `net-monitor` software:


### PR DESCRIPTION
The current README is broken when trying to use the demo steps


```
docker run -d -p 5000:5000 --platform linux/amd64 ghcr.io/oras-project/registry:v1.0.0-rc2
Unable to find image 'ghcr.io/oras-project/registry:v1.0.0-rc2' locally
docker: Error response from daemon: manifest unknown.
See 'docker run --help'.
```

There needs to be a dot in the tag.

```
crane ls ghcr.io/oras-project/registry
v0.0.1-alpha
v0.0.2-alpha
v0.0.3-alpha
latest
v1.0.0-rc
v1.0.0-rc.2
```

Tihis PR updates the README:

```
docker run -d -p 5000:5000 --platform linux/amd64 ghcr.io/oras-project/registry:v1.0.0-rc.2
Unable to find image 'ghcr.io/oras-project/registry:v1.0.0-rc.2' locally
v1.0.0-rc.2: Pulling from oras-project/registry
9621f1afde84: Pull complete
26bf68903cef: Pull complete
1991bda9245a: Pull complete
caa58183a89b: Pull complete
Digest: sha256:d3b10de113cd24404a0e35e6f6949854156a839deb7204fe8dfad9cc9723b1fb
Status: Downloaded newer image for ghcr.io/oras-project/registry:v1.0.0-rc.2
f11cb78ea5f1b3dff68caaae0a736e104df00ec5fe60a12a87f2058f30884455
```