### PR TITLE
Dont access value of default pointer if it is nil

### DIFF
--- a/cmd/notation/key.go
+++ b/cmd/notation/key.go
@@ -228,7 +228,9 @@ func deleteKeys(ctx context.Context, opts *keyDeleteOpts) error {
 	var deletedNames []string
 	var prevDefault string
 	exec := func(s *config.SigningKeys) error {
-		prevDefault = *s.Default
+		if s.Default != nil {
+			prevDefault = *s.Default
+		}
 		var err error
 		deletedNames, err = s.Remove(opts.names...)
 		if err != nil {


### PR DESCRIPTION
Don't access value of default pointer if it is nil. This is actually a bug(unable to delete key if defualt key is not present) fix.

Signed-off-by: Pritesh Bandi <pritesb@amazon.com>
