### PR TITLE
feat: simplify signing experience

### DIFF
--- a/cmd/notation/sign.go
+++ b/cmd/notation/sign.go
@@ -80,15 +80,12 @@ Example - Sign an OCI artifact and use OCI artifact manifest to store the signat
 		},
 	}
 	opts.LoggingFlagOpts.ApplyFlags(command.Flags())
-	opts.SignerFlagOpts.ApplyFlags(command.Flags())
+	opts.SignerFlagOpts.ApplyFlagsToCommand(command)
 	opts.SecureFlagOpts.ApplyFlags(command.Flags())
 	cmd.SetPflagExpiry(command.Flags(), &opts.expiry)
 	cmd.SetPflagPluginConfig(command.Flags(), &opts.pluginConfig)
 	command.Flags().StringVar(&opts.signatureManifest, "signature-manifest", signatureManifestImage, "manifest type for signature. options: \"image\", \"artifact\"")
 	cmd.SetPflagUserMetadata(command.Flags(), &opts.userMetadata, cmd.PflagUserMetadataSignUsage)
-	command.MarkFlagsRequiredTogether("id", "plugin")
-	command.MarkFlagsMutuallyExclusive("key", "id")
-	command.MarkFlagsMutuallyExclusive("key", "plugin")
 	return command
 }
 

--- a/cmd/notation/sign.go
+++ b/cmd/notation/sign.go
@@ -71,6 +71,26 @@ Example - Sign an OCI artifact and use OCI artifact manifest to store the signat
 			opts.reference = args[0]
 			return nil
 		},
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// Check if the options are valid for the key (Key is mutually exclusive with [KeyID, PluginName])
+			if opts.KeyID != "" && opts.PluginName != "" {
+				if opts.Key == "" {
+					// Valid, use ondemand key
+					return nil
+				} else {
+					return errors.New("incompatible options, do not provide a key name when providing a key ID and plugin name")
+				}
+			} else if opts.KeyID == "" && opts.PluginName == "" {
+				// Valid, use preconfigured key
+				return nil
+			} else {
+				if opts.Key == "" {
+					return errors.New("incompatible options, both a key ID and plugin name are required when not using an existing key")
+				} else {
+					return errors.New("incompatible options, do not provide a key ID or plugin name when providing a key name")
+				}
+			}
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// sanity check
 			if !validateSignatureManifest(opts.signatureManifest) {

--- a/cmd/notation/sign_test.go
+++ b/cmd/notation/sign_test.go
@@ -123,6 +123,38 @@ func TestSignCommand_CorrectConfig(t *testing.T) {
 	}
 }
 
+func TestSignCommmand_OnDemandKeyOptions(t *testing.T) {
+	opts := &signOpts{}
+	command := signCommand(opts)
+	expected := &signOpts{
+		reference: "ref",
+		SecureFlagOpts: SecureFlagOpts{
+			Username: "user",
+			Password: "password",
+		},
+		SignerFlagOpts: cmd.SignerFlagOpts{
+			KeyID:           "keyID",
+			PluginName:      "pluginName",
+			SignatureFormat: envelope.JWS,
+		},
+		signatureManifest: "image",
+	}
+	if err := command.ParseFlags([]string{
+		expected.reference,
+		"-u", expected.Username,
+		"--password", expected.Password,
+		"--id", expected.KeyID,
+		"--plugin", expected.PluginName}); err != nil {
+		t.Fatalf("Parse Flag failed: %v", err)
+	}
+	if err := command.Args(command, command.Flags().Args()); err != nil {
+		t.Fatalf("Parse args failed: %v", err)
+	}
+	if !reflect.DeepEqual(*expected, *opts) {
+		t.Fatalf("Expect sign opts: %v, got: %v", expected, opts)
+	}
+}
+
 func TestSignCommand_MissingArgs(t *testing.T) {
 	cmd := signCommand(nil)
 	if err := cmd.ParseFlags(nil); err != nil {

--- a/cmd/notation/sign_test.go
+++ b/cmd/notation/sign_test.go
@@ -155,6 +155,182 @@ func TestSignCommmand_OnDemandKeyOptions(t *testing.T) {
 	}
 }
 
+func TestSignCommmand_OnDemandKeyBadOptions(t *testing.T) {
+	t.Run("error when using id and plugin options with key", func(t *testing.T) {
+		opts := &signOpts{}
+		command := signCommand(opts)
+		expected := &signOpts{
+			reference: "ref",
+			SecureFlagOpts: SecureFlagOpts{
+				Username: "user",
+				Password: "password",
+			},
+			SignerFlagOpts: cmd.SignerFlagOpts{
+				KeyID:           "keyID",
+				PluginName:      "pluginName",
+				Key:             "keyName",
+				SignatureFormat: envelope.JWS,
+			},
+			signatureManifest: "image",
+		}
+		if err := command.ParseFlags([]string{
+			expected.reference,
+			"-u", expected.Username,
+			"--password", expected.Password,
+			"--id", expected.KeyID,
+			"--plugin", expected.PluginName,
+			"--key", expected.Key}); err != nil {
+			t.Fatalf("Parse Flag failed: %v", err)
+		}
+		if err := command.Args(command, command.Flags().Args()); err != nil {
+			t.Fatalf("Parse args failed: %v", err)
+		}
+		if !reflect.DeepEqual(*expected, *opts) {
+			t.Fatalf("Expect sign opts: %v, got: %v", expected, opts)
+		}
+		err := command.ValidateFlagGroups()
+		if err == nil || err.Error() != "if any flags in the group [key id] are set none of the others can be; [id key] were all set" {
+			t.Fatalf("Didn't get the expected error, but got: %v", err)
+		}
+	})
+	t.Run("error when using key and id options", func(t *testing.T) {
+		opts := &signOpts{}
+		command := signCommand(opts)
+		expected := &signOpts{
+			reference: "ref",
+			SecureFlagOpts: SecureFlagOpts{
+				Username: "user",
+				Password: "password",
+			},
+			SignerFlagOpts: cmd.SignerFlagOpts{
+				KeyID:           "keyID",
+				Key:             "keyName",
+				SignatureFormat: envelope.JWS,
+			},
+			signatureManifest: "image",
+		}
+		if err := command.ParseFlags([]string{
+			expected.reference,
+			"-u", expected.Username,
+			"--password", expected.Password,
+			"--id", expected.KeyID,
+			"--key", expected.Key}); err != nil {
+			t.Fatalf("Parse Flag failed: %v", err)
+		}
+		if err := command.Args(command, command.Flags().Args()); err != nil {
+			t.Fatalf("Parse args failed: %v", err)
+		}
+		if !reflect.DeepEqual(*expected, *opts) {
+			t.Fatalf("Expect sign opts: %v, got: %v", expected, opts)
+		}
+		err := command.ValidateFlagGroups()
+		if err == nil || err.Error() != "if any flags in the group [id plugin] are set they must all be set; missing [plugin]" {
+			t.Fatalf("Didn't get the expected error, but got: %v", err)
+		}
+	})
+	t.Run("error when using key and plugin options", func(t *testing.T) {
+		opts := &signOpts{}
+		command := signCommand(opts)
+		expected := &signOpts{
+			reference: "ref",
+			SecureFlagOpts: SecureFlagOpts{
+				Username: "user",
+				Password: "password",
+			},
+			SignerFlagOpts: cmd.SignerFlagOpts{
+				PluginName:      "pluginName",
+				Key:             "keyName",
+				SignatureFormat: envelope.JWS,
+			},
+			signatureManifest: "image",
+		}
+		if err := command.ParseFlags([]string{
+			expected.reference,
+			"-u", expected.Username,
+			"--password", expected.Password,
+			"--plugin", expected.PluginName,
+			"--key", expected.Key}); err != nil {
+			t.Fatalf("Parse Flag failed: %v", err)
+		}
+		if err := command.Args(command, command.Flags().Args()); err != nil {
+			t.Fatalf("Parse args failed: %v", err)
+		}
+		if !reflect.DeepEqual(*expected, *opts) {
+			t.Fatalf("Expect sign opts: %v, got: %v", expected, opts)
+		}
+		err := command.ValidateFlagGroups()
+		if err == nil || err.Error() != "if any flags in the group [id plugin] are set they must all be set; missing [id]" {
+			t.Fatalf("Didn't get the expected error, but got: %v", err)
+		}
+	})
+	t.Run("error when using id option and not plugin", func(t *testing.T) {
+		opts := &signOpts{}
+		command := signCommand(opts)
+		expected := &signOpts{
+			reference: "ref",
+			SecureFlagOpts: SecureFlagOpts{
+				Username: "user",
+				Password: "password",
+			},
+			SignerFlagOpts: cmd.SignerFlagOpts{
+				KeyID:           "keyID",
+				SignatureFormat: envelope.JWS,
+			},
+			signatureManifest: "image",
+		}
+		if err := command.ParseFlags([]string{
+			expected.reference,
+			"-u", expected.Username,
+			"--password", expected.Password,
+			"--id", expected.KeyID}); err != nil {
+			t.Fatalf("Parse Flag failed: %v", err)
+		}
+		if err := command.Args(command, command.Flags().Args()); err != nil {
+			t.Fatalf("Parse args failed: %v", err)
+		}
+		if !reflect.DeepEqual(*expected, *opts) {
+			t.Fatalf("Expect sign opts: %v, got: %v", expected, opts)
+		}
+		err := command.ValidateFlagGroups()
+		if err == nil || err.Error() != "if any flags in the group [id plugin] are set they must all be set; missing [plugin]" {
+			t.Fatalf("Didn't get the expected error, but got: %v", err)
+		}
+	})
+	t.Run("error when using plugin option and not id", func(t *testing.T) {
+		opts := &signOpts{}
+		command := signCommand(opts)
+		expected := &signOpts{
+			reference: "ref",
+			SecureFlagOpts: SecureFlagOpts{
+				Username: "user",
+				Password: "password",
+			},
+			SignerFlagOpts: cmd.SignerFlagOpts{
+				PluginName:      "pluginName",
+				SignatureFormat: envelope.JWS,
+			},
+			signatureManifest: "image",
+		}
+		if err := command.ParseFlags([]string{
+			expected.reference,
+			"-u", expected.Username,
+			"--password", expected.Password,
+			"--plugin", expected.PluginName}); err != nil {
+			t.Fatalf("Parse Flag failed: %v", err)
+		}
+		if err := command.Args(command, command.Flags().Args()); err != nil {
+			t.Fatalf("Parse args failed: %v", err)
+		}
+		if !reflect.DeepEqual(*expected, *opts) {
+			t.Fatalf("Expect sign opts: %v, got: %v", expected, opts)
+		}
+		err := command.ValidateFlagGroups()
+		if err == nil || err.Error() != "if any flags in the group [id plugin] are set they must all be set; missing [id]" {
+			t.Fatalf("Didn't get the expected error, but got: %v", err)
+		}
+	})
+}
+
 func TestSignCommand_MissingArgs(t *testing.T) {
 	cmd := signCommand(nil)
 	if err := cmd.ParseFlags(nil); err != nil {

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -51,7 +51,7 @@ var (
 
 	PflagPlugin = &pflag.Flag{
 		Name:  "plugin",
-		Usage: "signing plugin name. This is mutually exclusive with the --key flag",
+		Usage: "signing plugin name (required if --id is set). This is mutually exclusive with the --key flag",
 	}
 	SetPflagPlugin = func(fs *pflag.FlagSet, p *string) {
 		fs.StringVar(p, PflagPlugin.Name, "", PflagPlugin.Usage)

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -20,7 +20,7 @@ var (
 	PflagKey = &pflag.Flag{
 		Name:      "key",
 		Shorthand: "k",
-		Usage:     "signing key name, for a key previously added to notation's key list.",
+		Usage:     "signing key name, for a key previously added to notation's key list. This is mutually exclusive with the --id and --plugin flags",
 	}
 	SetPflagKey = func(fs *pflag.FlagSet, p *string) {
 		fs.StringVarP(p, PflagKey.Name, PflagKey.Shorthand, "", PflagKey.Usage)
@@ -39,6 +39,22 @@ var (
 		}
 
 		fs.StringVar(p, PflagSignatureFormat.Name, defaultSignatureFormat, PflagSignatureFormat.Usage)
+	}
+
+	PflagID = &pflag.Flag{
+		Name:  "id",
+		Usage: "key id (required if --plugin is set). This is mutually exclusive with the --key flag",
+	}
+	SetPflagID = func(fs *pflag.FlagSet, p *string) {
+		fs.StringVar(p, PflagID.Name, "", PflagID.Usage)
+	}
+
+	PflagPlugin = &pflag.Flag{
+		Name:  "plugin",
+		Usage: "signing plugin name. This is mutually exclusive with the --key flag",
+	}
+	SetPflagPlugin = func(fs *pflag.FlagSet, p *string) {
+		fs.StringVar(p, PflagPlugin.Name, "", PflagPlugin.Usage)
 	}
 
 	PflagTimestamp = &pflag.Flag{

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -57,15 +57,6 @@ var (
 		fs.StringVar(p, PflagPlugin.Name, "", PflagPlugin.Usage)
 	}
 
-	PflagTimestamp = &pflag.Flag{
-		Name:      "timestamp",
-		Shorthand: "t",
-		Usage:     "timestamp the signed signature via the remote TSA",
-	}
-	SetPflagTimestamp = func(fs *pflag.FlagSet, p *string) {
-		fs.StringVarP(p, PflagTimestamp.Name, PflagTimestamp.Shorthand, "", PflagTimestamp.Usage)
-	}
-
 	PflagExpiry = &pflag.Flag{
 		Name:      "expiry",
 		Shorthand: "e",

--- a/internal/cmd/options.go
+++ b/internal/cmd/options.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/notaryproject/notation/internal/trace"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -17,11 +18,15 @@ type SignerFlagOpts struct {
 }
 
 // ApplyFlags set flags and their default values for the FlagSet
-func (opts *SignerFlagOpts) ApplyFlags(fs *pflag.FlagSet) {
+func (opts *SignerFlagOpts) ApplyFlagsToCommand(command *cobra.Command) {
+	fs := command.Flags()
 	SetPflagKey(fs, &opts.Key)
 	SetPflagSignatureFormat(fs, &opts.SignatureFormat)
 	SetPflagID(fs, &opts.KeyID)
 	SetPflagPlugin(fs, &opts.PluginName)
+	command.MarkFlagsRequiredTogether("id", "plugin")
+	command.MarkFlagsMutuallyExclusive("key", "id")
+	command.MarkFlagsMutuallyExclusive("key", "plugin")
 }
 
 // LoggingFlagOpts option struct.

--- a/internal/cmd/options.go
+++ b/internal/cmd/options.go
@@ -12,12 +12,16 @@ import (
 type SignerFlagOpts struct {
 	Key             string
 	SignatureFormat string
+	KeyID           string
+	PluginName      string
 }
 
 // ApplyFlags set flags and their default values for the FlagSet
 func (opts *SignerFlagOpts) ApplyFlags(fs *pflag.FlagSet) {
 	SetPflagKey(fs, &opts.Key)
 	SetPflagSignatureFormat(fs, &opts.SignatureFormat)
+	SetPflagID(fs, &opts.KeyID)
+	SetPflagPlugin(fs, &opts.PluginName)
 }
 
 // LoggingFlagOpts option struct.

--- a/internal/cmd/signer.go
+++ b/internal/cmd/signer.go
@@ -12,12 +12,12 @@ import (
 )
 
 // GetSigner returns a signer according to the CLI context.
-func GetSigner(opts *SignerFlagOpts) (notation.Signer, error) {
+func GetSigner(ctx context.Context, opts *SignerFlagOpts) (notation.Signer, error) {
 	// Check if using on-demand key
 	if opts.KeyID != "" && opts.PluginName != "" && opts.Key == "" {
 		// Construct a signer from on-demand key
 		mgr := plugin.NewCLIManager(dir.PluginFS())
-		plugin, err := mgr.Get(context.Background(), opts.PluginName)
+		plugin, err := mgr.Get(ctx, opts.PluginName)
 		if err != nil {
 			return nil, err
 		}
@@ -27,7 +27,6 @@ func GetSigner(opts *SignerFlagOpts) (notation.Signer, error) {
 	// Construct a signer from preconfigured key pair in config.json
 	// if key name is provided as the CLI argument
 	key, err := configutil.ResolveKey(opts.Key)
-
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +37,7 @@ func GetSigner(opts *SignerFlagOpts) (notation.Signer, error) {
 	// corresponds to an external key
 	if key.ExternalKey != nil {
 		mgr := plugin.NewCLIManager(dir.PluginFS())
-		plugin, err := mgr.Get(context.Background(), key.PluginName)
+		plugin, err := mgr.Get(ctx, key.PluginName)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cmd/signer.go
+++ b/internal/cmd/signer.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 
 	"github.com/notaryproject/notation-go"
-	"github.com/notaryproject/notation-go/config"
 	"github.com/notaryproject/notation-go/dir"
 	"github.com/notaryproject/notation-go/plugin"
 	"github.com/notaryproject/notation-go/signer"
@@ -14,33 +13,20 @@ import (
 
 // GetSigner returns a signer according to the CLI context.
 func GetSigner(opts *SignerFlagOpts) (notation.Signer, error) {
-	var key config.KeySuite
-	var err error
-
-	// Check if the options are valid for the key (Key is mutually exclusive with [KeyID, PluginName])
-	if opts.KeyID != "" && opts.PluginName != "" {
-		if opts.Key == "" {
-			// Construct a signer from on-demand key
-			mgr := plugin.NewCLIManager(dir.PluginFS())
-			plugin, err := mgr.Get(context.Background(), opts.PluginName)
-			if err != nil {
-				return nil, err
-			}
-			return signer.NewFromPlugin(plugin, opts.KeyID, map[string]string{})
-		} else {
-			return nil, errors.New("incompatible options, do not provide a key name when providing a key ID and plugin name")
+	// Check if using on-demand key
+	if opts.KeyID != "" && opts.PluginName != "" && opts.Key == "" {
+		// Construct a signer from on-demand key
+		mgr := plugin.NewCLIManager(dir.PluginFS())
+		plugin, err := mgr.Get(context.Background(), opts.PluginName)
+		if err != nil {
+			return nil, err
 		}
-	} else if opts.KeyID == "" && opts.PluginName == "" {
-		// Construct a signer from preconfigured key pair in config.json
-		// if key name is provided as the CLI argument
-		key, err = configutil.ResolveKey(opts.Key)
-	} else {
-		if opts.Key == "" {
-			return nil, errors.New("incompatible options, both a key ID and plugin name are required when not using an existing key")
-		} else {
-			return nil, errors.New("incompatible options, do not provide a key ID or plugin name when providing a key name")
-		}
+		return signer.NewFromPlugin(plugin, opts.KeyID, map[string]string{})
 	}
+
+	// Construct a signer from preconfigured key pair in config.json
+	// if key name is provided as the CLI argument
+	key, err := configutil.ResolveKey(opts.Key)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR introduces a new option for users to sign using an on-demand key. Users are able to sign without needing to add a key first

This PR intends to address the following issue: #537 
Based on spec changes in #553 


---
Successful sign/verify:
```
c889f3b9d811:notation kodysk$ ./bin/notation sign --plugin com.example.plugin --id example:test-id $IMAGE
Warning: Always sign the artifact using digest(@sha256:...) rather than a tag(:v1) because tags are mutable and a tag reference can point to a different artifact than the one signed.
Successfully signed localhost:5000/net-monitor@sha256:07c30edca95116e23f6a150ba3f7ed296eca71021dba9d9569eb07820f8c0e7d

c889f3b9d811:notation kodysk$ ./bin/notation verify $IMAGE
Warning: Always verify the artifact using digest(@sha256:...) rather than a tag(:v1) because resolved digest may not point to the same signed artifact, as tags are mutable.
Successfully verified signature for localhost:5000/net-monitor@sha256:07c30edca95116e23f6a150ba3f7ed296eca71021dba9d9569eb07820f8c0e7d
```

Error when providing only one of the options
```
c889f3b9d811:notation kodysk$ ./bin/notation sign --plugin com.example.plugin $IMAGE 
Error: incompatible options, both a key ID and plugin name are required when not using an existing key

c889f3b9d811:notation kodysk$ ./bin/notation sign --id example:test-id $IMAGE 
Error: incompatible options, both a key ID and plugin name are required when not using an existing key
```

Error when providing key with both plugin and id:
```
c889f3b9d811:notation kodysk$ ./bin/notation sign --plugin com.example.plugin --id example:test-id --key my-key $IMAGE 
Error: incompatible options, do not provide a key name when providing a key ID and plugin name
```

Error when providing key with one of the other options
```
c889f3b9d811:notation kodysk$ ./bin/notation sign --plugin com.example.plugin --key my-key $IMAGE 
Error: incompatible options, do not provide a key ID or plugin name when providing a key name

c889f3b9d811:notation kodysk$ ./bin/notation sign --id example:test-id --key my-key $IMAGE 
Error: incompatible options, do not provide a key ID or plugin name when providing a key name
```
---

Signed-off-by: Kody Kimberl kody.kimberl.work@gmail.com