### PR TITLE
update: added `[Experimental]` label to the `--signature-manifest` flag

### DIFF
--- a/cmd/notation/sign.go
+++ b/cmd/notation/sign.go
@@ -61,7 +61,7 @@ Example - Sign an OCI artifact identified by a tag (Notation will resolve tag to
 Example - Sign an OCI artifact stored in a registry and specify the signature expiry duration, for example 24 hours
   notation sign --expiry 24h <registry>/<repository>@<digest>
 
-Example - Sign an OCI artifact and use OCI artifact manifest to store the signature:
+Example - [Experimental] Sign an OCI artifact and use OCI artifact manifest to store the signature:
   notation sign --signature-manifest artifact <registry>/<repository>@<digest>
 `,
 		Args: func(cmd *cobra.Command, args []string) error {
@@ -84,7 +84,7 @@ Example - Sign an OCI artifact and use OCI artifact manifest to store the signat
 	opts.SecureFlagOpts.ApplyFlags(command.Flags())
 	cmd.SetPflagExpiry(command.Flags(), &opts.expiry)
 	cmd.SetPflagPluginConfig(command.Flags(), &opts.pluginConfig)
-	command.Flags().StringVar(&opts.signatureManifest, "signature-manifest", signatureManifestImage, "manifest type for signature. options: \"image\", \"artifact\"")
+	command.Flags().StringVar(&opts.signatureManifest, "signature-manifest", signatureManifestImage, "[Experimental] manifest type for signature. options: \"image\", \"artifact\"")
 	cmd.SetPflagUserMetadata(command.Flags(), &opts.userMetadata, cmd.PflagUserMetadataSignUsage)
 	return command
 }


### PR DESCRIPTION
This change is based on the spec update: PR #577.