### PR TITLE
Add Pritesh Bandi as notation maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @notaryproject/notation-maintainers
+* @priteshbandi

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,1 @@
+Pritesh Bandi <priteshbandi@gmail.com> (@priteshbandi)


### PR DESCRIPTION
Add Pritesh Bandi as a seed maintainer of Notation based on [their](https://github.com/notaryproject/notation/commits?author=priteshbandi) activity as per - https://github.com/notaryproject/notation/issues/514


Signed-off-by: vaninrao10 <111005862+vaninrao10@users.noreply.github.com>