### PR TITLE
Add Yi Zha as notation maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @notaryproject/notation-maintainers
+* @yizha1

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,1 @@
+Yi Zha <yizha1@microsoft.com> (@yizha1)


### PR DESCRIPTION
Add Yi Zha as a seed maintainer of Notation based on [their](https://github.com/notaryproject/notation/commits?author=yizha1) activity as per - https://github.com/notaryproject/notation/issues/514

Signed-off-by: Lachlan Evenson <lachlan.evenson@microsoft.com>