### PR TITLE
feat: delete old dev release

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -42,3 +42,11 @@ jobs:
           args: release -f ./.dev.goreleaser.yml --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Delete old dev release
+        uses: dev-drprasad/delete-older-releases@v0.2.0
+        with:
+          keep_latest: 1
+          delete_tag_pattern: ".dev."
+          delete_tags: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Added deleting old dev release logic after weekly release.
- Only keep the latest one dev release.

Tested on personal repo.

Resolves https://github.com/notaryproject/notation/issues/448
Signed-off-by: Junjie Gao <junjiegao@microsoft.com>