### PR TITLE
Add Milind Gokarn as notation maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @notaryproject/notation-maintainers
+* @gokarnm

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,1 @@
+Milind Gokarn <gokarnm@amazon.com> (@gokarnm)


### PR DESCRIPTION
Add Milind Gokarn as a seed maintainer of Notation based on their activity as per - https://github.com/notaryproject/notation/issues/514

Signed-off-by: vaninrao10 <111005862+vaninrao10@users.noreply.github.com>