### PR TITLE
fix: optimize login `--password-stdin` flag behavior

### DIFF
--- a/cmd/notation/login.go
+++ b/cmd/notation/login.go
@@ -7,10 +7,12 @@ import (
 	"io"
 	"os"
 	"strings"
+	"syscall"
 
 	"github.com/notaryproject/notation/internal/cmd"
 	"github.com/notaryproject/notation/pkg/auth"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 	orasauth "oras.land/oras-go/v2/registry/remote/auth"
 )
 
@@ -108,11 +110,12 @@ func newCredentialFromInput(username, password string) orasauth.Credential {
 
 func readPassword(opts *loginOpts) error {
 	if opts.passwordStdin {
-		password, err := readLine()
+		fmt.Print("Enter password: ")
+		bytePass, err := term.ReadPassword(syscall.Stdin)
 		if err != nil {
 			return err
 		}
-		opts.Password = password
+		opts.Password = string(bytePass)
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
+	golang.org/x/term v0.2.0
 	oras.land/oras-go/v2 v2.0.0-rc.6
 )
 

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.2.0 h1:z85xZCsEl7bi/KwbNADeBYoOP0++7W1ipu+aGnpwzRM=
+golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Previously, when login with `--password-stdin` user needs to specify the EOF of the input by Ctrl+d and the password is shown on the screen, which is not an ideal behavior.

This PR fixed the issue by using term.ReadPassword() to hide the password and only read one line.

Signed-off-by: Junjie Gao <junjiegao@microsoft.com>