### PR TITLE
Add Shiwei Zhang as notation maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @notaryproject/notation-maintainers
+* @shizhMSFT

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,1 @@
+Shiwei Zhang <shizh@microsoft.com> (@shizhMSFT)


### PR DESCRIPTION
Add Shiwei Zhang (@shizhMSFT) as a seed maintainer of `notation` based on [their](https://github.com/notaryproject/notation/commits?author=shizhMSFT) activity as per - https://github.com/notaryproject/notation/issues/514

Signed-off-by: Yi Zha <yizha1@microsoft.com>