### PR TITLE
Updates for v0.12.0-beta.1 release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.19
 require (
 	github.com/distribution/distribution/v3 v3.0.0-20220729163034-26163d82560f
 	github.com/docker/docker-credential-helpers v0.7.0
-	github.com/notaryproject/notation-core-go v0.1.0-alpha.4.0.20221031114150-3033a42e145c
-	github.com/notaryproject/notation-go v0.11.0-alpha.4.0.20221031125007-82ec47d56828
+	github.com/notaryproject/notation-core-go v0.2.0-beta.1
+	github.com/notaryproject/notation-go v0.12.0-beta.1
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799
 	github.com/oras-project/artifacts-spec v1.0.0-rc.2

--- a/go.sum
+++ b/go.sum
@@ -17,10 +17,10 @@ github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQA
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/notaryproject/notation-core-go v0.1.0-alpha.4.0.20221031114150-3033a42e145c h1:PEZKUf1Ud5PzWo9Vab46YQ5ls7VoCMYcjscxgdLUWIE=
-github.com/notaryproject/notation-core-go v0.1.0-alpha.4.0.20221031114150-3033a42e145c/go.mod h1:s8DZptmN1rZS0tBLTPt/w+d4o6eAcGWTYYJlXaJhQ4U=
-github.com/notaryproject/notation-go v0.11.0-alpha.4.0.20221031125007-82ec47d56828 h1:I8LaaGAtkqDNrlv/t47MA65wsm0zDm6q71ycFOo0how=
-github.com/notaryproject/notation-go v0.11.0-alpha.4.0.20221031125007-82ec47d56828/go.mod h1:T0kojLczQaSj16rHGyjqhfE8YUKTf15VsJVbFdbqbcM=
+github.com/notaryproject/notation-core-go v0.2.0-beta.1 h1:8tFxNycWCcPLti9ZYST5kjkX2wMXtX9YPvMjiBAQ1tA=
+github.com/notaryproject/notation-core-go v0.2.0-beta.1/go.mod h1:s8DZptmN1rZS0tBLTPt/w+d4o6eAcGWTYYJlXaJhQ4U=
+github.com/notaryproject/notation-go v0.12.0-beta.1 h1:LATXX7gt/Y7a+vqLVN4Ydmd6GfaPAFRdKgUEjaEYhUM=
+github.com/notaryproject/notation-go v0.12.0-beta.1/go.mod h1:sfOLDfdt7IXtzU9tyGwhsWDYY357+OWr1ktCfHfLdOk=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86 h1:Oumw+lPnO8qNLTY2mrqPJZMoGExLi/0h/DdikoLTXVU=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86/go.mod h1:aA4vdXRS8E1TG7pLZOz85InHi3BiPdErh8IpJN6E0x4=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 var (
 	// Version shows the current notation version, optionally with pre-release.
-	Version = "v0.11.0-alpha.4"
+	Version = "v0.12.0-beta.1"
 
 	// BuildMetadata stores the build metadata.
 	//


### PR DESCRIPTION
1. Updating notation-go and notation-core-go dependencies
2. Bumpup version to v0.12.0-beta.1