### PR TITLE
fix!: remove short commands

### DIFF
--- a/cmd/notation/key.go
+++ b/cmd/notation/key.go
@@ -87,7 +87,7 @@ func keyAddCommand(opts *keyAddOpts) *cobra.Command {
 		},
 	}
 	opts.LoggingFlagOpts.ApplyFlags(command.Flags())
-	command.Flags().StringVarP(&opts.plugin, "plugin", "p", "", "signing plugin name")
+	command.Flags().StringVar(&opts.plugin, "plugin", "", "signing plugin name")
 	command.MarkFlagRequired("plugin")
 
 	command.Flags().StringVar(&opts.id, "id", "", "key id (required if --plugin is set)")

--- a/specs/commandline/key.md
+++ b/specs/commandline/key.md
@@ -37,8 +37,8 @@ Flags:
       --default                     mark as default
   -h, --help                        help for add
       --id string                   key id (required if --plugin is set)
-  -p, --plugin string               signing plugin name
-  -c, --plugin-config stringArray   {key}={value} pairs that are passed as it is to a plugin, refer plugin's documentation to set appropriate values
+      --plugin string               signing plugin name
+      --plugin-config stringArray   {key}={value} pairs that are passed as it is to a plugin, refer plugin's documentation to set appropriate values
   -v, --verbose                     verbose mode
 ```
 


### PR DESCRIPTION
Fix commands short
* `-p` is used for password so shouldn't use it for plugin
* `-c` is not being used anywhere for `plugin-config`