### PR TITLE
Add Junjie Gao as notation maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @notaryproject/notation-maintainers
+* @JeyJeyGao

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,1 @@
+Junjie Gao <junjiegao@microsoft.com> (@JeyJeyGao)


### PR DESCRIPTION
Add Junjie Gao (@JeyJeyGao) as a seed maintainer of `notation` based on [their](https://github.com/notaryproject/notation/commits?author=JeyJeyGao) activity as per - https://github.com/notaryproject/notation/issues/514

Signed-off-by: Yi Zha <yizha1@microsoft.com>