### PR TITLE
doc: notation Inspect Command line Spec

### DIFF
--- a/specs/commandline/inspect.md
+++ b/specs/commandline/inspect.md
@@ -9,14 +9,14 @@ Upon successful execution, both the digest of the signed artifact and the digest
 ```shell
 <registry>/<repository>@<digest>
 └── application/vnd.cncf.notary.signature
-    ├── <digest_of_signature_manifest>
-    |   ├── <signature algorithm>
-    |   ├── <signed attributes>
-    |   ├── <user defined attributes>
-    |   ├── <unsigned attributes>
-    |   ├── <certificates>
-    |   └── <signed artifact>
-    └── <digest_of_signature_manifest>
+    ├── <digest of signature manifest>
+    │   ├── <signature algorithm>
+    │   ├── <signed attributes>
+    │   ├── <user defined attributes>
+    │   ├── <unsigned attributes>
+    │   ├── <certificates>
+    │   └── <signed artifact>
+    └── <digest of signature manifest>
         ├── <signature algorithm>
         ├── <signed attributes>
         ├── <unsigned attributes>
@@ -61,59 +61,59 @@ An example output:
 localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac4efe37a5380ee9088f7ace2efcde9
 └── application/vnd.cncf.notary.signature
     ├── sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    |   ├── signature algorithm: RSASSA-PSS-SHA-256
-    |   ├── signed attributes
-    |   |   ├── content type: application/vnd.cncf.notary.payload.v1+json
-    |   |   ├── signing scheme: notary.default.x509
-    |   |   ├── signing time: Fri Jun 23 22:04:01 2023
-    |   |   ├── expiry: Sat Jun 29 22:04:01 2024
-    |   |   └── io.cncf.notary.verificationPlugin: com.example.nv2plugin    //extended attributes to support plugins
-    |   ├── user defined attributes
-    |   |   └── io.wabbit-networks.buildId: 123                             //user defined payload annotations
-    |   ├── unsigned attributes
-    |   |   ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)> //TSA response (time stamp token)
-    |   |   └── io.cncf.notary.signingAgent: notation/1.0.0                 //client that produced the signature
-    |   ├── certificates
-    |   |   ├── SHA1 fingerprint: E8C15B4C98AD91E051EE5AF5F524A8729050B2A
-    |   |   |   ├── issued to: wabbit-com Software
-    |   |   |   ├── issued by: wabbit-com Software Root Certificate Authority
-    |   |   |   └── expiry: Sun Jul 06 20:50:17 2025
-    |   |   ├── SHA1 fingerprint: 5DCC2147712B3C555B1C96CFCC00215403TF044D
-    |   |   |   ├── issued to: wabbit-com Software Code Signing PCA
-    |   |   |   ├── issued by: wabbit-com Software Root Certificate Authority
-    |   |   |   └── expiry: Sun Jul 06 20:50:17 2025
-    |   |   └── SHA1 fingerprint: 1GYA3107712B3C886B1C96AAEC89984914DC0A5A
-    |   |       ├── issued to: wabbit-com Software Root Certificate Authority
-    |   |       ├── issued by: wabbit-com Software Root Certificate Authority
-    |   |       └── expiry: Sat Jun 23 22:04:01 2035
-    |   └── signed artifact                                                 //descriptor of the signed target artifact
-    |       ├── media type: application/vnd.oci.image.manifest.v1+json
-    |       ├── digest: sha256:b94d27b9934d3e08a52e52d7da7dabfac48437a5380ee9088f7ace2efcde9
-    |       └── size: 16724
+    │   ├── signature algorithm: RSASSA-PSS-SHA-256
+    │   ├── signed attributes
+    │   │   ├── content type: application/vnd.cncf.notary.payload.v1+json
+    │   │   ├── signing scheme: notary.default.x509
+    │   │   ├── signing time: Fri Jun 23 22:04:01 2023
+    │   │   ├── expiry: Sat Jun 29 22:04:01 2024
+    │   │   └── io.cncf.notary.verificationPlugin: com.example.nv2plugin    //extended attributes 
+    │   ├── user defined attributes
+    │   │   └── io.wabbit-networks.buildId: 123                             //user defined metadata
+    │   ├── unsigned attributes
+    │   │   ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)> //TSA response 
+    │   │   └── io.cncf.notary.signingAgent: notation/1.0.0                 //client version
+    │   ├── certificates
+    │   │   ├── SHA1 fingerprint: E8C15B4C98AD91E051EE5AF5F524A8729050B2A
+    │   │   │   ├── issued to: wabbit-com Software
+    │   │   │   ├── issued by: wabbit-com Software Root Certificate Authority
+    │   │   │   └── expiry: Sun Jul 06 20:50:17 2025
+    │   │   ├── SHA1 fingerprint: 5DCC2147712B3C555B1C96CFCC00215403TF044D
+    │   │   │   ├── issued to: wabbit-com Software Code Signing PCA
+    │   │   │   ├── issued by: wabbit-com Software Root Certificate Authority
+    │   │   │   └── expiry: Sun Jul 06 20:50:17 2025
+    │   │   └── SHA1 fingerprint: 1GYA3107712B3C886B1C96AAEC89984914DC0A5A
+    │   │       ├── issued to: wabbit-com Software Root Certificate Authority
+    │   │       ├── issued by: wabbit-com Software Root Certificate Authority
+    │   │       └── expiry: Sat Jun 23 22:04:01 2035
+    │   └── signed artifact                                                 //descriptor of signed artifact
+    │       ├── media type: application/vnd.oci.image.manifest.v1+json
+    │       ├── digest: sha256:b94d27b9934d3e08a52e52d7da7dabfac48437a5380ee9088f7ace2efcde9
+    │       └── size: 16724
     └── sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
         ├── signature algorithm: RSASSA-PSS-SHA-256
         ├── signed attributes
-        |   ├── content type: application/vnd.cncf.notary.payload.v1+json
-        |   ├── signing scheme: notary.signingAuthority.x509
-        |   ├── signing time: Fri Jun 23 22:04:01 2023
-        |   ├── expiry: Sat Jun 29 22:04:01 2024
-        |   └── io.cncf.notary.verificationPlugin: com.example.nv2plugin                  
+        │   ├── content type: application/vnd.cncf.notary.payload.v1+json
+        │   ├── signing scheme: notary.signingAuthority.x509
+        │   ├── signing time: Fri Jun 23 22:04:01 2023
+        │   ├── expiry: Sat Jun 29 22:04:01 2024
+        │   └── io.cncf.notary.verificationPlugin: com.example.nv2plugin                  
         ├── unsigned attributes
-        |   ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)>
-        |   └── io.cncf.notary.signingAgent: notation/1.0.0                  
+        │   ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)>
+        │   └── io.cncf.notary.signingAgent: notation/1.0.0                  
         ├── certificates
-        |   ├── SHA1 fingerprint: 68C15B4C98AD91E051EE5AF5F524A8729040B1D
-        |   |   ├── issued to: wabbit-com Software
-        |   |   ├── issued by: wabbit-com Software Root Certificate Authority
-        |   |   └── expiry: Sun Jul 06 20:50:17 2025
-        |   ├── SHA1 fingerprint: 4ACC2147712B3C555B1C96CFCC00215403TE011C
-        |   |   ├── issued to: wabbit-com Software Code Signing PCA 2010
-        |   |   ├── issued by: wabbit-com Software Root Certificate Authority
-        |   |   └── expiry: Sun Jul 06 20:50:17 2025
-        |   └── SHA1 fingerprint: A4YA1205512B3C886B1C96AAEC89984914DC012A
-        |       ├── issued to: wabbit-com Software Root Certificate Authority
-        |       ├── issued by: wabbit-com Software Root Certificate Authority
-        |       └── expiry: Sat Jun 23 22:04:01 2035
+        │   ├── SHA1 fingerprint: 68C15B4C98AD91E051EE5AF5F524A8729040B1D
+        │   │   ├── issued to: wabbit-com Software
+        │   │   ├── issued by: wabbit-com Software Root Certificate Authority
+        │   │   └── expiry: Sun Jul 06 20:50:17 2025
+        │   ├── SHA1 fingerprint: 4ACC2147712B3C555B1C96CFCC00215403TE011C
+        │   │   ├── issued to: wabbit-com Software Code Signing PCA 2010
+        │   │   ├── issued by: wabbit-com Software Root Certificate Authority
+        │   │   └── expiry: Sun Jul 06 20:50:17 2025
+        │   └── SHA1 fingerprint: A4YA1205512B3C886B1C96AAEC89984914DC012A
+        │       ├── issued to: wabbit-com Software Root Certificate Authority
+        │       ├── issued by: wabbit-com Software Root Certificate Authority
+        │       └── expiry: Sat Jun 23 22:04:01 2035
         └── signed artifact 
             ├── media type: application/vnd.oci.image.manifest.v1+json
             ├── digest: sha256:b94d27b9934d3e08a52e52d7da7fac484efe37a5380ee9088f7ace2efcde9
@@ -139,59 +139,59 @@ Warning: The resolved digest may not point to the same signed artifact, since ta
 localhost:5000/net-monitor@sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380ee9088f7ace2eaab9
 └── application/vnd.cncf.notary.signature
     ├── sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    |   ├── signature algorithm: RSASSA-PSS-SHA-256
-    |   ├── signed attributes
-    |   |   ├── content type: application/vnd.cncf.notary.payload.v1+json
-    |   |   ├── signing scheme: notary.default.x509
-    |   |   ├── signing time: Fri Jun 23 22:04:01 2023
-    |   |   ├── expiry: Sat Jun 29 22:04:01 2024
-    |   |   └── io.cncf.notary.verificationPlugin: com.example.nv2plugin
-    |   ├── user defined attributes
-    |   |   └── io.wabbit-networks.buildId: 123
-    |   ├── unsigned attributes
-    |   |   ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)>
-    |   |   └── io.cncf.notary.signingAgent: notation/1.0.0
-    |   ├── certificates
-    |   |   ├── SHA1 fingerprint: E8C15B4C98AD91E051EE5AF5F524A8729050B2A
-    |   |   |   ├── issued to: wabbit-com Software
-    |   |   |   ├── issued by: wabbit-com Software Root Certificate Authority
-    |   |   |   └── expiry: Sun Jul 06 20:50:17 2025
-    |   |   ├── SHA1 fingerprint: 5DCC2147712B3C555B1C96CFCC00215403TF044D
-    |   |   |   ├── issued to: wabbit-com Software Code Signing PCA
-    |   |   |   ├── issued by: wabbit-com Software Root Certificate Authority
-    |   |   |   └── expiry: Sun Jul 06 20:50:17 2025
-    |   |   └── SHA1 fingerprint: 1GYA3107712B3C886B1C96AAEC89984914DC0A5A
-    |   |       ├── issued to: wabbit-com Software Root Certificate Authority
-    |   |       ├── issued by: wabbit-com Software Root Certificate Authority
-    |   |       └── expiry: Sat Jun 23 22:04:01 2035
-    |   └── signed artifact 
-    |       ├── media type: application/vnd.oci.image.manifest.v1+json
-    |       ├── digest: sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380ee9088f7ace2eaab9
-    |       └── size: 16724
+    │   ├── signature algorithm: RSASSA-PSS-SHA-256
+    │   ├── signed attributes
+    │   │   ├── content type: application/vnd.cncf.notary.payload.v1+json
+    │   │   ├── signing scheme: notary.default.x509
+    │   │   ├── signing time: Fri Jun 23 22:04:01 2023
+    │   │   ├── expiry: Sat Jun 29 22:04:01 2024
+    │   │   └── io.cncf.notary.verificationPlugin: com.example.nv2plugin
+    │   ├── user defined attributes
+    │   │   └── io.wabbit-networks.buildId: 123
+    │   ├── unsigned attributes
+    │   │   ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)>
+    │   │   └── io.cncf.notary.signingAgent: notation/1.0.0
+    │   ├── certificates
+    │   │   ├── SHA1 fingerprint: E8C15B4C98AD91E051EE5AF5F524A8729050B2A
+    │   │   │   ├── issued to: wabbit-com Software
+    │   │   │   ├── issued by: wabbit-com Software Root Certificate Authority
+    │   │   │   └── expiry: Sun Jul 06 20:50:17 2025
+    │   │   ├── SHA1 fingerprint: 5DCC2147712B3C555B1C96CFCC00215403TF044D
+    │   │   │   ├── issued to: wabbit-com Software Code Signing PCA
+    │   │   │   ├── issued by: wabbit-com Software Root Certificate Authority
+    │   │   │   └── expiry: Sun Jul 06 20:50:17 2025
+    │   │   └── SHA1 fingerprint: 1GYA3107712B3C886B1C96AAEC89984914DC0A5A
+    │   │       ├── issued to: wabbit-com Software Root Certificate Authority
+    │   │       ├── issued by: wabbit-com Software Root Certificate Authority
+    │   │       └── expiry: Sat Jun 23 22:04:01 2035
+    │   └── signed artifact 
+    │       ├── media type: application/vnd.oci.image.manifest.v1+json
+    │       ├── digest: sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380ee9088f7ace2eaab9
+    │       └── size: 16724
     └── sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
         ├── signature algorithm: RSASSA-PSS-SHA-256
         ├── signed attributes
-        |   ├── content type: application/vnd.cncf.notary.payload.v1+json
-        |   ├── signing scheme: notary.signingAuthority.x509
-        |   ├── signing time: Fri Jun 23 22:04:01 2023
-        |   ├── expiry: Sat Jun 29 22:04:01 2024
-        |   └── io.cncf.notary.verificationPlugin: com.example.nv2plugin     
+        │   ├── content type: application/vnd.cncf.notary.payload.v1+json
+        │   ├── signing scheme: notary.signingAuthority.x509
+        │   ├── signing time: Fri Jun 23 22:04:01 2023
+        │   ├── expiry: Sat Jun 29 22:04:01 2024
+        │   └── io.cncf.notary.verificationPlugin: com.example.nv2plugin     
         ├── unsigned attributes
-        |   ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)> 
-        |   └── io.cncf.notary.signingAgent: notation/1.0.0   
+        │   ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)> 
+        │   └── io.cncf.notary.signingAgent: notation/1.0.0   
         ├── certificates
-        |   ├── SHA1 fingerprint: 68C15B4C98AD91E051EE5AF5F524A8729040B1D
-        |   |   ├── issued to: wabbit-com Software
-        |   |   ├── issued by: wabbit-com Software Root Certificate Authority
-        |   |   └── expiry: Sun Jul 06 20:50:17 2025
-        |   ├── SHA1 fingerprint: 4ACC2147712B3C555B1C96CFCC00215403TE011C
-        |   |   ├── issued to: wabbit-com Software Code Signing PCA
-        |   |   ├── issued by: wabbit-com Software Root Certificate Authority
-        |   |   └── expiry: Sun Jul 06 20:50:17 2025
-        |   └── SHA1 fingerprint: A4YA1205512B3C886B1C96AAEC89984914DC012A
-        |       ├── issued to: wabbit-com Software Root Certificate Authority
-        |       ├── issued by: wabbit-com Software Root Certificate Authority
-        |       └── expiry: Sat Jun 23 22:04:01 2035
+        │   ├── SHA1 fingerprint: 68C15B4C98AD91E051EE5AF5F524A8729040B1D
+        │   │   ├── issued to: wabbit-com Software
+        │   │   ├── issued by: wabbit-com Software Root Certificate Authority
+        │   │   └── expiry: Sun Jul 06 20:50:17 2025
+        │   ├── SHA1 fingerprint: 4ACC2147712B3C555B1C96CFCC00215403TE011C
+        │   │   ├── issued to: wabbit-com Software Code Signing PCA
+        │   │   ├── issued by: wabbit-com Software Root Certificate Authority
+        │   │   └── expiry: Sun Jul 06 20:50:17 2025
+        │   └── SHA1 fingerprint: A4YA1205512B3C886B1C96AAEC89984914DC012A
+        │       ├── issued to: wabbit-com Software Root Certificate Authority
+        │       ├── issued by: wabbit-com Software Root Certificate Authority
+        │       └── expiry: Sat Jun 23 22:04:01 2035
         └── signed artifact 
             ├── media type: application/vnd.oci.image.manifest.v1+json
             ├── digest: sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380ee9088f7ace2eaab9

--- a/specs/commandline/inspect.md
+++ b/specs/commandline/inspect.md
@@ -278,7 +278,7 @@ An example output:
           "SHA1Fingerprint": "4ACC2147712B3C555B1C96CFCC00215403TE011C",
           "issuedTo": "wabbit-com Software Code Signing PCA",
           "issuedBy": "wabbit-com Software Root Certificate Authority",
-          "expires": "2025-07-06T20:50:17Z"
+          "expiry": "2025-07-06T20:50:17Z"
         },
         {
           "SHA1Fingerprint": "A4YA1205512B3C886B1C96AAEC89984914DC012A",

--- a/specs/commandline/inspect.md
+++ b/specs/commandline/inspect.md
@@ -53,12 +53,12 @@ notation inspect [flags] <registry>/<repository>@<digest>
 
 ```shell
 # Prerequisites: Signatures are stored in a registry referencing the signed OCI artifact
-notation inspect localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+notation inspect localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da1ac484efe37a5380ee9088f7ace2efcde9
 ```
 
 An example output:
 ```shell
-localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac4efe37a5380ee9088f7ace2efcde9
 └── application/vnd.cncf.notary.signature
     ├── sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
         ├── signing algorithm: RSASSA-PSS-SHA-256
@@ -69,22 +69,26 @@ localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380
             ├── expiry: Sat Jun 29 22:04:01 2024
             ├── io.cncf.notary.verificationPlugin: com.example.nv2plugin    //extended attributes to support plugins
         ├── user defined attributes
-            ├── io.wabbit-networks.buildId: 123                             //user defined payload annotations.
+            ├── io.wabbit-networks.buildId: 123                             //user defined payload annotations
         ├── unsigned attributes
-            ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)> //TSA response (time stamp token) is represented.
-            ├── io.cncf.notary.signingAgent: notation/1.0.0                 //identifier of a client that produced the signature
+            ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)> //TSA response (time stamp token)
+            ├── io.cncf.notary.signingAgent: notation/1.0.0                 //client that produced the signature
         ├── certificates
-            ├── SHA1 fingerprint: 2f1cc5b8455381cdefac83b4bd305b789cc9c16e
-                ├── issued to: Microsoft Root Certificate Authority 2010
-                ├── issued by: Microsoft Root Certificate Authority 2010
-                ├── expiry: Sat Jun 29 22:04:01 2024
-            ├── SHA1 fingerprint: 8BFE3107712B3C886B1C96AAEC89984914DC9B6B
-                ├── issued to: Microsoft Code Signing PCA 2010
-                ├── issued by: Microsoft Root Certificate Authority 2010
-                ├── expiry: Sat Jun 29 22:04:01 2024
-        └── signed artifact                                                 //descriptor of the target artifact manifest that is signed.
+            ├── SHA1 fingerprint: E8C15B4C98AD91E051EE5AF5F524A8729050B2A
+                ├── issued to: wabbit-com Software
+                ├── issued by: wabbit-com Software Root Certificate Authority
+                ├── expiry: Sun Jul 06 20:50:17 2025
+            ├── SHA1 fingerprint: 5DCC2147712B3C555B1C96CFCC00215403TF044D
+                ├── issued to: wabbit-com Software Code Signing PCA
+                ├── issued by: wabbit-com Software Root Certificate Authority
+                ├── expiry: Sun Jul 06 20:50:17 2025
+            ├── SHA1 fingerprint: 1GYA3107712B3C886B1C96AAEC89984914DC0A5A
+                ├── issued to: wabbit-com Software Root Certificate Authority
+                ├── issued by: wabbit-com Software Root Certificate Authority
+                ├── expiry: Sat Jun 23 22:04:01 2035
+        └── signed artifact                                                 //descriptor of the signed target artifact
             ├── media type: application/vnd.oci.image.manifest.v1+json
-            ├── digest: sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+            ├── digest: sha256:b94d27b9934d3e08a52e52d7da7dabfac48437a5380ee9088f7ace2efcde9
             └── size: 16724
     ├── sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
         ├── signing algorithm: RSASSA-PSS-SHA-256
@@ -98,25 +102,27 @@ localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380
             ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)>
             ├── io.cncf.notary.signingAgent: notation/1.0.0                  
         ├── certificates
-            ├── SHA1 fingerprint: 2f1rr5b8455381frdajc83b4bd305b743cc9513u
-                ├── issued to: Microsoft Root Certificate Authority 2010
-                ├── issued by: Microsoft Root Certificate Authority 2010
-                ├── expiry: Fri Jun 23 22:04:01 2023
-            ├── SHA1 fingerprint: 8BFE3107712B3C886B1C96AAEC89984914DC9B6B
-                ├── issued to: Microsoft Code Signing PCA 2010
-                ├── issued by: Microsoft Root Certificate Authority 2010
+            ├── SHA1 fingerprint: 68C15B4C98AD91E051EE5AF5F524A8729040B1D
+                ├── issued to: wabbit-com Software
+                ├── issued by: wabbit-com Software Root Certificate Authority
                 ├── expiry: Sun Jul 06 20:50:17 2025
+            ├── SHA1 fingerprint: 4ACC2147712B3C555B1C96CFCC00215403TE011C
+                ├── issued to: wabbit-com Software Code Signing PCA 2010
+                ├── issued by: wabbit-com Software Root Certificate Authority
+                ├── expiry: Sun Jul 06 20:50:17 2025
+            ├── SHA1 fingerprint: A4YA1205512B3C886B1C96AAEC89984914DC012A
+                ├── issued to: wabbit-com Software Root Certificate Authority
+                ├── issued by: wabbit-com Software Root Certificate Authority
+                ├── expiry: Sat Jun 23 22:04:01 2035
         └── signed attributes 
             ├── media type: application/vnd.oci.image.manifest.v1+json
-            ├── digest: sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+            ├── digest: sha256:b94d27b9934d3e08a52e52d7da7fac484efe37a5380ee9088f7ace2efcde9
             └── size: 16724
 ```
 
 ## Usage signatures on an OCI artifact identified by a tag
 
-```text
 `Tags` are mutable, but `Digests` uniquely and immutably identify an artifact. If a tag is used to identify a signed artifact, notation resolves the tag to the `digest` first.
-```
 
 ```shell
 # Prerequisites: Signatures are stored in a registry referencing the signed OCI artifact
@@ -132,7 +138,7 @@ Warning: The resolved digest may not point to the same signed artifact, since ta
 ```shell
 localhost:5000/net-monitor@sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380ee9088f7ace2eaab9
 └── application/vnd.cncf.notary.signature
-    ├── sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    ├── sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
         ├── signing algorithm: RSASSA-PSS-SHA-256
         ├── signed attributes
             ├── content type: application/vnd.cncf.notary.payload.v1+json
@@ -146,14 +152,18 @@ localhost:5000/net-monitor@sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380
             ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)>
             ├── io.cncf.notary.signingAgent: notation/1.0.0
         ├── certificates
-            ├── SHA1 fingerprint: 2f1cc5b8455381cdefac83b4bd305b789cc9c16e
-                ├── issued to: Microsoft Root Certificate Authority 2010
-                ├── issued by: Microsoft Root Certificate Authority 2010
-                ├── expiry: Sat Jun 23 22:04:01 2035
-            ├── SHA1 fingerprint: 8BFE3107712B3C886B1C96AAEC89984914DC9B6B
-                ├── issued to: Microsoft Code Signing PCA 2010
-                ├── issued by: Microsoft Root Certificate Authority 2010
+            ├── SHA1 fingerprint: E8C15B4C98AD91E051EE5AF5F524A8729050B2A
+                ├── issued to: wabbit-com Software
+                ├── issued by: wabbit-com Software Root Certificate Authority
                 ├── expiry: Sun Jul 06 20:50:17 2025
+            ├── SHA1 fingerprint: 5DCC2147712B3C555B1C96CFCC00215403TF044D
+                ├── issued to: wabbit-com Software Code Signing PCA
+                ├── issued by: wabbit-com Software Root Certificate Authority
+                ├── expiry: Sun Jul 06 20:50:17 2025
+            ├── SHA1 fingerprint: 1GYA3107712B3C886B1C96AAEC89984914DC0A5A
+                ├── issued to: wabbit-com Software Root Certificate Authority
+                ├── issued by: wabbit-com Software Root Certificate Authority
+                ├── expiry: Sat Jun 23 22:04:01 2035
         └── signed attribute 
             ├── media type: application/vnd.oci.image.manifest.v1+json
             ├── digest: sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380ee9088f7ace2eaab9
@@ -170,14 +180,18 @@ localhost:5000/net-monitor@sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380
             ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)> 
             ├── io.cncf.notary.signingAgent: notation/1.0.0   
         ├── certificates
-            ├── SHA1 fingerprint: 2f1rr5b8455381frdajc83b4bd305b743cc9513u
-                ├── issued to: Microsoft Root Certificate Authority 2010
-                ├── issued by: Microsoft Root Certificate Authority 2010
-                ├── expiry: Sat Jun 23 22:04:01 2035
-            ├── SHA1 fingerprint: 8BFE3107712B3C886B1C96AAEC89984914DC9B6B
-                ├── issued to: Microsoft Code Signing PCA 2010
-                ├── issued by: Microsoft Root Certificate Authority 2010
+            ├── SHA1 fingerprint: 68C15B4C98AD91E051EE5AF5F524A8729040B1D
+                ├── issued to: wabbit-com Software
+                ├── issued by: wabbit-com Software Root Certificate Authority
                 ├── expiry: Sun Jul 06 20:50:17 2025
+            ├── SHA1 fingerprint: 4ACC2147712B3C555B1C96CFCC00215403TE011C
+                ├── issued to: wabbit-com Software Code Signing PCA
+                ├── issued by: wabbit-com Software Root Certificate Authority
+                ├── expiry: Sun Jul 06 20:50:17 2025
+            ├── SHA1 fingerprint: A4YA1205512B3C886B1C96AAEC89984914DC012A
+                ├── issued to: wabbit-com Software Root Certificate Authority
+                ├── issued by: wabbit-com Software Root Certificate Authority
+                ├── expiry: Sat Jun 23 22:04:01 2035
         └── signed artifact 
             ├── media type: application/vnd.oci.image.manifest.v1+json
             ├── digest: sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380ee9088f7ace2eaab9
@@ -186,7 +200,7 @@ localhost:5000/net-monitor@sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380
 ## Inspect signatures on the supplied OCI artifact with an example of JSON Output
 
 ```shell
-notation inspect localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9 -o json
+notation inspect localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52da7dabfac484efe37a5380ee9088f7ace2efcde9 -o json
 ```
 
 An example output:
@@ -194,13 +208,13 @@ An example output:
 {
   "signatures": [
     {
-      "digest": "sha256:73c803930ea3ba1e54bc25c2bdc53edd0284c62ed651fe7b00369da519a3c333",
+      "digest": "sha256:73c803930ea3ba1e54bc25c2bdc53edd0284c62ed651fe7b00369da519a33",
       "signingAlgorithm": "RSASSA-PSS-SHA-256",
       "signedAttributes": {
         "contentType": "application/vnd.cncf.notary.payload.v1+json",
         "signingScheme": "notary.default.x509",
-        "signingTime": "Sun Feb 06 20:50:17 2022",
-        "expiry": "Sun Feb 06 20:50:17 2023",
+        "signingTime": "2022-02-06T20:50:17Z",
+        "expiry": "2023-02-06T20:50:17Z",
         "io.cncf.notary.verificationPlugin": "com.example.nv2plugin"
       },
       "userDefinedAttributes": {
@@ -212,22 +226,28 @@ An example output:
       },
       "certificates": [
         {
-          "SHA1Fingerprint": "8BFE3107712B3C886B1C96AAEC89984914DC9B6B",
-          "issuedTo": "Microsoft Root Certificate Authority 2010",
-          "issuedBy": "Microsoft Root Certificate Authority 2010",
+          "SHA1Fingerprint": "E8C15B4C98AD91E051EE5AF5F524A8729050B2A",
+          "issuedTo": "wabbit-com Software",
+          "issuedBy": "wabbit-com Software Root Certificate Authority",
           "expires": "Sun Jul 06 20:50:17 2025"
         },
         {
-          "SHA1Fingerprint": "8BFE3107712B3C886B1C96AAEC89984914DC9B6B",
-          "issuedTo": "Microsoft Code Signing PCA 2010",
-          "issuedBy": "Microsoft Root Certificate Authority 2010",
+          "SHA1Fingerprint": "5DCC2147712B3C555B1C96CFCC00215403TF044D",
+          "issuedTo": "wabbit-com Software Code Signing PCA",
+          "issuedBy": "wabbit-com Software Root Certificate Authority",
           "expires": "Sun Jul 06 20:50:17 2025"
+        },
+        {
+          "SHA1Fingerprint": "1GYA3107712B3C886B1C96AAEC89984914DC0A5A",
+          "issuedTo": "wabbit-com Software Root Certificate Authority",
+          "issuedBy": "wabbit-com Software Root Certificate Authority",
+          "expires": "Sat Jun 23 22:04:01 2035"
         }
       ],
       "signedArtifact": {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
-        "digest": "sha256:73c803930ea3ba1e54bc25c2bdc53edd0284c62ed651fe7b00369da519a3c333",
-        "size": "16724"
+        "digest": "sha256:73c803930ea3ba1e54bc25c2bdc53edd0284c62ed651fe7b00369519a3c333",
+        "size": 16724
       }
     },
     {
@@ -246,22 +266,28 @@ An example output:
       },
       "certificates": [
         {
-          "SHA1Fingerprint": "8BFE3107712B3C886B1C96AAEC89984914DC9B6B",
-          "issuedTo": "Microsoft Code Signing PCA 2010",
-          "issuedBy": "Microsoft Root Certificate Authority 2010",
+          "SHA1Fingerprint": "68C15B4C98AD91E051EE5AF5F524A8729040B1D",
+          "issuedTo": "wabbit-com Software",
+          "issuedBy": "wabbit-com Software Root Certificate Authority",
           "expires": "Sun Jul 06 20:50:17 2025"
         },
         {
-          "SHA1Fingerprint": "8BFE3107712B3C886B1C96AAEC89984914DC9B6B",
-          "issuedTo": "Microsoft Code Signing PCA 2010",
-          "issuedBy": "Microsoft Root Certificate Authority 2010",
+          "SHA1Fingerprint": "4ACC2147712B3C555B1C96CFCC00215403TE011C",
+          "issuedTo": "wabbit-com Software Code Signing PCA",
+          "issuedBy": "wabbit-com Software Root Certificate Authority",
           "expires": "Sun Jul 06 20:50:17 2025"
+        },
+        {
+          "SHA1Fingerprint": "A4YA1205512B3C886B1C96AAEC89984914DC012A",
+          "issuedTo": "wabbit-com Software Root Certificate Authority",
+          "issuedBy": "wabbit-com Software Root Certificate Authority",
+          "expires": "Sat Jun 23 22:04:01 2035"
         }
       ],
       "signedArtifact": {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
-        "digest": "sha256:73c803930ea3ba1e54bc25c2bdc53edd0284c62ed651fe7b00369da519a3c333",
-        "size": "16724"
+        "digest": "sha256:73c803930ea3ba1e54bc25c2bdc53edd0284c62ed651fe7b069da519a3c333",
+        "size": 16724
       }
     }
   ]

--- a/specs/commandline/inspect.md
+++ b/specs/commandline/inspect.md
@@ -98,10 +98,10 @@ localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac4efe37a5380ee
         │   ├── signing scheme: notary.signingAuthority.x509
         │   ├── signing time: Fri Jun 23 22:04:01 2023
         │   ├── expiry: Sat Jun 29 22:04:01 2024
-        │   └── io.cncf.notary.verificationPlugin: com.example.nv2plugin                  
+        │   └── io.cncf.notary.verificationPlugin: com.example.nv2plugin
         ├── unsigned attributes
         │   ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)>
-        │   └── io.cncf.notary.signingAgent: notation/1.0.0                  
+        │   └── io.cncf.notary.signingAgent: notation/1.0.0
         ├── certificates
         │   ├── SHA1 fingerprint: 68C15B4C98AD91E051EE5AF5F524A8729040B1D
         │   │   ├── issued to: wabbit-com Software
@@ -166,7 +166,7 @@ localhost:5000/net-monitor@sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380
     │   │       ├── issued to: wabbit-com Software Root Certificate Authority
     │   │       ├── issued by: wabbit-com Software Root Certificate Authority
     │   │       └── expiry: Sat Jun 23 22:04:01 2035
-    │   └── signed artifact 
+    │   └── signed artifact
     │       ├── media type: application/vnd.oci.image.manifest.v1+json
     │       ├── digest: sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380ee9088f7ace2eaab9
     │       └── size: 16724
@@ -177,10 +177,10 @@ localhost:5000/net-monitor@sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380
         │   ├── signing scheme: notary.signingAuthority.x509
         │   ├── signing time: Fri Jun 23 22:04:01 2023
         │   ├── expiry: Sat Jun 29 22:04:01 2024
-        │   └── io.cncf.notary.verificationPlugin: com.example.nv2plugin     
+        │   └── io.cncf.notary.verificationPlugin: com.example.nv2plugin
         ├── unsigned attributes
-        │   ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)> 
-        │   └── io.cncf.notary.signingAgent: notation/1.0.0   
+        │   ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)>
+        │   └── io.cncf.notary.signingAgent: notation/1.0.0
         ├── certificates
         │   ├── SHA1 fingerprint: 68C15B4C98AD91E051EE5AF5F524A8729040B1D
         │   │   ├── issued to: wabbit-com Software
@@ -194,7 +194,7 @@ localhost:5000/net-monitor@sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380
         │       ├── issued to: wabbit-com Software Root Certificate Authority
         │       ├── issued by: wabbit-com Software Root Certificate Authority
         │       └── expiry: Sat Jun 23 22:04:01 2035
-        └── signed artifact 
+        └── signed artifact
             ├── media type: application/vnd.oci.image.manifest.v1+json
             ├── digest: sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380ee9088f7ace2eaab9
             └── size: 16724
@@ -232,19 +232,19 @@ An example output:
           "SHA1Fingerprint": "E8C15B4C98AD91E051EE5AF5F524A8729050B2A",
           "issuedTo": "wabbit-com Software",
           "issuedBy": "wabbit-com Software Root Certificate Authority",
-          "expiry": "Sun Jul 06 20:50:17 2025"
+          "expiry": "2025-07-06T20:50:17Z"
         },
         {
           "SHA1Fingerprint": "5DCC2147712B3C555B1C96CFCC00215403TF044D",
           "issuedTo": "wabbit-com Software Code Signing PCA",
           "issuedBy": "wabbit-com Software Root Certificate Authority",
-          "expiry": "Sun Jul 06 20:50:17 2025"
+          "expiry": "2025-07-06T20:50:17Z"
         },
         {
           "SHA1Fingerprint": "1GYA3107712B3C886B1C96AAEC89984914DC0A5A",
           "issuedTo": "wabbit-com Software Root Certificate Authority",
           "issuedBy": "wabbit-com Software Root Certificate Authority",
-          "expiry": "Sat Jun 23 22:04:01 2035"
+          "expiry": "2035-07-06T20:50:17Z"
         }
       ],
       "signedArtifact": {
@@ -258,9 +258,9 @@ An example output:
       "signatureAlgorithm": "RSASSA-PSS-SHA-256",
       "signedAttributes": {
         "contentType": "application/vnd.cncf.notary.payload.v1+json",
-        "signingScheme": " notary.signingAuthority.x509",
-        "signingTime": "Sun Mar 05 20:50:17 2023",
-        "expiry": "Tue Mar 06 20:50:17 2023",
+        "signingScheme": "notary.signingAuthority.x509",
+        "signingTime": "2022-02-06T20:50:17Z",
+        "expiry": "2023-02-06T20:50:17Z",
         "io.cncf.notary.verificationPlugin": "com.example.nv2plugin"
       },
       "unsignedAttributes": {
@@ -272,19 +272,19 @@ An example output:
           "SHA1Fingerprint": "68C15B4C98AD91E051EE5AF5F524A8729040B1D",
           "issuedTo": "wabbit-com Software",
           "issuedBy": "wabbit-com Software Root Certificate Authority",
-          "expiry": "Sun Jul 06 20:50:17 2025"
+          "expiry": "2025-07-06T20:50:17Z"
         },
         {
           "SHA1Fingerprint": "4ACC2147712B3C555B1C96CFCC00215403TE011C",
           "issuedTo": "wabbit-com Software Code Signing PCA",
           "issuedBy": "wabbit-com Software Root Certificate Authority",
-          "expires": "Sun Jul 06 20:50:17 2025"
+          "expires": "2025-07-06T20:50:17Z"
         },
         {
           "SHA1Fingerprint": "A4YA1205512B3C886B1C96AAEC89984914DC012A",
           "issuedTo": "wabbit-com Software Root Certificate Authority",
           "issuedBy": "wabbit-com Software Root Certificate Authority",
-          "expiry": "Sat Jun 23 22:04:01 2035"
+          "expiry": "2035-07-06T20:50:17Z"
         }
       ],
       "signedArtifact": {

--- a/specs/commandline/inspect.md
+++ b/specs/commandline/inspect.md
@@ -10,14 +10,14 @@ Upon successful execution, both the digest of the signed artifact and the digest
 <registry>/<repository>@<digest>
 └── application/vnd.cncf.notary.signature
     ├── <digest_of_signature_manifest>
-        ├── <signing algorithm>
-        ├── <signed attributes>
-        ├── <user defined attributes>
-        ├── <unsigned attributes>
-        ├── <certificates>
-        └── <signed artifact>
-    ├── <digest_of_signature_manifest>
-        ├── <signing algorithm>
+    |   ├── <signature algorithm>
+    |   ├── <signed attributes>
+    |   ├── <user defined attributes>
+    |   ├── <unsigned attributes>
+    |   ├── <certificates>
+    |   └── <signed artifact>
+    └── <digest_of_signature_manifest>
+        ├── <signature algorithm>
         ├── <signed attributes>
         ├── <unsigned attributes>
         ├── <certificates>
@@ -27,7 +27,7 @@ Upon successful execution, both the digest of the signed artifact and the digest
 ## Outline
 
 ```text
-Inspect all signatures with the signed artifact.
+Inspect all signatures associated with the signed artifact.
 
 Usage:
     notation inspect [flags] <reference>
@@ -61,66 +61,66 @@ An example output:
 localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac4efe37a5380ee9088f7ace2efcde9
 └── application/vnd.cncf.notary.signature
     ├── sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-        ├── signing algorithm: RSASSA-PSS-SHA-256
+    |   ├── signature algorithm: RSASSA-PSS-SHA-256
+    |   ├── signed attributes
+    |   |   ├── content type: application/vnd.cncf.notary.payload.v1+json
+    |   |   ├── signing scheme: notary.default.x509
+    |   |   ├── signing time: Fri Jun 23 22:04:01 2023
+    |   |   ├── expiry: Sat Jun 29 22:04:01 2024
+    |   |   └── io.cncf.notary.verificationPlugin: com.example.nv2plugin    //extended attributes to support plugins
+    |   ├── user defined attributes
+    |   |   └── io.wabbit-networks.buildId: 123                             //user defined payload annotations
+    |   ├── unsigned attributes
+    |   |   ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)> //TSA response (time stamp token)
+    |   |   └── io.cncf.notary.signingAgent: notation/1.0.0                 //client that produced the signature
+    |   ├── certificates
+    |   |   ├── SHA1 fingerprint: E8C15B4C98AD91E051EE5AF5F524A8729050B2A
+    |   |   |   ├── issued to: wabbit-com Software
+    |   |   |   ├── issued by: wabbit-com Software Root Certificate Authority
+    |   |   |   └── expiry: Sun Jul 06 20:50:17 2025
+    |   |   ├── SHA1 fingerprint: 5DCC2147712B3C555B1C96CFCC00215403TF044D
+    |   |   |   ├── issued to: wabbit-com Software Code Signing PCA
+    |   |   |   ├── issued by: wabbit-com Software Root Certificate Authority
+    |   |   |   └── expiry: Sun Jul 06 20:50:17 2025
+    |   |   └── SHA1 fingerprint: 1GYA3107712B3C886B1C96AAEC89984914DC0A5A
+    |   |       ├── issued to: wabbit-com Software Root Certificate Authority
+    |   |       ├── issued by: wabbit-com Software Root Certificate Authority
+    |   |       └── expiry: Sat Jun 23 22:04:01 2035
+    |   └── signed artifact                                                 //descriptor of the signed target artifact
+    |       ├── media type: application/vnd.oci.image.manifest.v1+json
+    |       ├── digest: sha256:b94d27b9934d3e08a52e52d7da7dabfac48437a5380ee9088f7ace2efcde9
+    |       └── size: 16724
+    └── sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+        ├── signature algorithm: RSASSA-PSS-SHA-256
         ├── signed attributes
-            ├── content type: application/vnd.cncf.notary.payload.v1+json
-            ├── signing scheme: notary.default.x509
-            ├── signing time: Fri Jun 23 22:04:01 2023
-            ├── expiry: Sat Jun 29 22:04:01 2024
-            ├── io.cncf.notary.verificationPlugin: com.example.nv2plugin    //extended attributes to support plugins
-        ├── user defined attributes
-            ├── io.wabbit-networks.buildId: 123                             //user defined payload annotations
+        |   ├── content type: application/vnd.cncf.notary.payload.v1+json
+        |   ├── signing scheme: notary.signingAuthority.x509
+        |   ├── signing time: Fri Jun 23 22:04:01 2023
+        |   ├── expiry: Sat Jun 29 22:04:01 2024
+        |   └── io.cncf.notary.verificationPlugin: com.example.nv2plugin                  
         ├── unsigned attributes
-            ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)> //TSA response (time stamp token)
-            ├── io.cncf.notary.signingAgent: notation/1.0.0                 //client that produced the signature
+        |   ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)>
+        |   └── io.cncf.notary.signingAgent: notation/1.0.0                  
         ├── certificates
-            ├── SHA1 fingerprint: E8C15B4C98AD91E051EE5AF5F524A8729050B2A
-                ├── issued to: wabbit-com Software
-                ├── issued by: wabbit-com Software Root Certificate Authority
-                ├── expiry: Sun Jul 06 20:50:17 2025
-            ├── SHA1 fingerprint: 5DCC2147712B3C555B1C96CFCC00215403TF044D
-                ├── issued to: wabbit-com Software Code Signing PCA
-                ├── issued by: wabbit-com Software Root Certificate Authority
-                ├── expiry: Sun Jul 06 20:50:17 2025
-            ├── SHA1 fingerprint: 1GYA3107712B3C886B1C96AAEC89984914DC0A5A
-                ├── issued to: wabbit-com Software Root Certificate Authority
-                ├── issued by: wabbit-com Software Root Certificate Authority
-                ├── expiry: Sat Jun 23 22:04:01 2035
-        └── signed artifact                                                 //descriptor of the signed target artifact
-            ├── media type: application/vnd.oci.image.manifest.v1+json
-            ├── digest: sha256:b94d27b9934d3e08a52e52d7da7dabfac48437a5380ee9088f7ace2efcde9
-            └── size: 16724
-    ├── sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-        ├── signing algorithm: RSASSA-PSS-SHA-256
-        ├── signed attributes
-            ├── content type: application/vnd.cncf.notary.payload.v1+json
-            ├── signing scheme: notary.signingAuthority.x509
-            ├── signing time: Fri Jun 23 22:04:01 2023
-            ├── expiry: Sat Jun 29 22:04:01 2024
-            ├── io.cncf.notary.verificationPlugin: com.example.nv2plugin                  
-        ├── unsigned attributes
-            ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)>
-            ├── io.cncf.notary.signingAgent: notation/1.0.0                  
-        ├── certificates
-            ├── SHA1 fingerprint: 68C15B4C98AD91E051EE5AF5F524A8729040B1D
-                ├── issued to: wabbit-com Software
-                ├── issued by: wabbit-com Software Root Certificate Authority
-                ├── expiry: Sun Jul 06 20:50:17 2025
-            ├── SHA1 fingerprint: 4ACC2147712B3C555B1C96CFCC00215403TE011C
-                ├── issued to: wabbit-com Software Code Signing PCA 2010
-                ├── issued by: wabbit-com Software Root Certificate Authority
-                ├── expiry: Sun Jul 06 20:50:17 2025
-            ├── SHA1 fingerprint: A4YA1205512B3C886B1C96AAEC89984914DC012A
-                ├── issued to: wabbit-com Software Root Certificate Authority
-                ├── issued by: wabbit-com Software Root Certificate Authority
-                ├── expiry: Sat Jun 23 22:04:01 2035
-        └── signed attributes 
+        |   ├── SHA1 fingerprint: 68C15B4C98AD91E051EE5AF5F524A8729040B1D
+        |   |   ├── issued to: wabbit-com Software
+        |   |   ├── issued by: wabbit-com Software Root Certificate Authority
+        |   |   └── expiry: Sun Jul 06 20:50:17 2025
+        |   ├── SHA1 fingerprint: 4ACC2147712B3C555B1C96CFCC00215403TE011C
+        |   |   ├── issued to: wabbit-com Software Code Signing PCA 2010
+        |   |   ├── issued by: wabbit-com Software Root Certificate Authority
+        |   |   └── expiry: Sun Jul 06 20:50:17 2025
+        |   └── SHA1 fingerprint: A4YA1205512B3C886B1C96AAEC89984914DC012A
+        |       ├── issued to: wabbit-com Software Root Certificate Authority
+        |       ├── issued by: wabbit-com Software Root Certificate Authority
+        |       └── expiry: Sat Jun 23 22:04:01 2035
+        └── signed artifact 
             ├── media type: application/vnd.oci.image.manifest.v1+json
             ├── digest: sha256:b94d27b9934d3e08a52e52d7da7fac484efe37a5380ee9088f7ace2efcde9
             └── size: 16724
 ```
 
-## Usage signatures on an OCI artifact identified by a tag
+## Inspect signatures on an OCI artifact identified by a tag
 
 `Tags` are mutable, but `Digests` uniquely and immutably identify an artifact. If a tag is used to identify a signed artifact, notation resolves the tag to the `digest` first.
 
@@ -139,59 +139,59 @@ Warning: The resolved digest may not point to the same signed artifact, since ta
 localhost:5000/net-monitor@sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380ee9088f7ace2eaab9
 └── application/vnd.cncf.notary.signature
     ├── sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-        ├── signing algorithm: RSASSA-PSS-SHA-256
+    |   ├── signature algorithm: RSASSA-PSS-SHA-256
+    |   ├── signed attributes
+    |   |   ├── content type: application/vnd.cncf.notary.payload.v1+json
+    |   |   ├── signing scheme: notary.default.x509
+    |   |   ├── signing time: Fri Jun 23 22:04:01 2023
+    |   |   ├── expiry: Sat Jun 29 22:04:01 2024
+    |   |   └── io.cncf.notary.verificationPlugin: com.example.nv2plugin
+    |   ├── user defined attributes
+    |   |   └── io.wabbit-networks.buildId: 123
+    |   ├── unsigned attributes
+    |   |   ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)>
+    |   |   └── io.cncf.notary.signingAgent: notation/1.0.0
+    |   ├── certificates
+    |   |   ├── SHA1 fingerprint: E8C15B4C98AD91E051EE5AF5F524A8729050B2A
+    |   |   |   ├── issued to: wabbit-com Software
+    |   |   |   ├── issued by: wabbit-com Software Root Certificate Authority
+    |   |   |   └── expiry: Sun Jul 06 20:50:17 2025
+    |   |   ├── SHA1 fingerprint: 5DCC2147712B3C555B1C96CFCC00215403TF044D
+    |   |   |   ├── issued to: wabbit-com Software Code Signing PCA
+    |   |   |   ├── issued by: wabbit-com Software Root Certificate Authority
+    |   |   |   └── expiry: Sun Jul 06 20:50:17 2025
+    |   |   └── SHA1 fingerprint: 1GYA3107712B3C886B1C96AAEC89984914DC0A5A
+    |   |       ├── issued to: wabbit-com Software Root Certificate Authority
+    |   |       ├── issued by: wabbit-com Software Root Certificate Authority
+    |   |       └── expiry: Sat Jun 23 22:04:01 2035
+    |   └── signed artifact 
+    |       ├── media type: application/vnd.oci.image.manifest.v1+json
+    |       ├── digest: sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380ee9088f7ace2eaab9
+    |       └── size: 16724
+    └── sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+        ├── signature algorithm: RSASSA-PSS-SHA-256
         ├── signed attributes
-            ├── content type: application/vnd.cncf.notary.payload.v1+json
-            ├── signing scheme: notary.default.x509
-            ├── signing time: Fri Jun 23 22:04:01 2023
-            ├── expiry: Sat Jun 29 22:04:01 2024
-            ├── io.cncf.notary.verificationPlugin: com.example.nv2plugin
-        ├── user defined attributes
-            ├── io.wabbit-networks.buildId: 123
+        |   ├── content type: application/vnd.cncf.notary.payload.v1+json
+        |   ├── signing scheme: notary.signingAuthority.x509
+        |   ├── signing time: Fri Jun 23 22:04:01 2023
+        |   ├── expiry: Sat Jun 29 22:04:01 2024
+        |   └── io.cncf.notary.verificationPlugin: com.example.nv2plugin     
         ├── unsigned attributes
-            ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)>
-            ├── io.cncf.notary.signingAgent: notation/1.0.0
+        |   ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)> 
+        |   └── io.cncf.notary.signingAgent: notation/1.0.0   
         ├── certificates
-            ├── SHA1 fingerprint: E8C15B4C98AD91E051EE5AF5F524A8729050B2A
-                ├── issued to: wabbit-com Software
-                ├── issued by: wabbit-com Software Root Certificate Authority
-                ├── expiry: Sun Jul 06 20:50:17 2025
-            ├── SHA1 fingerprint: 5DCC2147712B3C555B1C96CFCC00215403TF044D
-                ├── issued to: wabbit-com Software Code Signing PCA
-                ├── issued by: wabbit-com Software Root Certificate Authority
-                ├── expiry: Sun Jul 06 20:50:17 2025
-            ├── SHA1 fingerprint: 1GYA3107712B3C886B1C96AAEC89984914DC0A5A
-                ├── issued to: wabbit-com Software Root Certificate Authority
-                ├── issued by: wabbit-com Software Root Certificate Authority
-                ├── expiry: Sat Jun 23 22:04:01 2035
-        └── signed attribute 
-            ├── media type: application/vnd.oci.image.manifest.v1+json
-            ├── digest: sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380ee9088f7ace2eaab9
-            └── size: 16724
-    ├── sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-        ├── signing algorithm: RSASSA-PSS-SHA-256
-        ├── signed attributes
-            ├── content type: application/vnd.cncf.notary.payload.v1+json
-            ├── signing scheme: notary.signingAuthority.x509
-            ├── signing time: Fri Jun 23 22:04:01 2023
-            ├── expiry: Sat Jun 29 22:04:01 2024
-            ├── io.cncf.notary.verificationPlugin: com.example.nv2plugin     
-        ├── unsigned attributes
-            ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)> 
-            ├── io.cncf.notary.signingAgent: notation/1.0.0   
-        ├── certificates
-            ├── SHA1 fingerprint: 68C15B4C98AD91E051EE5AF5F524A8729040B1D
-                ├── issued to: wabbit-com Software
-                ├── issued by: wabbit-com Software Root Certificate Authority
-                ├── expiry: Sun Jul 06 20:50:17 2025
-            ├── SHA1 fingerprint: 4ACC2147712B3C555B1C96CFCC00215403TE011C
-                ├── issued to: wabbit-com Software Code Signing PCA
-                ├── issued by: wabbit-com Software Root Certificate Authority
-                ├── expiry: Sun Jul 06 20:50:17 2025
-            ├── SHA1 fingerprint: A4YA1205512B3C886B1C96AAEC89984914DC012A
-                ├── issued to: wabbit-com Software Root Certificate Authority
-                ├── issued by: wabbit-com Software Root Certificate Authority
-                ├── expiry: Sat Jun 23 22:04:01 2035
+        |   ├── SHA1 fingerprint: 68C15B4C98AD91E051EE5AF5F524A8729040B1D
+        |   |   ├── issued to: wabbit-com Software
+        |   |   ├── issued by: wabbit-com Software Root Certificate Authority
+        |   |   └── expiry: Sun Jul 06 20:50:17 2025
+        |   ├── SHA1 fingerprint: 4ACC2147712B3C555B1C96CFCC00215403TE011C
+        |   |   ├── issued to: wabbit-com Software Code Signing PCA
+        |   |   ├── issued by: wabbit-com Software Root Certificate Authority
+        |   |   └── expiry: Sun Jul 06 20:50:17 2025
+        |   └── SHA1 fingerprint: A4YA1205512B3C886B1C96AAEC89984914DC012A
+        |       ├── issued to: wabbit-com Software Root Certificate Authority
+        |       ├── issued by: wabbit-com Software Root Certificate Authority
+        |       └── expiry: Sat Jun 23 22:04:01 2035
         └── signed artifact 
             ├── media type: application/vnd.oci.image.manifest.v1+json
             ├── digest: sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380ee9088f7ace2eaab9
@@ -209,7 +209,7 @@ An example output:
   "signatures": [
     {
       "digest": "sha256:73c803930ea3ba1e54bc25c2bdc53edd0284c62ed651fe7b00369da519a33",
-      "signingAlgorithm": "RSASSA-PSS-SHA-256",
+      "signatureAlgorithm": "RSASSA-PSS-SHA-256",
       "signedAttributes": {
         "contentType": "application/vnd.cncf.notary.payload.v1+json",
         "signingScheme": "notary.default.x509",
@@ -229,19 +229,19 @@ An example output:
           "SHA1Fingerprint": "E8C15B4C98AD91E051EE5AF5F524A8729050B2A",
           "issuedTo": "wabbit-com Software",
           "issuedBy": "wabbit-com Software Root Certificate Authority",
-          "expires": "Sun Jul 06 20:50:17 2025"
+          "expiry": "Sun Jul 06 20:50:17 2025"
         },
         {
           "SHA1Fingerprint": "5DCC2147712B3C555B1C96CFCC00215403TF044D",
           "issuedTo": "wabbit-com Software Code Signing PCA",
           "issuedBy": "wabbit-com Software Root Certificate Authority",
-          "expires": "Sun Jul 06 20:50:17 2025"
+          "expiry": "Sun Jul 06 20:50:17 2025"
         },
         {
           "SHA1Fingerprint": "1GYA3107712B3C886B1C96AAEC89984914DC0A5A",
           "issuedTo": "wabbit-com Software Root Certificate Authority",
           "issuedBy": "wabbit-com Software Root Certificate Authority",
-          "expires": "Sat Jun 23 22:04:01 2035"
+          "expiry": "Sat Jun 23 22:04:01 2035"
         }
       ],
       "signedArtifact": {
@@ -252,7 +252,7 @@ An example output:
     },
     {
       "digest": "sha256:73c803930ea3ba1e54bc25c2bdc53edd0284c62ed651fe7b00369da519a3c333",
-      "signingAlgorithm": "RSASSA-PSS-SHA-256",
+      "signatureAlgorithm": "RSASSA-PSS-SHA-256",
       "signedAttributes": {
         "contentType": "application/vnd.cncf.notary.payload.v1+json",
         "signingScheme": " notary.signingAuthority.x509",
@@ -269,7 +269,7 @@ An example output:
           "SHA1Fingerprint": "68C15B4C98AD91E051EE5AF5F524A8729040B1D",
           "issuedTo": "wabbit-com Software",
           "issuedBy": "wabbit-com Software Root Certificate Authority",
-          "expires": "Sun Jul 06 20:50:17 2025"
+          "expiry": "Sun Jul 06 20:50:17 2025"
         },
         {
           "SHA1Fingerprint": "4ACC2147712B3C555B1C96CFCC00215403TE011C",
@@ -281,7 +281,7 @@ An example output:
           "SHA1Fingerprint": "A4YA1205512B3C886B1C96AAEC89984914DC012A",
           "issuedTo": "wabbit-com Software Root Certificate Authority",
           "issuedBy": "wabbit-com Software Root Certificate Authority",
-          "expires": "Sat Jun 23 22:04:01 2035"
+          "expiry": "Sat Jun 23 22:04:01 2035"
         }
       ],
       "signedArtifact": {

--- a/specs/commandline/inspect.md
+++ b/specs/commandline/inspect.md
@@ -8,20 +8,20 @@ Upon successful execution, both the digest of the signed artifact and the digest
 
 ```shell
 <registry>/<repository>@<digest>
-└──application/vnd.cncf.notary.signature
-  ├──<digest_of_signature_manifest>
-    ├──<signingAlgorithm>
-    ├──<signedAttributes>
-    ├──<userDefinedAttributes>
-    ├──<unsignedAttributes>
-    ├──<certificates>
-    └──<payload>
-  ├──<digest_of_signature_manifest>
-    ├──<signingAlgorithm>
-    ├──<signedAttributes>
-    ├──<unsignedAttributes>
-    ├──<certificates>
-    └──<payload>
+└── application/vnd.cncf.notary.signature
+    ├── <digest_of_signature_manifest>
+        ├── <signing algorithm>
+        ├── <signed attributes>
+        ├── <user defined attributes>
+        ├── <unsigned attributes>
+        ├── <certificates>
+        └── <signed artifact>
+    ├── <digest_of_signature_manifest>
+        ├── <signing algorithm>
+        ├── <signed attributes>
+        ├── <unsigned attributes>
+        ├── <certificates>
+        └── <signed artifact>
 ```
 
 ## Outline
@@ -59,58 +59,57 @@ notation inspect localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7da
 An example output:
 ```shell
 localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
-└──application/vnd.cncf.notary.signature
+└── application/vnd.cncf.notary.signature
     ├── sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-      ├──signingAlgorithm: RSASSA-PSS-SHA-256
-      ├──signedAttributes
-            ├──contentType: application/vnd.cncf.notary.payload.v1+json
-            ├──signingScheme: notary.default.x509
-            ├──signingTime: 2022-04-06T07:01:20Z
-            ├──expiry: 2022-10-06T07:01:20Z
-            ├──io.cncf.notary.verificationPlugin: com.example.nv2plugin     //extended attributes to support plugins
-      ├──userDefinedAttributes
-            ├──io.wabbit-networks.buildId: 123                              //user defined payload annotations.
-      ├──unsignedAttributes
-            ├──io.cncf.notary.timestampSignature: <Base64(TimeStampToken)>  //how TSA response (time stamp token) is represented.
-            ├──io.cncf.notary.signingAgent: notation/1.0.0                  //provides the identifier of a client (e.g. Notation) that produced the signature
-      ├──certificates
-            ├──SHA1Fingerprint: 2f1cc5b8455381cdefac83b4bd305b789cc9c16e
-              ├──issuedTo: Microsoft Root Certificate Authority 2010
-              ├──issuedBy: Microsoft Root Certificate Authority 2010
-              ├──expires: Sat Jun 23 22:04:01 2035
-            ├──SHA1Fingerprint: 8BFE3107712B3C886B1C96AAEC89984914DC9B6B
-              ├──issuedTo: Microsoft Code Signing PCA 2010
-              ├──issuedBy: Microsoft Root Certificate Authority 2010
-              ├──expires: Sun Jul 06 20:50:17 2025
-      └──payload                                                           //descriptor of the target artifact manifest that is signed.
-            ├──mediaType: application/vnd.oci.image.manifest.v1+json
-            ├──digest: sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
-            └──size: 16724
-      
+        ├── signing algorithm: RSASSA-PSS-SHA-256
+        ├── signed attributes
+            ├── content type: application/vnd.cncf.notary.payload.v1+json
+            ├── signing scheme: notary.default.x509
+            ├── signing time: Fri Jun 23 22:04:01 2023
+            ├── expiry: Sat Jun 29 22:04:01 2024
+            ├── io.cncf.notary.verificationPlugin: com.example.nv2plugin    //extended attributes to support plugins
+        ├── user defined attributes
+            ├── io.wabbit-networks.buildId: 123                             //user defined payload annotations.
+        ├── unsigned attributes
+            ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)> //TSA response (time stamp token) is represented.
+            ├── io.cncf.notary.signingAgent: notation/1.0.0                 //identifier of a client that produced the signature
+        ├── certificates
+            ├── SHA1 fingerprint: 2f1cc5b8455381cdefac83b4bd305b789cc9c16e
+                ├── issued to: Microsoft Root Certificate Authority 2010
+                ├── issued by: Microsoft Root Certificate Authority 2010
+                ├── expiry: Sat Jun 29 22:04:01 2024
+            ├── SHA1 fingerprint: 8BFE3107712B3C886B1C96AAEC89984914DC9B6B
+                ├── issued to: Microsoft Code Signing PCA 2010
+                ├── issued by: Microsoft Root Certificate Authority 2010
+                ├── expiry: Sat Jun 29 22:04:01 2024
+        └── signed artifact                                                 //descriptor of the target artifact manifest that is signed.
+            ├── media type: application/vnd.oci.image.manifest.v1+json
+            ├── digest: sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+            └── size: 16724
     ├── sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-      ├──signingAlgorithm: RSASSA-PSS-SHA-256
-      ├──signedAttributes
-            ├──contentType: application/vnd.cncf.notary.payload.v1+json
-            ├──signingScheme: notary.signingAuthority.x509
-            ├──signingTime: 2022-04-06T07:01:20Z
-            ├──expiry: 2022-10-06T07:01:20Z
-            ├──io.cncf.notary.verificationPlugin: com.example.nv2plugin                  
-      ├──unsignedAttributes
-            ├──io.cncf.notary.timestampSignature: <Base64(TimeStampToken)>
-            ├──io.cncf.notary.signingAgent: notation/1.0.0                  
-      ├──certificates
-            ├──SHA1Fingerprint: 2f1rr5b8455381frdajc83b4bd305b743cc9513u
-              ├──issuedTo: Microsoft Root Certificate Authority 2010
-              ├──issuedBy: Microsoft Root Certificate Authority 2010
-              ├──expires: Sat Jun 23 22:04:01 2035
-            ├──SHA1Fingerprint: 8BFE3107712B3C886B1C96AAEC89984914DC9B6B
-              ├──issuedTo: Microsoft Code Signing PCA 2010
-              ├──issuedBy: Microsoft Root Certificate Authority 2010
-              ├──expires: Sun Jul 06 20:50:17 2025
-      └──payload 
-            ├──mediaType: application/vnd.oci.image.manifest.v1+json
-            ├──digest: sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
-            └──size: 16724
+        ├── signing algorithm: RSASSA-PSS-SHA-256
+        ├── signed attributes
+            ├── content type: application/vnd.cncf.notary.payload.v1+json
+            ├── signing scheme: notary.signingAuthority.x509
+            ├── signing time: Fri Jun 23 22:04:01 2023
+            ├── expiry: Sat Jun 29 22:04:01 2024
+            ├── io.cncf.notary.verificationPlugin: com.example.nv2plugin                  
+        ├── unsigned attributes
+            ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)>
+            ├── io.cncf.notary.signingAgent: notation/1.0.0                  
+        ├── certificates
+            ├── SHA1 fingerprint: 2f1rr5b8455381frdajc83b4bd305b743cc9513u
+                ├── issued to: Microsoft Root Certificate Authority 2010
+                ├── issued by: Microsoft Root Certificate Authority 2010
+                ├── expiry: Fri Jun 23 22:04:01 2023
+            ├── SHA1 fingerprint: 8BFE3107712B3C886B1C96AAEC89984914DC9B6B
+                ├── issued to: Microsoft Code Signing PCA 2010
+                ├── issued by: Microsoft Root Certificate Authority 2010
+                ├── expiry: Sun Jul 06 20:50:17 2025
+        └── signed attributes 
+            ├── media type: application/vnd.oci.image.manifest.v1+json
+            ├── digest: sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+            └── size: 16724
 ```
 
 ## Usage signatures on an OCI artifact identified by a tag
@@ -132,58 +131,57 @@ Warning: The resolved digest may not point to the same signed artifact, since ta
 
 ```shell
 localhost:5000/net-monitor@sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380ee9088f7ace2eaab9
-└──application/vnd.cncf.notary.signature
+└── application/vnd.cncf.notary.signature
     ├── sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-      ├──signingAlgorithm: RSASSA-PSS-SHA-256
-      ├──signedAttributes
-            ├──contentType: application/vnd.cncf.notary.payload.v1+json
-            ├──signingScheme: notary.default.x509
-            ├──signingTime: 2022-04-06T07:01:20Z
-            ├──expiry: 2022-10-06T07:01:20Z
-            ├──io.cncf.notary.verificationPlugin: com.example.nv2plugin
-      ├──userDefinedAttributes
-            ├──io.wabbit-networks.buildId: 123
-      ├──unsignedAttributes
-            ├──io.cncf.notary.timestampSignature: <Base64(TimeStampToken)>
-            ├──io.cncf.notary.signingAgent: notation/1.0.0
-      ├──certificates
-            ├──SHA1Fingerprint: 2f1cc5b8455381cdefac83b4bd305b789cc9c16e
-              ├──issuedTo: Microsoft Root Certificate Authority 2010
-              ├──issuedBy: Microsoft Root Certificate Authority 2010
-              ├──expires: Sat Jun 23 22:04:01 2035
-            ├──SHA1Fingerprint: 8BFE3107712B3C886B1C96AAEC89984914DC9B6B
-              ├──issuedTo: Microsoft Code Signing PCA 2010
-              ├──issuedBy: Microsoft Root Certificate Authority 2010
-              ├──expires: Sun Jul 06 20:50:17 2025
-      └──payload 
-            ├──mediaType: application/vnd.oci.image.manifest.v1+json
-            ├──digest: sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380ee9088f7ace2eaab9
-            └──size: 16724
-      
+        ├── signing algorithm: RSASSA-PSS-SHA-256
+        ├── signed attributes
+            ├── content type: application/vnd.cncf.notary.payload.v1+json
+            ├── signing scheme: notary.default.x509
+            ├── signing time: Fri Jun 23 22:04:01 2023
+            ├── expiry: Sat Jun 29 22:04:01 2024
+            ├── io.cncf.notary.verificationPlugin: com.example.nv2plugin
+        ├── user defined attributes
+            ├── io.wabbit-networks.buildId: 123
+        ├── unsigned attributes
+            ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)>
+            ├── io.cncf.notary.signingAgent: notation/1.0.0
+        ├── certificates
+            ├── SHA1 fingerprint: 2f1cc5b8455381cdefac83b4bd305b789cc9c16e
+                ├── issued to: Microsoft Root Certificate Authority 2010
+                ├── issued by: Microsoft Root Certificate Authority 2010
+                ├── expiry: Sat Jun 23 22:04:01 2035
+            ├── SHA1 fingerprint: 8BFE3107712B3C886B1C96AAEC89984914DC9B6B
+                ├── issued to: Microsoft Code Signing PCA 2010
+                ├── issued by: Microsoft Root Certificate Authority 2010
+                ├── expiry: Sun Jul 06 20:50:17 2025
+        └── signed attribute 
+            ├── media type: application/vnd.oci.image.manifest.v1+json
+            ├── digest: sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380ee9088f7ace2eaab9
+            └── size: 16724
     ├── sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-      ├──signingAlgorithm: RSASSA-PSS-SHA-256
-      ├──signedAttributes
-            ├──contentType: application/vnd.cncf.notary.payload.v1+json
-            ├──signingScheme: notary.signingAuthority.x509
-            ├──signingTime: 2022-04-06T07:01:20Z
-            ├──expiry: 2022-10-06T07:01:20Z
-            ├──io.cncf.notary.verificationPlugin: com.example.nv2plugin     
-      ├──unsignedAttributes
-            ├──io.cncf.notary.timestampSignature: <Base64(TimeStampToken)> 
-            ├──io.cncf.notary.signingAgent: notation/1.0.0   
-      ├──certificates
-            ├──SHA1Fingerprint: 2f1rr5b8455381frdajc83b4bd305b743cc9513u
-              ├──issuedTo: Microsoft Root Certificate Authority 2010
-              ├──issuedBy: Microsoft Root Certificate Authority 2010
-              ├──expires: Sat Jun 23 22:04:01 2035
-            ├──SHA1Fingerprint: 8BFE3107712B3C886B1C96AAEC89984914DC9B6B
-              ├──issuedTo: Microsoft Code Signing PCA 2010
-              ├──issuedBy: Microsoft Root Certificate Authority 2010
-              ├──expires: Sun Jul 06 20:50:17 2025
-      └──payload 
-            ├──mediaType: application/vnd.oci.image.manifest.v1+json
-            ├──digest: sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380ee9088f7ace2eaab9
-            └──size: 16724
+        ├── signing algorithm: RSASSA-PSS-SHA-256
+        ├── signed attributes
+            ├── content type: application/vnd.cncf.notary.payload.v1+json
+            ├── signing scheme: notary.signingAuthority.x509
+            ├── signing time: Fri Jun 23 22:04:01 2023
+            ├── expiry: Sat Jun 29 22:04:01 2024
+            ├── io.cncf.notary.verificationPlugin: com.example.nv2plugin     
+        ├── unsigned attributes
+            ├── io.cncf.notary.timestampSignature: <Base64(TimeStampToken)> 
+            ├── io.cncf.notary.signingAgent: notation/1.0.0   
+        ├── certificates
+            ├── SHA1 fingerprint: 2f1rr5b8455381frdajc83b4bd305b743cc9513u
+                ├── issued to: Microsoft Root Certificate Authority 2010
+                ├── issued by: Microsoft Root Certificate Authority 2010
+                ├── expiry: Sat Jun 23 22:04:01 2035
+            ├── SHA1 fingerprint: 8BFE3107712B3C886B1C96AAEC89984914DC9B6B
+                ├── issued to: Microsoft Code Signing PCA 2010
+                ├── issued by: Microsoft Root Certificate Authority 2010
+                ├── expiry: Sun Jul 06 20:50:17 2025
+        └── signed artifact 
+            ├── media type: application/vnd.oci.image.manifest.v1+json
+            ├── digest: sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380ee9088f7ace2eaab9
+            └── size: 16724
 ```
 ## Inspect signatures on the supplied OCI artifact with an example of JSON Output
 
@@ -201,8 +199,8 @@ An example output:
       "signedAttributes": {
         "contentType": "application/vnd.cncf.notary.payload.v1+json",
         "signingScheme": "notary.default.x509",
-        "signingTime": "2022-04-06T07:01:20Z",
-        "expiry": "2022-10-06T07:01:20Z",
+        "signingTime": "Sun Feb 06 20:50:17 2022",
+        "expiry": "Sun Feb 06 20:50:17 2023",
         "io.cncf.notary.verificationPlugin": "com.example.nv2plugin"
       },
       "userDefinedAttributes": {
@@ -226,7 +224,7 @@ An example output:
           "expires": "Sun Jul 06 20:50:17 2025"
         }
       ],
-      "payload": {
+      "signedArtifact": {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "digest": "sha256:73c803930ea3ba1e54bc25c2bdc53edd0284c62ed651fe7b00369da519a3c333",
         "size": "16724"
@@ -238,8 +236,8 @@ An example output:
       "signedAttributes": {
         "contentType": "application/vnd.cncf.notary.payload.v1+json",
         "signingScheme": " notary.signingAuthority.x509",
-        "signingTime": "2022-04-06T07:01:20Z",
-        "expiry": "2022-10-06T07:01:20Z",
+        "signingTime": "Sun Mar 05 20:50:17 2023",
+        "expiry": "Tue Mar 06 20:50:17 2023",
         "io.cncf.notary.verificationPlugin": "com.example.nv2plugin"
       },
       "unsignedAttributes": {
@@ -260,7 +258,7 @@ An example output:
           "expires": "Sun Jul 06 20:50:17 2025"
         }
       ],
-      "payload": {
+      "signedArtifact": {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "digest": "sha256:73c803930ea3ba1e54bc25c2bdc53edd0284c62ed651fe7b00369da519a3c333",
         "size": "16724"

--- a/specs/commandline/inspect.md
+++ b/specs/commandline/inspect.md
@@ -58,6 +58,7 @@ notation inspect localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da1ac
 
 An example output:
 ```shell
+Inspecting all signatures for signed artifact
 localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac4efe37a5380ee9088f7ace2efcde9
 └── application/vnd.cncf.notary.signature
     ├── sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -136,6 +137,7 @@ Warning: The resolved digest may not point to the same signed artifact, since ta
 ```
 
 ```shell
+Inspecting all signatures for signed artifact
 localhost:5000/net-monitor@sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380ee9088f7ace2eaab9
 └── application/vnd.cncf.notary.signature
     ├── sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -206,6 +208,7 @@ notation inspect localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52da7dabf
 An example output:
 ```jsonc
 {
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
   "signatures": [
     {
       "digest": "sha256:73c803930ea3ba1e54bc25c2bdc53edd0284c62ed651fe7b00369da519a33",

--- a/specs/commandline/inspect.md
+++ b/specs/commandline/inspect.md
@@ -1,0 +1,271 @@
+# notation inspect
+
+## Description
+
+Use `notation inspect` command to inspect all the signatures associated with signed artifact in a human readable format.
+
+Upon successful execution, both the digest of the signed artifact and the digests of signatures manifest along with their properties associated with the signed artifact are printed in the following format:
+
+```shell
+<registry>/<repository>@<digest>
+└──application/vnd.cncf.notary.signature
+  ├──<digest_of_signature_manifest>
+    ├──<signingAlgorithm>
+    ├──<signedAttributes>
+    ├──<userDefinedAttributes>
+    ├──<unsignedAttributes>
+    ├──<certificates>
+    └──<payload>
+  ├──<digest_of_signature_manifest>
+    ├──<signingAlgorithm>
+    ├──<signedAttributes>
+    ├──<unsignedAttributes>
+    ├──<certificates>
+    └──<payload>
+```
+
+## Outline
+
+```text
+Inspect all signatures with the signed artifact.
+
+Usage:
+    notation inspect [flags] <reference>
+  
+Flags:
+   -h, --help              help for describing the signature
+   -o, --output json       output on command line sets the output to json
+   -p, --password string   password for registry operations (default to $NOTATION_PASSWORD if not specified)
+       --plain-http        registry access via plain HTTP
+   -u, --username string   username for registry operations (default to $NOTATION_USERNAME if not specified)
+```
+
+## Usage
+
+### Display the details of all the listed signatures and its associated certificate properties of the signed container image
+
+
+```text
+notation inspect [flags] <registry>/<repository>@<digest>
+```
+
+## Inspect signatures on the supplied OCI artifact identified by the digest
+
+```shell
+# Prerequisites: Signatures are stored in a registry referencing the signed OCI artifact
+notation inspect localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+```
+
+An example output:
+```shell
+localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+└──application/vnd.cncf.notary.signature
+    ├── sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      ├──signingAlgorithm: RSASSA-PSS-SHA-256
+      ├──signedAttributes
+            ├──contentType: application/vnd.cncf.notary.payload.v1+json
+            ├──signingScheme: notary.default.x509
+            ├──signingTime: 2022-04-06T07:01:20Z
+            ├──expiry: 2022-10-06T07:01:20Z
+            ├──io.cncf.notary.verificationPlugin: com.example.nv2plugin     //extended attributes to support plugins
+      ├──userDefinedAttributes
+            ├──io.wabbit-networks.buildId: 123                              //user defined payload annotations.
+      ├──unsignedAttributes
+            ├──io.cncf.notary.timestampSignature: <Base64(TimeStampToken)>  //how TSA response (time stamp token) is represented.
+            ├──io.cncf.notary.signingAgent: notation/1.0.0                  //provides the identifier of a client (e.g. Notation) that produced the signature
+      ├──certificates
+            ├──SHA1Fingerprint: 2f1cc5b8455381cdefac83b4bd305b789cc9c16e
+              ├──issuedTo: Microsoft Root Certificate Authority 2010
+              ├──issuedBy: Microsoft Root Certificate Authority 2010
+              ├──expires: Sat Jun 23 22:04:01 2035
+            ├──SHA1Fingerprint: 8BFE3107712B3C886B1C96AAEC89984914DC9B6B
+              ├──issuedTo: Microsoft Code Signing PCA 2010
+              ├──issuedBy: Microsoft Root Certificate Authority 2010
+              ├──expires: Sun Jul 06 20:50:17 2025
+      └──payload                                                           //descriptor of the target artifact manifest that is signed.
+            ├──mediaType: application/vnd.oci.image.manifest.v1+json
+            ├──digest: sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+            └──size: 16724
+      
+    ├── sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      ├──signingAlgorithm: RSASSA-PSS-SHA-256
+      ├──signedAttributes
+            ├──contentType: application/vnd.cncf.notary.payload.v1+json
+            ├──signingScheme: notary.signingAuthority.x509
+            ├──signingTime: 2022-04-06T07:01:20Z
+            ├──expiry: 2022-10-06T07:01:20Z
+            ├──io.cncf.notary.verificationPlugin: com.example.nv2plugin                  
+      ├──unsignedAttributes
+            ├──io.cncf.notary.timestampSignature: <Base64(TimeStampToken)>
+            ├──io.cncf.notary.signingAgent: notation/1.0.0                  
+      ├──certificates
+            ├──SHA1Fingerprint: 2f1rr5b8455381frdajc83b4bd305b743cc9513u
+              ├──issuedTo: Microsoft Root Certificate Authority 2010
+              ├──issuedBy: Microsoft Root Certificate Authority 2010
+              ├──expires: Sat Jun 23 22:04:01 2035
+            ├──SHA1Fingerprint: 8BFE3107712B3C886B1C96AAEC89984914DC9B6B
+              ├──issuedTo: Microsoft Code Signing PCA 2010
+              ├──issuedBy: Microsoft Root Certificate Authority 2010
+              ├──expires: Sun Jul 06 20:50:17 2025
+      └──payload 
+            ├──mediaType: application/vnd.oci.image.manifest.v1+json
+            ├──digest: sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+            └──size: 16724
+```
+
+## Usage signatures on an OCI artifact identified by a tag
+
+```text
+`Tags` are mutable, but `Digests` uniquely and immutably identify an artifact. If a tag is used to identify a signed artifact, notation resolves the tag to the `digest` first.
+```
+
+```shell
+# Prerequisites: Signatures are stored in a registry referencing the signed OCI artifact
+notation inspect localhost:5000/net-monitor:v1
+```
+
+An example output:
+```text
+Resolved artifact tag `v1` to digest `sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9` before inspect.
+Warning: The resolved digest may not point to the same signed artifact, since tags are mutable.
+```
+
+```shell
+localhost:5000/net-monitor@sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380ee9088f7ace2eaab9
+└──application/vnd.cncf.notary.signature
+    ├── sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      ├──signingAlgorithm: RSASSA-PSS-SHA-256
+      ├──signedAttributes
+            ├──contentType: application/vnd.cncf.notary.payload.v1+json
+            ├──signingScheme: notary.default.x509
+            ├──signingTime: 2022-04-06T07:01:20Z
+            ├──expiry: 2022-10-06T07:01:20Z
+            ├──io.cncf.notary.verificationPlugin: com.example.nv2plugin
+      ├──userDefinedAttributes
+            ├──io.wabbit-networks.buildId: 123
+      ├──unsignedAttributes
+            ├──io.cncf.notary.timestampSignature: <Base64(TimeStampToken)>
+            ├──io.cncf.notary.signingAgent: notation/1.0.0
+      ├──certificates
+            ├──SHA1Fingerprint: 2f1cc5b8455381cdefac83b4bd305b789cc9c16e
+              ├──issuedTo: Microsoft Root Certificate Authority 2010
+              ├──issuedBy: Microsoft Root Certificate Authority 2010
+              ├──expires: Sat Jun 23 22:04:01 2035
+            ├──SHA1Fingerprint: 8BFE3107712B3C886B1C96AAEC89984914DC9B6B
+              ├──issuedTo: Microsoft Code Signing PCA 2010
+              ├──issuedBy: Microsoft Root Certificate Authority 2010
+              ├──expires: Sun Jul 06 20:50:17 2025
+      └──payload 
+            ├──mediaType: application/vnd.oci.image.manifest.v1+json
+            ├──digest: sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380ee9088f7ace2eaab9
+            └──size: 16724
+      
+    ├── sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      ├──signingAlgorithm: RSASSA-PSS-SHA-256
+      ├──signedAttributes
+            ├──contentType: application/vnd.cncf.notary.payload.v1+json
+            ├──signingScheme: notary.signingAuthority.x509
+            ├──signingTime: 2022-04-06T07:01:20Z
+            ├──expiry: 2022-10-06T07:01:20Z
+            ├──io.cncf.notary.verificationPlugin: com.example.nv2plugin     
+      ├──unsignedAttributes
+            ├──io.cncf.notary.timestampSignature: <Base64(TimeStampToken)> 
+            ├──io.cncf.notary.signingAgent: notation/1.0.0   
+      ├──certificates
+            ├──SHA1Fingerprint: 2f1rr5b8455381frdajc83b4bd305b743cc9513u
+              ├──issuedTo: Microsoft Root Certificate Authority 2010
+              ├──issuedBy: Microsoft Root Certificate Authority 2010
+              ├──expires: Sat Jun 23 22:04:01 2035
+            ├──SHA1Fingerprint: 8BFE3107712B3C886B1C96AAEC89984914DC9B6B
+              ├──issuedTo: Microsoft Code Signing PCA 2010
+              ├──issuedBy: Microsoft Root Certificate Authority 2010
+              ├──expires: Sun Jul 06 20:50:17 2025
+      └──payload 
+            ├──mediaType: application/vnd.oci.image.manifest.v1+json
+            ├──digest: sha256:ca5427b5567d3e06a72e52d7da7dabfac484efe37a5380ee9088f7ace2eaab9
+            └──size: 16724
+```
+## Inspect signatures on the supplied OCI artifact with an example of JSON Output
+
+```shell
+notation inspect localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9 -o json
+```
+
+An example output:
+```jsonc
+{
+  "signatures": [
+    {
+      "digest": "sha256:73c803930ea3ba1e54bc25c2bdc53edd0284c62ed651fe7b00369da519a3c333",
+      "signingAlgorithm": "RSASSA-PSS-SHA-256",
+      "signedAttributes": {
+        "contentType": "application/vnd.cncf.notary.payload.v1+json",
+        "signingScheme": "notary.default.x509",
+        "signingTime": "2022-04-06T07:01:20Z",
+        "expiry": "2022-10-06T07:01:20Z",
+        "io.cncf.notary.verificationPlugin": "com.example.nv2plugin"
+      },
+      "userDefinedAttributes": {
+        "io.wabbit-networks.buildId": "123"
+      },
+      "unsignedAttributes": {
+        "io.cncf.notary.timestampSignature": "<Base64(TimeStampToken)>",
+        "io.cncf.notary.signingAgent": "notation/1.0.0"
+      },
+      "certificates": [
+        {
+          "SHA1Fingerprint": "8BFE3107712B3C886B1C96AAEC89984914DC9B6B",
+          "issuedTo": "Microsoft Root Certificate Authority 2010",
+          "issuedBy": "Microsoft Root Certificate Authority 2010",
+          "expires": "Sun Jul 06 20:50:17 2025"
+        },
+        {
+          "SHA1Fingerprint": "8BFE3107712B3C886B1C96AAEC89984914DC9B6B",
+          "issuedTo": "Microsoft Code Signing PCA 2010",
+          "issuedBy": "Microsoft Root Certificate Authority 2010",
+          "expires": "Sun Jul 06 20:50:17 2025"
+        }
+      ],
+      "payload": {
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "digest": "sha256:73c803930ea3ba1e54bc25c2bdc53edd0284c62ed651fe7b00369da519a3c333",
+        "size": "16724"
+      }
+    },
+    {
+      "digest": "sha256:73c803930ea3ba1e54bc25c2bdc53edd0284c62ed651fe7b00369da519a3c333",
+      "signingAlgorithm": "RSASSA-PSS-SHA-256",
+      "signedAttributes": {
+        "contentType": "application/vnd.cncf.notary.payload.v1+json",
+        "signingScheme": " notary.signingAuthority.x509",
+        "signingTime": "2022-04-06T07:01:20Z",
+        "expiry": "2022-10-06T07:01:20Z",
+        "io.cncf.notary.verificationPlugin": "com.example.nv2plugin"
+      },
+      "unsignedAttributes": {
+        "io.cncf.notary.timestampSignature": "<Base64(TimeStampToken)>",
+        "io.cncf.notary.signingAgent": "notation/1.0.0"
+      },
+      "certificates": [
+        {
+          "SHA1Fingerprint": "8BFE3107712B3C886B1C96AAEC89984914DC9B6B",
+          "issuedTo": "Microsoft Code Signing PCA 2010",
+          "issuedBy": "Microsoft Root Certificate Authority 2010",
+          "expires": "Sun Jul 06 20:50:17 2025"
+        },
+        {
+          "SHA1Fingerprint": "8BFE3107712B3C886B1C96AAEC89984914DC9B6B",
+          "issuedTo": "Microsoft Code Signing PCA 2010",
+          "issuedBy": "Microsoft Root Certificate Authority 2010",
+          "expires": "Sun Jul 06 20:50:17 2025"
+        }
+      ],
+      "payload": {
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "digest": "sha256:73c803930ea3ba1e54bc25c2bdc53edd0284c62ed651fe7b00369da519a3c333",
+        "size": "16724"
+      }
+    }
+  ]
+}
+```

--- a/specs/notation-cli.md
+++ b/specs/notation-cli.md
@@ -4,17 +4,19 @@ This spec contains reference information on using notation commands. Each comman
 
 ## Notation Commands
 
-| Command                                     | Description                            |
-| ------------------------------------------- | -------------------------------------- |
-| [certificate](./commandline/certificate.md) | Manage certificates in trust store     |
-| [key](./commandline/key.md)                 | Manage keys used for signing           |
-| [list](./commandline/list.md)               | List signatures of the signed artifact |
-| [login](./commandline/login.md)             | Login to registries                    |
-| [logout](./commandline/logout.md)           | Log out from the logged in registries  |
-| [plugin](./commandline/plugin.md)           | Manage plugins                         |
-| [sign](./commandline/sign.md)               | Sign artifacts                         |
-| [verify](./commandline/verify.md)           | Verify artifacts                       |
-| [version](./commandline/version.md)         | Print the version of notation CLI      |
+| Command                                     | Description                               |
+| ------------------------------------------- | ----------------------------------------- |
+| [certificate](./commandline/certificate.md) | Manage certificates in trust store        |
+| [inspect](./commandline/inspect.md)         | Inspect signatures                        |
+| [key](./commandline/key.md)                 | Manage keys used for signing              |
+| [list](./commandline/list.md)               | List signatures of the signed artifact    |
+| [login](./commandline/login.md)             | Login to registries                       |
+| [logout](./commandline/logout.md)           | Log out from the logged in registries     |
+| [plugin](./commandline/plugin.md)           | Manage plugins                            |
+| [sign](./commandline/sign.md)               | Sign artifacts                            |
+| [verify](./commandline/verify.md)           | Verify artifacts                          |
+| [version](./commandline/version.md)         | Print the version of notation CLI         |
+
 
 ## Notation Outline
 
@@ -26,6 +28,7 @@ Usage:
 
 Available Commands:
   certificate Manage certificates in trust store
+  inspect     Inspect all signatures associated with the signed artifact
   key         Manage keys used for signing
   list        List signatures of the signed artifact
   login       Login to registry


### PR DESCRIPTION
Use Case / Scenarios:

-     Troubleshooting
-     Auditing
-     If verification of the image digest / signature digest fails due to wrong certificate configuration, user will execute the inspect command to extract the certificate thumb print, a hash of a certificate which is a unique identifier for certificates.
