### PR TITLE
doc: update notation sign and verify spec for metadata

### DIFF
--- a/specs/commandline/sign.md
+++ b/specs/commandline/sign.md
@@ -40,11 +40,6 @@ Flags:
   -um, --user-metadata strings    {key}={value} pairs that are added to the signature
 ```
 
-### User Metadata Restrictions
-- `notation sign` must fail if metadata keys or values are not strings
-- `notation sign` must fail if duplicate metadata keys are provided
-- `notation sign` must fail if metadata keys conflict with reserved Notary or OCI keys
-
 ## Usage
 
 ### Sign an OCI artifact

--- a/specs/commandline/sign.md
+++ b/specs/commandline/sign.md
@@ -29,15 +29,21 @@ Usage:
   notation sign [flags] <reference>
 
 Flags:
-  -e, --expiry duration          optional expiry that provides a "best by use" time for the artifact. The duration is specified in minutes(m) and/or hours(h). For example: 12h, 30m, 3h20m
-  -h, --help                     help for sign
-  -k, --key string               signing key name, for a key previously added to notation's key list.
-  -p, --password string          password for registry operations (default to $NOTATION_PASSWORD if not specified)
-      --plain-http               registry access via plain HTTP
-      --plugin-config strings    {key}={value} pairs that are passed as it is to a plugin, refer plugin's documentation to set appropriate values
-      --signature-format string  signature envelope format, options: 'jws', 'cose' (default "jws")
-  -u, --username string          username for registry operations (default to $NOTATION_USERNAME if not specified)
+  -e,  --expiry duration          optional expiry that provides a "best by use" time for the artifact. The duration is specified in minutes(m) and/or hours(h). For example: 12h, 30m, 3h20m
+  -h,  --help                     help for sign
+  -k,  --key string               signing key name, for a key previously added to notation's key list.
+  -p,  --password string          password for registry operations (default to $NOTATION_PASSWORD if not specified)
+       --plain-http               registry access via plain HTTP
+       --plugin-config strings    {key}={value} pairs that are passed as it is to a plugin, refer plugin's documentation to set appropriate values
+       --signature-format string  signature envelope format, options: 'jws', 'cose' (default "jws")
+  -u,  --username string          username for registry operations (default to $NOTATION_USERNAME if not specified)
+  -um, --user-metadata strings    {key}={value} pairs that are added to the signature
 ```
+
+### User Metadata Restrictions
+- `notation sign` must fail if metadata keys or values are not strings
+- `notation sign` must fail if duplicate metadata keys are provided
+- `notation sign` must fail if metadata keys conflict with reserved Notary or OCI keys
 
 ## Usage
 
@@ -80,6 +86,16 @@ notation sign --signature-format cose <registry>/<repository>@<digest>
 
 # Use a digest that uniquely and immutably identifies an OCI artifact.
 notation sign <registry>/<repository>@<digest>
+```
+
+### Sign an OCI Artifact with user metadata
+
+```shell
+# Prerequisites: 
+# A default signing key is configured using CLI "notation key"
+
+# sign an artifact stored in a registry and add user-metadata io.wabbit-networks.buildId=123 to the payload
+notation sign <registry>/<repository>@<digest> --user-metadata io.wabbit-networks.buildId=123
 ```
 
 ### Sign an OCI artifact stored in a registry and specify the signature expiry duration, for example 24 hours

--- a/specs/commandline/sign.md
+++ b/specs/commandline/sign.md
@@ -37,7 +37,7 @@ Flags:
        --plugin-config strings    {key}={value} pairs that are passed as it is to a plugin, refer plugin's documentation to set appropriate values
        --signature-format string  signature envelope format, options: 'jws', 'cose' (default "jws")
   -u,  --username string          username for registry operations (default to $NOTATION_USERNAME if not specified)
-  -um, --user-metadata strings    {key}={value} pairs that are added to the signature
+  -m,  --user-metadata strings    {key}={value} pairs that are added to the signature payload
 ```
 
 ## Usage
@@ -90,7 +90,10 @@ notation sign <registry>/<repository>@<digest>
 # A default signing key is configured using CLI "notation key"
 
 # sign an artifact stored in a registry and add user-metadata io.wabbit-networks.buildId=123 to the payload
-notation sign <registry>/<repository>@<digest> --user-metadata io.wabbit-networks.buildId=123
+notation sign --user-metadata io.wabbit-networks.buildId=123 <registry>/<repository>@<digest>
+
+# sign an artifact stored in a registry and add user-metadata io.wabbit-networks.buildId=123 and io.wabbit-networks.buildTime=1672944615 to the payload
+notation sign --user-metadata io.wabbit-networks.buildId=123 --user-metadata io.wabbit-networks.buildTime=1672944615 <registry>/<repository>@<digest>
 ```
 
 ### Sign an OCI artifact stored in a registry and specify the signature expiry duration, for example 24 hours

--- a/specs/commandline/verify.md
+++ b/specs/commandline/verify.md
@@ -21,8 +21,10 @@ The signed descriptor may have user defined metadata attached. If the signature 
 ```text
 Successfully verified signature for <registry>/<repository>@<digest>
 
-User Metadata:
-- <key> : <value>
+The artifact is signed with the following user metadata.
+
+KEY    VALUE
+<key>  <value>
 ```
 
 ## Outline
@@ -35,12 +37,11 @@ Usage:
 
 Flags:
   -h,  --help                    help for verify
-  -o,  --output string           output format, options: 'plaintext', 'json' (default: 'plaintext')
   -p,  --password string         password for registry operations (default to $NOTATION_PASSWORD if not specified)
        --plain-http              registry access via plain HTTP
        --plugin-config strings   {key}={value} pairs that are passed as it is to a plugin, if the verification is associated with a verification plugin, refer plugin documentation to set appropriate values
   -u,  --username string         username for registry operations (default to $NOTATION_USERNAME if not specified)
-  -um, --user-metadata strings   user defined {key}={value} pairs that must be present in the signature for successful verification if provided
+  -m,  --user-metadata strings   user defined {key}={value} pairs that must be present in the signature for successful verification if provided
 ```
 
 ## Usage
@@ -129,8 +130,8 @@ Successfully verified signature for localhost:5000/net-monitor@sha256:b94d27b993
 Use the `--user-metadata` flag to verify that provided key-value pairs are present in the payload of the valid signature.
 
 ```shell
-# Verify signatures on the supplied OCI artifact identified by the digest and verify that io.wabbit-networks.data=foo is present in the signed payload
-notation verify localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9 --user-metadata io.wabbit-networks.data=foo
+# Verify signatures on the supplied OCI artifact identified by the digest and verify that io.wabbit-networks.buildId=123 is present in the signed payload
+notation verify --user-metadata io.wabbit-networks.buildId=123 localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
 ```
 
 An example of output messages for a successful verification:
@@ -138,24 +139,37 @@ An example of output messages for a successful verification:
 ```text
 Successfully verified signature for localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
 
-User Metadata:
-- io.wabbit-networks.data : foo
+The artifact is signed with the following user metadata.
+
+KEY                         VALUE
+io.wabbit-networks.buildId  123
 ```
 
-### Verify signatures on an OCI artifact and format output as json
-
-Use the `--output` flag to configure the format of signature information returned on successful verification.
-
-```shell
-
-# Verify signatures on the supplied OCI artifact identified by the digest and output result as json
-notation verify localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9 --output json
-```
-
-An example of output messages for a successful verification:
+An example of output messages for an unsuccessful verification:
 
 ```text
-{"reference":"localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9","outcome":"Success","signatures":[{"digest":"sha256:73c803930ea3ba1e54bc25c2bdc53edd0284c62ed651fe7b00369da519a3c333","userMetadata":{"io.wabbit-networks.data":"foo"}}]}
+Error: signature verification failed for all the signatures associated with localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+```
+
+An example of output messages for an unsuccessful verification with verbose logging enabled:
+
+```text
+INFO Checking whether signature verification should be skipped or not
+INFO Check over. Trust policy is not configured to skip signature verification
+INFO Processing signature with digest: sha256:dbb22c0686b714ccbb53e4579771ee0f9ab9d37cd77cadb767549322742979f3
+INFO User Metadata flag is present. Checking signature metadata for specified values.
+Error: signature verification failed for all the signatures associated with localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+```
+
+An example of output messages for an unsuccessful verification with debug logging enabled:
+
+```text
+...
+INFO User Metadata flag is present. Checking signature metadata for specified values.
+DEBU[2023-01-05T11:35:07-08:00] Verifying that metadata { "io.wabbit-networks.buildId":"123" } is present in signature metadata.
+DEBU[2023-01-05T11:35:07-08:00] Signature metadata: { "io.wabbit-networks.buildId":"321" }
+DEBU[2023-01-05T11:35:07-08:00] Error: specified metadata is not present in the signature.
+Error: signature verification failed for all the signatures associated with localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
 ```
 
 ### Verify signatures on an OCI artifact identified by a tag

--- a/specs/commandline/verify.md
+++ b/specs/commandline/verify.md
@@ -40,7 +40,7 @@ Flags:
        --plain-http              registry access via plain HTTP
        --plugin-config strings   {key}={value} pairs that are passed as it is to a plugin, if the verification is associated with a verification plugin, refer plugin documentation to set appropriate values
   -u,  --username string         username for registry operations (default to $NOTATION_USERNAME if not specified)
-  -um, --user-metadata strings   {key}={value} pairs that must be present in the signature for successful verification if provided
+  -um, --user-metadata strings   user defined {key}={value} pairs that must be present in the signature for successful verification if provided
 ```
 
 ## Usage
@@ -124,40 +124,18 @@ An example of output messages for a successful verification:
 Successfully verified signature for localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
 ```
 
-### Verify signatures on an OCI artifact identified by a tag
-
-A tag is resolved to a digest first before verification.
-
-```shell
-# Prerequisites: Signatures are stored in a registry referencing the signed OCI artifact
-
-# Verify signatures on an OCI artifact identified by the tag
-notation verify localhost:5000/net-monitor:v1
-```
-
-An example of output messages for a successful verification:
-
-```text
-Resolved artifact tag `v1` to digest `sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9` before verification.
-Warning: The resolved digest may not point to the same signed artifact, since tags are mutable.
-Successfully verified signature for localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
-```
-
 ### Verify signatures on an OCI artifact with user metadata
 
 Use the `--user-metadata` flag to verify that provided key-value pairs are present in the payload of the valid signature.
 
 ```shell
-# Prerequisites: Signatures are stored in a registry referencing the signed OCI artifact
-# Verify signatures on an OCI artifact identified by the tag and verify that io.wabbit-networks.data=foo is present in the signed payload
-notation verify localhost:5000/net-monitor:v1 --user-metadata io.wabbit-networks.data=foo
+# Verify signatures on the supplied OCI artifact identified by the digest and verify that io.wabbit-networks.data=foo is present in the signed payload
+notation verify localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9 --user-metadata io.wabbit-networks.data=foo
 ```
 
 An example of output messages for a successful verification:
 
 ```text
-Resolved artifact tag `v1` to digest `sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9` before verification.
-Warning: The resolved digest may not point to the same signed artifact, since tags are mutable.
 Successfully verified signature for localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
 
 User Metadata:
@@ -169,9 +147,25 @@ User Metadata:
 Use the `--output` flag to configure the format of signature information returned on successful verification.
 
 ```shell
+
+# Verify signatures on the supplied OCI artifact identified by the digest and output result as json
+notation verify localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9 --output json
+```
+
+An example of output messages for a successful verification:
+
+```text
+{"reference":"localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9","outcome":"Success","signatures":[{"digest":"sha256:73c803930ea3ba1e54bc25c2bdc53edd0284c62ed651fe7b00369da519a3c333","userMetadata":{"io.wabbit-networks.data":"foo"}}]}
+```
+
+### Verify signatures on an OCI artifact identified by a tag
+
+A tag is resolved to a digest first before verification.
+
+```shell
 # Prerequisites: Signatures are stored in a registry referencing the signed OCI artifact
 # Verify signatures on an OCI artifact identified by the tag
-notation verify localhost:5000/net-monitor:v1 --output json
+notation verify localhost:5000/net-monitor:v1
 ```
 
 An example of output messages for a successful verification:
@@ -179,5 +173,5 @@ An example of output messages for a successful verification:
 ```text
 Resolved artifact tag `v1` to digest `sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9` before verification.
 Warning: The resolved digest may not point to the same signed artifact, since tags are mutable.
-{"reference":"localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9","outcome":"Success","signatures":[{"digest":"sha256:73c803930ea3ba1e54bc25c2bdc53edd0284c62ed651fe7b00369da519a3c333","userMetadata":{"io.wabbit-networks.data":"foo"}}]}
+Successfully verified signature for localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
 ```

--- a/specs/commandline/verify.md
+++ b/specs/commandline/verify.md
@@ -16,6 +16,15 @@ Warning: The resolved digest may not point to the same signed artifact, since ta
 Successfully verified signature for <registry>/<repository>@<digest>
 ```
 
+The signed descriptor may have user defined metadata attached. If the signature for the OCI artifact contains any metadata, the output message is as follows:
+
+```text
+Successfully verified signature for <registry>/<repository>@<digest>
+
+User Metadata:
+- <key> : <value>
+```
+
 ## Outline
 
 ```text
@@ -25,11 +34,13 @@ Usage:
   notation verify [flags] <reference>
 
 Flags:
-  -h, --help                    help for verify
-  -p, --password string         password for registry operations (default to $NOTATION_PASSWORD if not specified)
-      --plain-http              registry access via plain HTTP
-      --plugin-config strings   {key}={value} pairs that are passed as it is to a plugin, if the verification is associated with a verification plugin, refer plugin documentation to set appropriate values
-  -u, --username string         username for registry operations (default to $NOTATION_USERNAME if not specified)
+  -h,  --help                    help for verify
+  -o,  --output string           output format, options: 'plaintext', 'json' (default: 'plaintext')
+  -p,  --password string         password for registry operations (default to $NOTATION_PASSWORD if not specified)
+       --plain-http              registry access via plain HTTP
+       --plugin-config strings   {key}={value} pairs that are passed as it is to a plugin, if the verification is associated with a verification plugin, refer plugin documentation to set appropriate values
+  -u,  --username string         username for registry operations (default to $NOTATION_USERNAME if not specified)
+  -um, --user-metadata strings   {key}={value} pairs that must be present in the signature for successful verification if provided
 ```
 
 ## Usage
@@ -130,4 +141,43 @@ An example of output messages for a successful verification:
 Resolved artifact tag `v1` to digest `sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9` before verification.
 Warning: The resolved digest may not point to the same signed artifact, since tags are mutable.
 Successfully verified signature for localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+```
+
+### Verify signatures on an OCI artifact with user metadata
+
+Use the `--user-metadata` flag to verify that provided key-value pairs are present in the payload of the valid signature.
+
+```shell
+# Prerequisites: Signatures are stored in a registry referencing the signed OCI artifact
+# Verify signatures on an OCI artifact identified by the tag and verify that io.wabbit-networks.data=foo is present in the signed payload
+notation verify localhost:5000/net-monitor:v1 --user-metadata io.wabbit-networks.data=foo
+```
+
+An example of output messages for a successful verification:
+
+```text
+Resolved artifact tag `v1` to digest `sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9` before verification.
+Warning: The resolved digest may not point to the same signed artifact, since tags are mutable.
+Successfully verified signature for localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+
+User Metadata:
+- io.wabbit-networks.data : foo
+```
+
+### Verify signatures on an OCI artifact and format output as json
+
+Use the `--output` flag to configure the format of signature information returned on successful verification.
+
+```shell
+# Prerequisites: Signatures are stored in a registry referencing the signed OCI artifact
+# Verify signatures on an OCI artifact identified by the tag
+notation verify localhost:5000/net-monitor:v1 --output json
+```
+
+An example of output messages for a successful verification:
+
+```text
+Resolved artifact tag `v1` to digest `sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9` before verification.
+Warning: The resolved digest may not point to the same signed artifact, since tags are mutable.
+{"reference":"localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9","outcome":"Success","signatures":[{"digest":"sha256:73c803930ea3ba1e54bc25c2bdc53edd0284c62ed651fe7b00369da519a3c333","userMetadata":{"io.wabbit-networks.data":"foo"}}]}
 ```

--- a/specs/commandline/verify.md
+++ b/specs/commandline/verify.md
@@ -148,6 +148,7 @@ io.wabbit-networks.buildId  123
 An example of output messages for an unsuccessful verification:
 
 ```text
+Error: unable to find specified metadata in any signatures associated with localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
 Error: signature verification failed for all the signatures associated with localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
 ```
 
@@ -158,6 +159,7 @@ INFO Checking whether signature verification should be skipped or not
 INFO Check over. Trust policy is not configured to skip signature verification
 INFO Processing signature with digest: sha256:dbb22c0686b714ccbb53e4579771ee0f9ab9d37cd77cadb767549322742979f3
 INFO User Metadata flag is present. Checking signature metadata for specified values.
+Error: unable to find specified metadata in any signatures associated with localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
 Error: signature verification failed for all the signatures associated with localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
 ```
 
@@ -169,6 +171,7 @@ INFO User Metadata flag is present. Checking signature metadata for specified va
 DEBU[2023-01-05T11:35:07-08:00] Verifying that metadata { "io.wabbit-networks.buildId":"123" } is present in signature metadata.
 DEBU[2023-01-05T11:35:07-08:00] Signature metadata: { "io.wabbit-networks.buildId":"321" }
 DEBU[2023-01-05T11:35:07-08:00] Error: specified metadata is not present in the signature.
+Error: unable to find specified metadata in any signatures associated with localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
 Error: signature verification failed for all the signatures associated with localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
 ```
 

--- a/specs/commandline/verify.md
+++ b/specs/commandline/verify.md
@@ -16,12 +16,12 @@ Warning: The resolved digest may not point to the same signed artifact, since ta
 Successfully verified signature for <registry>/<repository>@<digest>
 ```
 
-The signed descriptor may have user defined metadata attached. If the signature for the OCI artifact contains any metadata, the output message is as follows:
+A signature can have user defined metadata. If the signature for the OCI artifact contains any metadata, the output message is as follows:
 
 ```text
 Successfully verified signature for <registry>/<repository>@<digest>
 
-The artifact is signed with the following user metadata.
+The artifact was signed with the following user metadata.
 
 KEY    VALUE
 <key>  <value>
@@ -148,31 +148,7 @@ io.wabbit-networks.buildId  123
 An example of output messages for an unsuccessful verification:
 
 ```text
-Error: unable to find specified metadata in any signatures associated with localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
-Error: signature verification failed for all the signatures associated with localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
-```
-
-An example of output messages for an unsuccessful verification with verbose logging enabled:
-
-```text
-INFO Checking whether signature verification should be skipped or not
-INFO Check over. Trust policy is not configured to skip signature verification
-INFO Processing signature with digest: sha256:dbb22c0686b714ccbb53e4579771ee0f9ab9d37cd77cadb767549322742979f3
-INFO User Metadata flag is present. Checking signature metadata for specified values.
-Error: unable to find specified metadata in any signatures associated with localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
-Error: signature verification failed for all the signatures associated with localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
-```
-
-An example of output messages for an unsuccessful verification with debug logging enabled:
-
-```text
-...
-INFO User Metadata flag is present. Checking signature metadata for specified values.
-DEBU[2023-01-05T11:35:07-08:00] Verifying that metadata { "io.wabbit-networks.buildId":"123" } is present in signature metadata.
-DEBU[2023-01-05T11:35:07-08:00] Signature metadata: { "io.wabbit-networks.buildId":"321" }
-DEBU[2023-01-05T11:35:07-08:00] Error: specified metadata is not present in the signature.
-Error: unable to find specified metadata in any signatures associated with localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
-Error: signature verification failed for all the signatures associated with localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+Error: signature verification failed: unable to find specified metadata in any signatures
 ```
 
 ### Verify signatures on an OCI artifact identified by a tag


### PR DESCRIPTION
Spec update to support https://github.com/notaryproject/roadmap/issues/67

`notation sign`: 
- user will be able to specify additional key value pairs with the `--user-metadata` flag (`-um` short) that will be signed as part of the payload.

`notation verify`:
- user will be able to specify additional key value pairs with the `--user-metadata` flag (`-um` short) that must be present in the signature to pass verification.
- user will be able to configure output format as either plaintext (default) or json with the `--output` flag (`-o` short)