### PR TITLE
chore: update sign command descriptions to align with the spec

### DIFF
--- a/cmd/notation/sign.go
+++ b/cmd/notation/sign.go
@@ -84,7 +84,7 @@ Example - Sign an OCI artifact and use OCI image manifest to store the signature
 	opts.SecureFlagOpts.ApplyFlags(command.Flags())
 	cmd.SetPflagExpiry(command.Flags(), &opts.expiry)
 	cmd.SetPflagPluginConfig(command.Flags(), &opts.pluginConfig)
-	command.Flags().StringVar(&opts.signatureManifest, "signature-manifest", signatureManifestArtifact, "manifest type for signatures. options: artifact, image")
+	command.Flags().StringVar(&opts.signatureManifest, "signature-manifest", signatureManifestArtifact, "manifest type for signature. options: \"artifact\", \"image\"")
 	cmd.SetPflagUserMetadata(command.Flags(), &opts.userMetadata, cmd.PflagUserMetadataSignUsage)
 	return command
 }

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -23,7 +23,7 @@ var (
 
 	PflagSignatureFormat = &pflag.Flag{
 		Name:  "signature-format",
-		Usage: "signature envelope format, options: 'jws', 'cose'",
+		Usage: "signature envelope format, options: \"jws\", \"cose\"",
 	}
 	SetPflagSignatureFormat = func(fs *pflag.FlagSet, p *string) {
 		defaultSignatureFormat := envelope.JWS
@@ -75,9 +75,9 @@ var (
 		Name:      "user-metadata",
 		Shorthand: "m",
 	}
-	PflagUserMetadataSignUsage = "{key}={value} pairs that are added to the signature payload"
+	PflagUserMetadataSignUsage   = "{key}={value} pairs that are added to the signature payload"
 	PflagUserMetadataVerifyUsage = "user defined {key}={value} pairs that must be present in the signature for successful verification if provided"
-	SetPflagUserMetadata = func(fs *pflag.FlagSet, p *[]string, usage string) {
+	SetPflagUserMetadata         = func(fs *pflag.FlagSet, p *[]string, usage string) {
 		fs.StringArrayVarP(p, PflagUserMetadata.Name, PflagUserMetadata.Shorthand, nil, usage)
 	}
 )


### PR DESCRIPTION
After discussion with @yizha1, aligning with the spec in this [PR](https://github.com/notaryproject/notation/pull/540).

Signed-off-by: Patrick Zheng <patrickzheng@microsoft.com>