### PR TITLE
Build: bump up versions for rc.1 release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/docker/docker-credential-helpers v0.7.0
-	github.com/notaryproject/notation-core-go v0.2.0-beta.1.0.20221205183432-3022517b84c1
-	github.com/notaryproject/notation-go v0.12.0-beta.1.0.20221206051503-180ad994fe80
+	github.com/notaryproject/notation-core-go v1.0.0-rc.1
+	github.com/notaryproject/notation-go v1.0.0-rc.1
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc2
 	github.com/sirupsen/logrus v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -18,10 +18,10 @@ github.com/golang-jwt/jwt/v4 v4.4.3/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/notaryproject/notation-core-go v0.2.0-beta.1.0.20221205183432-3022517b84c1 h1:PkR2MA3WYXq92G2EK+f1O7ya87vEL8hw5aqrdto8WoQ=
-github.com/notaryproject/notation-core-go v0.2.0-beta.1.0.20221205183432-3022517b84c1/go.mod h1:n8Gbvl9sKa00KptkKEL5XKUyMTIALe74QipKauE2rj4=
-github.com/notaryproject/notation-go v0.12.0-beta.1.0.20221206051503-180ad994fe80 h1:iOYUxdneLOe8cPdNRhHpQNoXmv2kFkYoAUhbOVx8tZs=
-github.com/notaryproject/notation-go v0.12.0-beta.1.0.20221206051503-180ad994fe80/go.mod h1:e8zTpWv9Vaz0u/rh3MMUOHD9YROvPpfMYTU83x3OK4I=
+github.com/notaryproject/notation-core-go v1.0.0-rc.1 h1:ACi0gr6mD1bzp9+gu3P0meJ/N6iWHlyM9zgtdnooNAA=
+github.com/notaryproject/notation-core-go v1.0.0-rc.1/go.mod h1:n8Gbvl9sKa00KptkKEL5XKUyMTIALe74QipKauE2rj4=
+github.com/notaryproject/notation-go v1.0.0-rc.1 h1:WobIGCUPcPUDCD2qGMCccTfLm2J5y1bsh4SFVsyMIaA=
+github.com/notaryproject/notation-go v1.0.0-rc.1/go.mod h1:xk4q0GXqGfEiy7WmyHi3Om3OM2dgHk0OHL6NIiJv5vA=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0-rc2 h1:2zx/Stx4Wc5pIPDvIxHXvXtQFW/7XWJGmnM7r3wg034=

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 var (
 	// Version shows the current notation version, optionally with pre-release.
-	Version = "v0.12.0-beta.1"
+	Version = "v1.0.0-rc.1"
 
 	// BuildMetadata stores the build metadata.
 	//


### PR DESCRIPTION
- update to `notation-core-go` `v1.0.0-rc.1`
- update to `notation-go` `v1.0.0-rc.1`
- update Version to `v1.0.0-rc.1`

Signed-off-by: Yi Zha <yizha1@microsoft.com>