### PR TITLE
fix: fix the CODEOWNERS format issue

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,13 +1,3 @@
-# Org-Level Owners (in alphabetical order)
-* @justincormack 
-* @niazfk
-* @stevelasker
-
 # Repo-Level Owners (in alphabetical order)
 # Note: This is only for the notaryproject/notation repo
-* @gokarnm
-* @JeyJeyGao
-* @patrickzheng200
-* @priteshbandi
-* @rgnote
-* @shizhMSFT
+* @gokarnm @JeyJeyGao @justincormack @niazfk @patrickzheng200 @priteshbandi @rgnote @shizhMSFT @stevelasker


### PR DESCRIPTION
Fix the format issue of CODEOWNERS file
- The owners should be listed on one line
- org-level owners are also added as sub-repo code owners

Signed-off-by: Yi Zha <yizha1@microsoft.com>