### PR TITLE
feat: add `show` and `import`  for trust policy management

### DIFF
--- a/cmd/notation/main.go
+++ b/cmd/notation/main.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/notaryproject/notation/cmd/notation/cert"
+	"github.com/notaryproject/notation/cmd/notation/policy"
 	"github.com/spf13/cobra"
 )
 
@@ -18,6 +19,7 @@ func main() {
 		verifyCommand(nil),
 		listCommand(nil),
 		cert.Cmd(),
+		policy.Cmd(),
 		keyCommand(),
 		pluginCommand(),
 		loginCommand(nil),

--- a/cmd/notation/policy/cmd.go
+++ b/cmd/notation/policy/cmd.go
@@ -1,0 +1,18 @@
+package policy
+
+import "github.com/spf13/cobra"
+
+func Cmd() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "policy [command]",
+		Short: "[Preview] Manage trust policy configuration",
+		Long:  "[Preview] Manage trust policy configuration for signature verification.",
+	}
+
+	command.AddCommand(
+		showCmd(),
+		importCmd(),
+	)
+
+	return command
+}

--- a/cmd/notation/policy/import.go
+++ b/cmd/notation/policy/import.go
@@ -1,0 +1,83 @@
+package policy
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/notaryproject/notation-go/dir"
+	"github.com/notaryproject/notation-go/verifier/trustpolicy"
+	"github.com/notaryproject/notation/cmd/notation/internal/cmdutil"
+	"github.com/notaryproject/notation/internal/osutil"
+	"github.com/spf13/cobra"
+)
+
+type importOpts struct {
+	filePath string
+	force    bool
+}
+
+func importCmd() *cobra.Command {
+	var opts importOpts
+	command := &cobra.Command{
+		Use:   "import [flags] <file_path>",
+		Short: "[Preview] Import trust policy configuration from a JSON file",
+		Long: `[Preview] Import trust policy configuration from a JSON file.
+
+** This command is in preview and under development. **
+
+Example - Import trust policy configuration from a file:
+  notation policy import my_policy.json
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.filePath = args[0]
+			return runImport(cmd, opts)
+		},
+	}
+	command.Flags().BoolVar(&opts.force, "force", false, "override the existing trust policy configuration, never prompt")
+	return command
+}
+
+func runImport(command *cobra.Command, opts importOpts) error {
+	// optional confirmation
+	if !opts.force {
+		if _, err := trustpolicy.LoadDocument(); err == nil {
+			confirmed, err := cmdutil.AskForConfirmation(os.Stdin, "Existing trust policy configuration found, do you want to overwrite it?", opts.force)
+			if err != nil {
+				return err
+			}
+			if !confirmed {
+				return nil
+			}
+		}
+	} else {
+		fmt.Fprintf(os.Stderr, "Warning: existing trust policy configuration file will be overwritten")
+	}
+
+	// read configuration
+	policyJSON, err := os.ReadFile(opts.filePath)
+	if err != nil {
+		return fmt.Errorf("failed to read trust policy file: %w", err)
+	}
+
+	// parse and validate
+	var doc trustpolicy.Document
+	if err = json.Unmarshal(policyJSON, &doc); err != nil {
+		return fmt.Errorf("failed to parse trust policy configuration: %w", err)
+	}
+	if err = doc.Validate(); err != nil {
+		return fmt.Errorf("failed to validate trust policy: %w", err)
+	}
+
+	// write
+	policyPath, err := dir.ConfigFS().SysPath(dir.PathTrustPolicy)
+	if err != nil {
+		return fmt.Errorf("failed to obtain path of trust policy file: %w", err)
+	}
+	if err = osutil.WriteFile(policyPath, policyJSON); err != nil {
+		return fmt.Errorf("failed to write trust policy file: %w", err)
+	}
+	_, err = fmt.Fprintln(os.Stdout, "Trust policy configuration imported successfully.")
+	return err
+}

--- a/cmd/notation/policy/show.go
+++ b/cmd/notation/policy/show.go
@@ -1,0 +1,64 @@
+package policy
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/notaryproject/notation-go/dir"
+	"github.com/notaryproject/notation-go/verifier/trustpolicy"
+	"github.com/spf13/cobra"
+)
+
+type showOpts struct {
+}
+
+func showCmd() *cobra.Command {
+	var opts showOpts
+	command := &cobra.Command{
+		Use:   "show [flags]",
+		Short: "[Preview] Show trust policy configuration",
+		Long: `[Preview] Show trust policy configuration.
+
+** This command is in preview and under development. **
+
+Example - Show current trust policy configuration:
+  notation policy show
+
+Example - Save current trust policy configuration to a file:
+  notation policy show > my_policy.json
+`,
+		Args: cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runShow(cmd, opts)
+		},
+	}
+	return command
+}
+
+func runShow(command *cobra.Command, opts showOpts) error {
+	// get policy file path
+	policyPath, err := dir.ConfigFS().SysPath(dir.PathTrustPolicy)
+	if err != nil {
+		return fmt.Errorf("failed to obtain path of trust policy configuration file: %w", err)
+	}
+
+	// core process
+	policyJSON, err := os.ReadFile(policyPath)
+	if err != nil {
+		return fmt.Errorf("failed to load trust policy configuration, you may import one via `notation policy import <path-to-policy.json>`: %w", err)
+	}
+	var doc trustpolicy.Document
+	if err = json.Unmarshal(policyJSON, &doc); err == nil {
+		err = doc.Validate()
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+		fmt.Fprintf(os.Stderr, "Existing trust policy configuration is invalid, you may update or create a new one via `notation policy import <path-to-policy.json>`\n")
+		// not returning to show the invalid policy configuration
+	}
+
+	// show policy content
+	_, err = os.Stdout.Write(policyJSON)
+	return err
+}

--- a/specs/commandline/policy.md
+++ b/specs/commandline/policy.md
@@ -94,10 +94,8 @@ Usage:
   notation policy import [flags] <file_path>
 
 Flags:
-  -d, --debug     debug mode
       --force     override the existing trust policy configuration, never prompt
   -h, --help      help for import
-  -v, --verbose   verbose mode
 ```
 
 ### notation policy show
@@ -109,9 +107,7 @@ Usage:
   notation policy show [flags]
 
 Flags:
-  -d, --debug     debug mode
   -h, --help      help for show
-  -v, --verbose   verbose mode
 ```
 
 ## Usage
@@ -136,7 +132,7 @@ Use the following command to show trust policy configuration:
 notation policy show
 ```
 
-Upon successful execution, the trust policy configuration are printed out in a pretty JSON format. If trust policy is not configured, users should receive an error message, and a tip to import trust policy configuration from a JSON file.
+Upon successful execution, the trust policy configuration are printed out to standard output. If trust policy is not configured or is malformed, users should receive an error message via standard error output, and a tip to import trust policy configuration from a JSON file.
 
 ### Export trust policy configuration into a JSON file
 

--- a/test/e2e/suite/command/policy.go
+++ b/test/e2e/suite/command/policy.go
@@ -1,0 +1,188 @@
+package command
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "github.com/notaryproject/notation/test/e2e/internal/notation"
+	"github.com/notaryproject/notation/test/e2e/internal/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("trust policy maintainer", func() {
+	When("showing configuration", func() {
+		It("should show error and hint if policy doesn't exist", func() {
+			Host(Opts(), func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+				notation.ExpectFailure().
+					Exec("policy", "show").
+					MatchErrKeyWords("failed to load trust policy configuration", "notation policy import")
+			})
+		})
+
+		It("should show exist policy", func() {
+			content, err := os.ReadFile(filepath.Join(NotationE2ETrustPolicyDir, TrustPolicyName))
+			Expect(err).NotTo(HaveOccurred())
+			Host(Opts(AddTrustPolicyOption(TrustPolicyName)), func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+				notation.Exec("policy", "show").
+					MatchContent(string(content))
+			})
+		})
+
+		It("should display error hint when showing invalid policy", func() {
+			policyName := "invalid_format_trustpolicy.json"
+			content, err := os.ReadFile(filepath.Join(NotationE2ETrustPolicyDir, policyName))
+			Expect(err).NotTo(HaveOccurred())
+			Host(Opts(AddTrustPolicyOption(policyName)), func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+				notation.Exec("policy", "show").
+					MatchErrKeyWords("existing trust policy configuration is invalid").
+					MatchContent(string(content))
+			})
+		})
+	})
+
+	When("importing configuration without existing trust policy configuration", func() {
+		opts := Opts()
+		It("should fail if no file path is provided", func() {
+			Host(opts, func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+				notation.ExpectFailure().
+					Exec("policy", "import")
+			})
+		})
+
+		It("should fail if provided file doesn't exist", func() {
+			Host(opts, func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+				notation.ExpectFailure().
+					Exec("policy", "import", "/??/???")
+			})
+		})
+
+		It("should fail if registry scope is malformed", func() {
+			Host(opts, func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+				notation.ExpectFailure().
+					Exec("policy", "import", filepath.Join(NotationE2ETrustPolicyDir, "malformed_registry_scope_trustpolicy.json"))
+			})
+		})
+
+		It("should fail if store is malformed", func() {
+			Host(opts, func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+				notation.ExpectFailure().
+					Exec("policy", "import", filepath.Join(NotationE2ETrustPolicyDir, "malformed_trust_store_trustpolicy.json"))
+			})
+		})
+
+		It("should fail if identity is malformed", func() {
+			Host(opts, func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+				notation.ExpectFailure().
+					Exec("policy", "import", filepath.Join(NotationE2ETrustPolicyDir, "malformed_trusted_identity_trustpolicy.json"))
+			})
+		})
+
+		It("should import successfully", func() {
+			Host(opts, func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+				notation.Exec("policy", "import", filepath.Join(NotationE2ETrustPolicyDir, TrustPolicyName))
+			})
+		})
+
+		It("should import successfully by force", func() {
+			Host(opts, func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+				notation.Exec("policy", "import", filepath.Join(NotationE2ETrustPolicyDir, TrustPolicyName), "--force")
+			})
+		})
+	})
+
+	When("importing configuration with existing trust policy configuration", func() {
+		opts := Opts(AddTrustPolicyOption(TrustPolicyName))
+		It("should fail if no file path is provided", func() {
+			Host(opts, func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+				notation.ExpectFailure().
+					Exec("policy", "import")
+			})
+		})
+
+		It("should fail if provided file doesn't exist", func() {
+			Host(opts, func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+				notation.ExpectFailure().
+					Exec("policy", "import", "/??/???", "--force")
+			})
+		})
+
+		It("should fail if registry scope is malformed", func() {
+			Host(opts, func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+				notation.WithInput(strings.NewReader("Y\n")).ExpectFailure().
+					Exec("policy", "import", filepath.Join(NotationE2ETrustPolicyDir, "malformed_registry_scope_trustpolicy.json"))
+			})
+		})
+
+		It("should fail if store is malformed", func() {
+			Host(opts, func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+				notation.WithInput(strings.NewReader("Y\n")).ExpectFailure().
+					Exec("policy", "import", filepath.Join(NotationE2ETrustPolicyDir, "malformed_trust_store_trustpolicy.json"))
+			})
+		})
+
+		It("should fail if identity is malformed", func() {
+			Host(opts, func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+				notation.WithInput(strings.NewReader("Y\n")).ExpectFailure().
+					Exec("policy", "import", filepath.Join(NotationE2ETrustPolicyDir, "malformed_trusted_identity_trustpolicy.json"))
+			})
+		})
+
+		It("should cancel import with N", func() {
+			Host(opts, func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+				notation.WithInput(strings.NewReader("N\n")).Exec("policy", "import", filepath.Join(NotationE2ETrustPolicyDir, "skip_trustpolicy.json"))
+				// validate
+				content, err := os.ReadFile(filepath.Join(NotationE2ETrustPolicyDir, TrustPolicyName))
+				Expect(err).NotTo(HaveOccurred())
+				notation.Exec("policy", "show").MatchContent(string(content))
+			})
+		})
+
+		It("should cancel import by default", func() {
+			Host(opts, func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+				notation.Exec("policy", "import", filepath.Join(NotationE2ETrustPolicyDir, "skip_trustpolicy.json"))
+				// validate
+				content, err := os.ReadFile(filepath.Join(NotationE2ETrustPolicyDir, TrustPolicyName))
+				Expect(err).NotTo(HaveOccurred())
+				notation.Exec("policy", "show").MatchContent(string(content))
+			})
+		})
+
+		It("should skip confirmation if existing policy is malformed", func() {
+			Host(Opts(AddTrustPolicyOption("invalid_format_trustpolicy.json")), func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+				policyFileName := "skip_trustpolicy.json"
+				notation.Exec("policy", "import", filepath.Join(NotationE2ETrustPolicyDir, policyFileName)).MatchKeyWords().
+					MatchKeyWords("Trust policy configuration imported successfully.")
+				// validate
+				content, err := os.ReadFile(filepath.Join(NotationE2ETrustPolicyDir, policyFileName))
+				Expect(err).NotTo(HaveOccurred())
+				notation.Exec("policy", "show").MatchContent(string(content))
+			})
+		})
+
+		It("should confirm import", func() {
+			Host(opts, func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+				policyFileName := "skip_trustpolicy.json"
+				notation.WithInput(strings.NewReader("Y\n")).Exec("policy", "import", filepath.Join(NotationE2ETrustPolicyDir, policyFileName)).
+					MatchKeyWords("Trust policy configuration imported successfully.")
+				// validate
+				content, err := os.ReadFile(filepath.Join(NotationE2ETrustPolicyDir, policyFileName))
+				Expect(err).NotTo(HaveOccurred())
+				notation.Exec("policy", "show").MatchContent(string(content))
+			})
+		})
+
+		It("should confirm import by force", func() {
+			Host(opts, func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+				policyFileName := "skip_trustpolicy.json"
+				notation.Exec("policy", "import", filepath.Join(NotationE2ETrustPolicyDir, policyFileName), "--force").
+					MatchKeyWords("Trust policy configuration imported successfully.")
+				// validate
+				content, err := os.ReadFile(filepath.Join(NotationE2ETrustPolicyDir, policyFileName))
+				Expect(err).NotTo(HaveOccurred())
+				notation.Exec("policy", "show").MatchContent(string(content))
+			})
+		})
+	})
+})

--- a/test/e2e/testdata/config/trustpolicies/invalid_format_trustpolicy.json
+++ b/test/e2e/testdata/config/trustpolicies/invalid_format_trustpolicy.json
@@ -1,0 +1,9 @@
+{
+	"version": "1.0",
+	"trustPolicies": [
+	    {
+		"name": "e2e",
+		"registryScopes": [ "*" ]
+	    }}
+	]
+}


### PR DESCRIPTION
This PR implements what's described in [policy.md](https://github.com/notaryproject/notation/blob/18efc3de233ef5eb00e2f32009475a2b8a3eae47/specs/commandline/policy.md).

Resolves #548 

