### PR TITLE
Improve error message when default signing key is not set

### DIFF
--- a/pkg/configutil/util.go
+++ b/pkg/configutil/util.go
@@ -34,16 +34,16 @@ func ResolveKey(name string) (config.KeySuite, error) {
 	if err != nil {
 		return config.KeySuite{}, err
 	}
-	
+
 	// if name is empty, look for default signing key
 	if name == "" {
 		name = signingKeys.Default
-	}
 
-	// if name is still empty, return error
-	if name == "" {
-		return config.KeySuite{}, errors.New("default signing key not set." +
-			" Please set default singing key or specify a key name")
+		// if name is still empty, return error
+		if name == "" {
+			return config.KeySuite{}, errors.New("default signing key not set." +
+				" Please set default singing key or specify a key name")
+		}
 	}
 	
 	idx := slices.Index(signingKeys.Keys, name)

--- a/pkg/configutil/util.go
+++ b/pkg/configutil/util.go
@@ -34,9 +34,18 @@ func ResolveKey(name string) (config.KeySuite, error) {
 	if err != nil {
 		return config.KeySuite{}, err
 	}
+	
+	// if name is empty, look for default signing key
 	if name == "" {
 		name = signingKeys.Default
 	}
+
+	// if name is still empty, return error
+	if name == "" {
+		return config.KeySuite{}, errors.New("default signing key not set." +
+			" Please set default singing key or specify a key name")
+	}
+	
 	idx := slices.Index(signingKeys.Keys, name)
 	if idx < 0 {
 		return config.KeySuite{}, ErrKeyNotFound


### PR DESCRIPTION
Fixes Issue: https://github.com/notaryproject/notation/issues/410

**Test output**
```
➜  notation git:(fix) ✗ ./notation key ls
NAME   KEY PATH   CERTIFICATE PATH   ID   PLUGIN NAME
➜  notation git:(fix) ✗ ./notation sign --plain-http $IMAGE
Error: default signing key not set. Please set default singing key or specify a key name
```