### PR TITLE
update: refactored notation list command

### DIFF
--- a/cmd/notation/list.go
+++ b/cmd/notation/list.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	notationregistry "github.com/notaryproject/notation-go/registry"
+	"github.com/notaryproject/notation/internal/cmd"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/spf13/cobra"
@@ -13,6 +14,7 @@ import (
 )
 
 type listOpts struct {
+	cmd.LoggingFlagOpts
 	SecureFlagOpts
 	reference string
 }
@@ -34,40 +36,37 @@ func listCommand(opts *listOpts) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runList(cmd, opts)
+			return runList(cmd.Context(), opts)
 		},
 	}
-	opts.ApplyFlags(cmd.Flags())
+	opts.LoggingFlagOpts.ApplyFlags(cmd.Flags())
+	opts.SecureFlagOpts.ApplyFlags(cmd.Flags())
 	return cmd
 }
 
-func runList(command *cobra.Command, opts *listOpts) error {
+func runList(ctx context.Context, opts *listOpts) error {
+	// set log level
+	ctx = opts.LoggingFlagOpts.SetLoggerLevel(ctx)
+
 	// initialize
 	reference := opts.reference
-	sigRepo, err := getSignatureRepository(command.Context(), &opts.SecureFlagOpts, reference)
+	sigRepo, err := getSignatureRepository(ctx, &opts.SecureFlagOpts, reference)
 	if err != nil {
 		return err
 	}
-
-	// core process
-	manifestDesc, _, err := getManifestDescriptor(command.Context(), &opts.SecureFlagOpts, reference)
+	manifestDesc, ref, err := getManifestDescriptor(ctx, &opts.SecureFlagOpts, reference, sigRepo)
 	if err != nil {
 		return err
 	}
 
 	// print all signature manifest digests
-	return printSignatureManifestDigests(command.Context(), manifestDesc.Digest, sigRepo, reference)
+	return printSignatureManifestDigests(ctx, manifestDesc, sigRepo, ref)
 }
 
 // printSignatureManifestDigests returns the signature manifest digests of
 // the subject manifest.
-func printSignatureManifestDigests(ctx context.Context, manifestDigest digest.Digest, sigRepo notationregistry.Repository, reference string) error {
-	// prepare title
-	ref, err := registry.ParseReference(reference)
-	if err != nil {
-		return err
-	}
-	ref.Reference = manifestDigest.String()
+func printSignatureManifestDigests(ctx context.Context, manifestDesc ocispec.Descriptor, sigRepo notationregistry.Repository, ref registry.Reference) error {
+	ref.Reference = manifestDesc.Digest.String()
 	titlePrinted := false
 	printTitle := func() {
 		if !titlePrinted {
@@ -77,13 +76,8 @@ func printSignatureManifestDigests(ctx context.Context, manifestDigest digest.Di
 		}
 	}
 
-	// traverse referrers
-	artifactDescriptor, err := sigRepo.Resolve(ctx, reference)
-	if err != nil {
-		return err
-	}
 	var prevDigest digest.Digest
-	err = sigRepo.ListSignatures(ctx, artifactDescriptor, func(signatureManifests []ocispec.Descriptor) error {
+	err := sigRepo.ListSignatures(ctx, manifestDesc, func(signatureManifests []ocispec.Descriptor) error {
 		for _, sigManifestDesc := range signatureManifests {
 			if prevDigest != "" {
 				// check and print title

--- a/cmd/notation/manifest.go
+++ b/cmd/notation/manifest.go
@@ -31,6 +31,6 @@ func getManifestDescriptor(ctx context.Context, opts *SecureFlagOpts, reference 
 		return ocispec.Descriptor{}, registry.Reference{}, err
 	}
 
-	logger.Infof("Reference resolved to manifest descriptor: {MediaType:%v, Digest:%v, Size:%v}", manifestDesc.MediaType, manifestDesc.Digest, manifestDesc.Size)
+	logger.Infof("Reference %s resolved to manifest descriptor: %+v", ref.Reference, manifestDesc)
 	return manifestDesc, ref, nil
 }

--- a/cmd/notation/manifest.go
+++ b/cmd/notation/manifest.go
@@ -4,13 +4,17 @@ import (
 	"context"
 	"errors"
 
+	"github.com/notaryproject/notation-go/log"
+	notationregistry "github.com/notaryproject/notation-go/registry"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/registry"
 )
 
 // getManifestDescriptor returns target artifact manifest descriptor and
 // registry.Reference given user input reference.
-func getManifestDescriptor(ctx context.Context, opts *SecureFlagOpts, reference string) (ocispec.Descriptor, registry.Reference, error) {
+func getManifestDescriptor(ctx context.Context, opts *SecureFlagOpts, reference string, sigRepo notationregistry.Repository) (ocispec.Descriptor, registry.Reference, error) {
+	logger := log.GetLogger(ctx)
+
 	if reference == "" {
 		return ocispec.Descriptor{}, registry.Reference{}, errors.New("missing reference")
 	}
@@ -21,14 +25,12 @@ func getManifestDescriptor(ctx context.Context, opts *SecureFlagOpts, reference 
 	if ref.Reference == "" {
 		return ocispec.Descriptor{}, registry.Reference{}, errors.New("reference is missing digest or tag")
 	}
-	repo, err := getRepositoryClient(ctx, opts, ref)
+
+	manifestDesc, err := sigRepo.Resolve(ctx, ref.Reference)
 	if err != nil {
 		return ocispec.Descriptor{}, registry.Reference{}, err
 	}
 
-	manifestDesc, err := repo.Resolve(ctx, ref.Reference)
-	if err != nil {
-		return ocispec.Descriptor{}, registry.Reference{}, err
-	}
+	logger.Infof("Reference resolved to manifest descriptor: {MediaType:%v, Digest:%v, Size:%v}", manifestDesc.MediaType, manifestDesc.Digest, manifestDesc.Size)
 	return manifestDesc, ref, nil
 }

--- a/cmd/notation/verify.go
+++ b/cmd/notation/verify.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 
 	"github.com/notaryproject/notation-go"
-	"github.com/notaryproject/notation-go/log"
 	notationregistry "github.com/notaryproject/notation-go/registry"
 	"github.com/notaryproject/notation-go/verifier"
 	"github.com/notaryproject/notation-go/verifier/trustpolicy"
@@ -63,7 +62,6 @@ Example - Verify a signature on an OCI artifact identified by a tag  (Notation w
 func runVerify(command *cobra.Command, opts *verifyOpts) error {
 	// set log level
 	ctx := opts.LoggingFlagOpts.SetLoggerLevel(command.Context())
-	logger := log.GetLogger(ctx)
 
 	// initialize
 	reference := opts.reference
@@ -104,7 +102,7 @@ func runVerify(command *cobra.Command, opts *verifyOpts) error {
 	// core process
 	_, outcomes, err := notation.Verify(ctx, verifier, sigRepo, verifyOpts)
 	if err != nil {
-		logger.Error(err)
+		fmt.Println("Verification error:", err)
 	}
 	// write out on failure
 	if err != nil || len(outcomes) == 0 {

--- a/cmd/notation/verify.go
+++ b/cmd/notation/verify.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/notaryproject/notation-go"
+	"github.com/notaryproject/notation-go/log"
 	notationregistry "github.com/notaryproject/notation-go/registry"
 	"github.com/notaryproject/notation-go/verifier"
 	"github.com/notaryproject/notation-go/verifier/trustpolicy"
@@ -62,6 +63,7 @@ Example - Verify a signature on an OCI artifact identified by a tag  (Notation w
 func runVerify(command *cobra.Command, opts *verifyOpts) error {
 	// set log level
 	ctx := opts.LoggingFlagOpts.SetLoggerLevel(command.Context())
+	logger := log.GetLogger(ctx)
 
 	// initialize
 	reference := opts.reference
@@ -102,7 +104,7 @@ func runVerify(command *cobra.Command, opts *verifyOpts) error {
 	// core process
 	_, outcomes, err := notation.Verify(ctx, verifier, sigRepo, verifyOpts)
 	if err != nil {
-		fmt.Println("Verification error:", err)
+		logger.Error(err)
 	}
 	// write out on failure
 	if err != nil || len(outcomes) == 0 {


### PR DESCRIPTION
This PR refactors the `notation list` command reducing the number of calls to getSignatureRepository() and repo.Resolve().