### PR TITLE
update: check if verification is skipped by trust policy

### DIFF
--- a/cmd/notation/verify.go
+++ b/cmd/notation/verify.go
@@ -104,6 +104,10 @@ func runVerify(command *cobra.Command, opts *verifyOpts) error {
 
 	// on success
 	outcome := outcomes[0]
+	if outcome.VerificationLevel.Name == "skip" {
+		fmt.Println("Trust policy is configured to skip signature verification for", ref.String())
+		return nil
+	}
 	// print out warning for any failed result with logged verification action
 	for _, result := range outcome.VerificationResults {
 		if result.Error != nil {

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/docker/docker-credential-helpers v0.7.0
-	github.com/notaryproject/notation-core-go v0.2.0-beta.1.0.20221123104522-9b5de089a023
-	github.com/notaryproject/notation-go v0.12.0-beta.1.0.20221205052202-e9545a718368
+	github.com/notaryproject/notation-core-go v0.2.0-beta.1.0.20221205183432-3022517b84c1
+	github.com/notaryproject/notation-go v0.12.0-beta.1.0.20221206051503-180ad994fe80
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc2
 	github.com/sirupsen/logrus v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -18,10 +18,10 @@ github.com/golang-jwt/jwt/v4 v4.4.3/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/notaryproject/notation-core-go v0.2.0-beta.1.0.20221123104522-9b5de089a023 h1:Z/2hxPJOjWfmgOPTNkGBDp/LVIEtizd9uJNQvjFE0Dc=
-github.com/notaryproject/notation-core-go v0.2.0-beta.1.0.20221123104522-9b5de089a023/go.mod h1:n8Gbvl9sKa00KptkKEL5XKUyMTIALe74QipKauE2rj4=
-github.com/notaryproject/notation-go v0.12.0-beta.1.0.20221205052202-e9545a718368 h1:OIrolpRY9PpFeWPtMPEOKNdYf+2TI13XY6gmmkJc+JY=
-github.com/notaryproject/notation-go v0.12.0-beta.1.0.20221205052202-e9545a718368/go.mod h1:2Xy40C9rJip3h9XPC6ei2HEEdUoZJ5KDC6mlX/FD0oQ=
+github.com/notaryproject/notation-core-go v0.2.0-beta.1.0.20221205183432-3022517b84c1 h1:PkR2MA3WYXq92G2EK+f1O7ya87vEL8hw5aqrdto8WoQ=
+github.com/notaryproject/notation-core-go v0.2.0-beta.1.0.20221205183432-3022517b84c1/go.mod h1:n8Gbvl9sKa00KptkKEL5XKUyMTIALe74QipKauE2rj4=
+github.com/notaryproject/notation-go v0.12.0-beta.1.0.20221206051503-180ad994fe80 h1:iOYUxdneLOe8cPdNRhHpQNoXmv2kFkYoAUhbOVx8tZs=
+github.com/notaryproject/notation-go v0.12.0-beta.1.0.20221206051503-180ad994fe80/go.mod h1:e8zTpWv9Vaz0u/rh3MMUOHD9YROvPpfMYTU83x3OK4I=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0-rc2 h1:2zx/Stx4Wc5pIPDvIxHXvXtQFW/7XWJGmnM7r3wg034=


### PR DESCRIPTION
Previous to this PR: if -v flag is not set, and the verification process is skipped, notation would still print out message stating "Successfully verified signature for xxx".

This PR tries to fix this, if verification is actually skipped, notation would print out "Trust policy is configured to skip signature verification for xxx".

Signed-off-by: Patrick Zheng <patrickzheng@microsoft.com>