### PR TITLE
chore: improve warning message when signing or verifying with tag

### DIFF
--- a/cmd/notation/sign.go
+++ b/cmd/notation/sign.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/notaryproject/notation-go"
@@ -100,8 +101,7 @@ func runSign(command *cobra.Command, cmdOpts *signOpts) error {
 
 func prepareSigningContent(ctx context.Context, opts *signOpts, sigRepo notationregistry.Repository) (notation.SignOptions, registry.Reference, error) {
 	ref, err := resolveReference(ctx, &opts.SecureFlagOpts, opts.reference, sigRepo, func(ref registry.Reference, manifestDesc ocispec.Descriptor) {
-		fmt.Printf("Warning: Always sign the artifact using digest(`@sha256:...`) rather than a tag(`:%s`) because tags are mutable and a tag reference can point to a different artifact than the one signed.\n", ref.Reference)
-		fmt.Printf("Resolved artifact tag `%s` to digest `%s` before signing.\n", ref.Reference, manifestDesc.Digest.String())
+		fmt.Fprintf(os.Stderr, "Warning: Always sign the artifact using digest(@sha256:...) rather than a tag(:%s) because tags are mutable and a tag reference can point to a different artifact than the one signed.\n", ref.Reference)
 	})
 	if err != nil {
 		return notation.SignOptions{}, registry.Reference{}, err

--- a/cmd/notation/verify.go
+++ b/cmd/notation/verify.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"os"
 	"reflect"
 
 	"github.com/notaryproject/notation-go"
@@ -72,8 +73,7 @@ func runVerify(command *cobra.Command, opts *verifyOpts) error {
 
 	// resolve the given reference and set the digest
 	ref, err := resolveReference(command.Context(), &opts.SecureFlagOpts, reference, sigRepo, func(ref registry.Reference, manifestDesc ocispec.Descriptor) {
-		fmt.Printf("Resolved artifact tag `%s` to digest `%s` before verification.\n", ref.Reference, manifestDesc.Digest.String())
-		fmt.Println("Warning: The resolved digest may not point to the same signed artifact, since tags are mutable.")
+		fmt.Fprintf(os.Stderr, "Warning: Always verify the artifact using digest(@sha256:...) rather than a tag(:%s) because resolved digest may not point to the same signed artifact, as tags are mutable.\n", ref.Reference)
 	})
 	if err != nil {
 		return err
@@ -119,7 +119,7 @@ func runVerify(command *cobra.Command, opts *verifyOpts) error {
 		if result.Error != nil {
 			// at this point, the verification action has to be logged and
 			// it's failed
-			fmt.Printf("Warning: %v was set to %q and failed with error: %v\n", result.Type, result.Action, result.Error)
+			fmt.Fprintf(os.Stderr, "Warning: %v was set to %q and failed with error: %v\n", result.Type, result.Action, result.Error)
 		}
 	}
 	if reflect.DeepEqual(outcome.VerificationLevel, trustpolicy.LevelSkip) {

--- a/specs/commandline/sign.md
+++ b/specs/commandline/sign.md
@@ -16,7 +16,6 @@ If a `tag` is used to identify the OCI artifact, the output message is as follow
 
 ```test
 Warning: Always sign the artifact using digest(`@sha256:...`) rather than a tag(`:<tag>`) because tags are mutable and a tag reference can point to a different artifact than the one signed.
-Resolved artifact tag `<tag>` to digest `<digest>` before signing.
 Successfully signed <registry>/<repository>@<digest>
 ```
 
@@ -74,7 +73,7 @@ For registries not listed in the page, users can consider using flag `--image-sp
 ### Sign an OCI artifact
 
 ```shell
-# Prerequisites: 
+# Prerequisites:
 # - A signing plugin is installed. See plugin documentation (https://github.com/notaryproject/notaryproject/blob/main/specs/plugin-extensibility.md) for more details.
 # - Configure the signing plugin as instructed by plugin vendor.
 
@@ -95,7 +94,7 @@ Successfully signed localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da
 ### Sign an OCI artifact using COSE signature format
 
 ```shell
-# Prerequisites: 
+# Prerequisites:
 # A default signing key is configured using CLI "notation key"
 
 # Use option "--signature-format" to set the signature format to COSE.
@@ -105,7 +104,7 @@ notation sign --signature-format cose <registry>/<repository>@<digest>
 ### Sign an OCI artifact stored in a registry using the default signing key
 
 ```shell
-# Prerequisites: 
+# Prerequisites:
 # A default signing key is configured using CLI "notation key"
 
 # Use a digest that uniquely and immutably identifies an OCI artifact.
@@ -115,7 +114,7 @@ notation sign <registry>/<repository>@<digest>
 ### Sign an OCI Artifact with user metadata
 
 ```shell
-# Prerequisites: 
+# Prerequisites:
 # A default signing key is configured using CLI "notation key"
 
 # sign an artifact stored in a registry and add user-metadata io.wabbit-networks.buildId=123 to the payload
@@ -144,7 +143,7 @@ notation sign --key <key_name> <registry>/<repository>@<digest>
 ### Sign an OCI artifact identified by a tag
 
 ```shell
-# Prerequisites: 
+# Prerequisites:
 # A default signing key is configured using CLI "notation key"
 
 # Use a tag to identify a container image
@@ -156,7 +155,6 @@ An example for a successful signing:
 ```console
 $ notation sign localhost:5000/net-monitor:v1
 Warning: Always sign the artifact using digest(`@sha256:...`) rather than a tag(`:v1`) because tags are mutable and a tag reference can point to a different artifact than the one signed.
-Resolved artifact tag `v1` to digest `sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9` before signing.
 Successfully signed localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
 ```
 
@@ -167,7 +165,7 @@ notation sign --image-spec v1.1-image <registry>/<repository>@<digest>
 ```
 
 [oci-artifact-manifest]: https://github.com/opencontainers/image-spec/blob/v1.1.0-rc2/artifact.md
-[oci-image-spec]: https://github.com/opencontainers/image-spec/blob/v1.1.0-rc2/spec.md 
+[oci-image-spec]: https://github.com/opencontainers/image-spec/blob/v1.1.0-rc2/spec.md
 [oci-backward-compatibility]: https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#backwards-compatibility
 [registry-support]: https://notaryproject.dev/docs/registrysupport/
 [oras-land]: https://oras.land/

--- a/specs/commandline/verify.md
+++ b/specs/commandline/verify.md
@@ -11,8 +11,7 @@ Successfully verified signature for <registry>/<repository>@<digest>
 Tags are mutable and a tag reference can point to a different artifact than that was signed referred by the same tag. If a `tag` is used to identify the OCI artifact, the output message is as follows:
 
 ```text
-Resolved artifact tag `<tag>` to digest `<digest>` before verification.
-Warning: The resolved digest may not point to the same signed artifact, since tags are mutable.
+Warning:  Always verify the artifact using digest(@sha256:...) rather than a tag(:v1) because resolved digest may not point to the same signed artifact, as tags are mutable.
 Successfully verified signature for <registry>/<repository>@<digest>
 ```
 
@@ -164,7 +163,6 @@ notation verify localhost:5000/net-monitor:v1
 An example of output messages for a successful verification:
 
 ```text
-Resolved artifact tag `v1` to digest `sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9` before verification.
-Warning: The resolved digest may not point to the same signed artifact, since tags are mutable.
+Warning:  Always verify the artifact using digest(@sha256:...) rather than a tag(:v1) because resolved digest may not point to the same signed artifact, as tags are mutable.
 Successfully verified signature for localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
 ```


### PR DESCRIPTION

### Old
➜  notation git:(main) ✗ ./notation sign $IMAGE
Warning: Always sign the artifact using digest(`@sha256:...`) rather than a tag(`:v1`) because tags are mutable and a tag reference can point to a different artifact than the one signed.
Resolved artifact tag `v1` to digest `sha256:36ca4d6834ed680362327811238b97c687e77c5cf4a04a74d0853d3c0c17e059` before signing.
Successfully signed localhost:6000/net-monitor@sha256:36ca4d6834ed680362327811238b97c687e77c5cf4a04a74d0853d3c0c17e059

➜  notation git:(main) ✗ ./notation verify $IMAGE
Resolved artifact tag `v1` to digest `sha256:36ca4d6834ed680362327811238b97c687e77c5cf4a04a74d0853d3c0c17e059` before verification.
Warning: The resolved digest may not point to the same signed artifact, since tags are mutable.
Successfully verified signature for localhost:6000/net-monitor@sha256:36ca4d6834ed680362327811238b97c687e77c5cf4a04a74d0853d3c0c17e059

### New

➜  notation git:(main) ✗ ./notation sign $IMAGE
Warning: Resolved artifact tag `v1` to digest `sha256:36ca4d6834ed680362327811238b97c687e77c5cf4a04a74d0853d3c0c17e059` before signing. Always sign the artifact using digest(`@sha256:...`) rather than a tag(`:v1`) because tags are mutable and a tag reference can point to a different artifact than the one signed.
Successfully signed localhost:6000/net-monitor@sha256:36ca4d6834ed680362327811238b97c687e77c5cf4a04a74d0853d3c0c17e059


➜  notation git:(main) ✗ ./notation verify $IMAGE
Warning: Resolved artifact tag `v1` to digest `sha256:36ca4d6834ed680362327811238b97c687e77c5cf4a04a74d0853d3c0c17e059` before verification. The resolved digest may not point to the same signed artifact, since tags are mutable.
Successfully verified signature for localhost:6000/net-monitor@sha256:36ca4d6834ed680362327811238b97c687e77c5cf4a04a74d0853d3c0c17e059