### PR TITLE
doc: improve error output in notation key and notation cert

### DIFF
--- a/specs/commandline/certificate.md
+++ b/specs/commandline/certificate.md
@@ -208,7 +208,7 @@ A prompt is showed asking user to confirm the deletion. Upon successful deletion
 notation certificate delete --type <type> --store <name> <cert_fileName>
 ```
 
-A prompt is showed asking user to confirm the deletion. Upon successful deletion, the specific certificate is deleted from the trust store named `<name>` of type `<type>`. The output message is printed out as following:
+A prompt is displayed, asking the user to confirm the deletion. Upon successful deletion, the specific certificate is deleted from the trust store named `<name>` of type `<type>`. The output message is printed out as following:
 
 ```text
 Successfully deleted <cert_fileName> from the trust store. 

--- a/specs/commandline/certificate.md
+++ b/specs/commandline/certificate.md
@@ -208,7 +208,17 @@ A prompt is showed asking user to confirm the deletion. Upon successful deletion
 notation certificate delete --type <type> --store <name> <cert_fileName>
 ```
 
-A prompt is showed asking user to confirm the deletion. Upon successful deletion, the specific certificate is deleted in trust store named `<name>` of type `<type>`. If deletion fails, an error message with specific reasons is printed out.
+A prompt is showed asking user to confirm the deletion. Upon successful deletion, the specific certificate is deleted from the trust store named `<name>` of type `<type>`. The output message is printed out as following:
+
+```text
+Successfully deleted <cert_fileName> from the trust store. 
+```
+
+If users execute the deletion without specifying required flags using `notation cert delete <cert_fileName>`, the deletion fails and the error output message is printed out as follows:
+
+```text
+Error: You need to specify the required flag "--type" and "--store". Try "notation cert delete -h" to view examples.
+```
 
 ### Generate a local RSA key and a corresponding self-generated certificate for testing purpose and add the certificate into trust store
 

--- a/specs/commandline/certificate.md
+++ b/specs/commandline/certificate.md
@@ -217,7 +217,7 @@ Successfully deleted <cert_fileName> from the trust store.
 If users execute the deletion without specifying required flags using `notation cert delete <cert_fileName>`, the deletion fails and the error output message is printed out as follows:
 
 ```text
-Error: You need to specify the required flag "--type" and "--store". Try "notation cert delete -h" to view examples.
+Error: required flag(s) "store", "type" not set
 ```
 
 ### Generate a local RSA key and a corresponding self-generated certificate for testing purpose and add the certificate into trust store

--- a/specs/commandline/key.md
+++ b/specs/commandline/key.md
@@ -124,12 +124,12 @@ notation key remove <key_name>
 - Upon successful removal of a local testing key created by notation, the output message is printed out as follows:
 
 ```text
-Removed <key_name> from Notation signing key list. The source key file still exists locally.
+Removed <key_name> from Notation signing key list. The source key file still exists.
 ```
 - Upon successful removal of a key associated with a KMS, the output message is printed out as follows:
 
 ```text
-Removed <key_name> from Notation signing key list.
+Removed <key_name> from Notation signing key list. The source key files still exist.
 ```
 
 ### Remove two keys from Notation signing key list
@@ -141,7 +141,7 @@ notation key remove <key_name_1> <key_name_2>
 Upon successful execution, the output message is printed out as follows. Please be noted if default signing key is removed, Notation will not automatically assign a new default signing key. User needs to update the default signing key explicitly.
 
 ```text
-Removed the following keys from Notation signing key list. The source key files still exist locally.
+Removed the following keys from Notation signing key list. The source key files still exist.
 <key_name_1>
 <key_name_2>
 ```

--- a/specs/commandline/key.md
+++ b/specs/commandline/key.md
@@ -121,10 +121,15 @@ Upon successful execution, a list of keys is printed out with information of nam
 notation key remove <key_name>
 ```
 
-Upon successful execution, the output message is printed out as following:
+- Upon successful execution, the output message is printed out as below when removed a key created by notation for local testing purpose:
 
 ```text
 Removed <key_name> from signing key list. You still need to delete the key file from <key_path> and delete the certificate from <cert_path>.
+```
+- Upon successful execution, the output message is printed out as below when removed a key associates with a KMS:
+
+```text
+Removed <key_name> from signing key list.
 ```
 
 ### Remove two keys from signing key list

--- a/specs/commandline/key.md
+++ b/specs/commandline/key.md
@@ -121,12 +121,12 @@ Upon successful execution, a list of keys is printed out with information of nam
 notation key remove <key_name>
 ```
 
-- Upon successful execution, the output message is printed out as below when removed a key created by notation for local testing purpose:
+- Upon successful removal of a local testing key created by notation, the output message is printed out as follows:
 
 ```text
-Removed <key_name> from signing key list. You still need to delete the key file from <key_path> and delete the certificate from <cert_path>.
+Removed <key_name> from signing key list. The source key file is still existed in <key_path>.
 ```
-- Upon successful execution, the output message is printed out as below when removed a key associates with a KMS:
+- Upon successful removal of a key associated with a KMS, the output message is printed out as follows:
 
 ```text
 Removed <key_name> from signing key list.
@@ -138,4 +138,10 @@ Removed <key_name> from signing key list.
 notation key remove <key_name_1> <key_name_2>
 ```
 
-Upon successful execution, the names of removed signing keys are printed out. Please be noted if default signing key is removed, Notation will not automatically assign a new default signing key. User needs to update the default signing key explicitly.
+Upon successful execution, the output message is printed out as follows. Please be noted if default signing key is removed, Notation will not automatically assign a new default signing key. User needs to update the default signing key explicitly.
+
+```text
+Removed the following keys from signing key list. The source key files are still existed in <key_path>.
+<key_name_1>
+<key_name_2>
+```

--- a/specs/commandline/key.md
+++ b/specs/commandline/key.md
@@ -16,7 +16,7 @@ Usage:
 
 Available Commands:
   add         Add key to Notation signing key list
-  remove      Remove key from Notation signing key list
+  delete      Remove key from Notation signing key list
   list        List keys used for signing
   update      Update key in Notation signing key list
 

--- a/specs/commandline/key.md
+++ b/specs/commandline/key.md
@@ -124,7 +124,7 @@ notation key remove <key_name>
 - Upon successful removal of a local testing key created by notation, the output message is printed out as follows:
 
 ```text
-Removed <key_name> from Notation signing key list. The source key file is still existed in <key_path>.
+Removed <key_name> from Notation signing key list. The source key file still exists locally.
 ```
 - Upon successful removal of a key associated with a KMS, the output message is printed out as follows:
 
@@ -141,7 +141,7 @@ notation key remove <key_name_1> <key_name_2>
 Upon successful execution, the output message is printed out as follows. Please be noted if default signing key is removed, Notation will not automatically assign a new default signing key. User needs to update the default signing key explicitly.
 
 ```text
-Removed the following keys from Notation signing key list. The source key files are still existed in <key_path>.
+Removed the following keys from Notation signing key list. The source key files still exist locally.
 <key_name_1>
 <key_name_2>
 ```

--- a/specs/commandline/key.md
+++ b/specs/commandline/key.md
@@ -48,7 +48,7 @@ Flags:
 Remove key from Notation signing key list
 
 Usage:
-  notation key remove [flags] <key_name>...
+  notation key delete [flags] <key_name>...
 
 Flags:
   -d, --debug     debug mode
@@ -118,7 +118,7 @@ Upon successful execution, a list of keys is printed out with information of nam
 ### Remove a specified key from Notation signing key list
 
 ```shell
-notation key remove <key_name>
+notation key delete <key_name>
 ```
 
 - Upon successful removal of a local testing key created by notation, the output message is printed out as follows:
@@ -135,7 +135,7 @@ Removed <key_name> from Notation signing key list. The source key files still ex
 ### Remove two keys from Notation signing key list
 
 ```shell
-notation key remove <key_name_1> <key_name_2>
+notation key delete <key_name_1> <key_name_2>
 ```
 
 Upon successful execution, the output message is printed out as follows. Please be noted if default signing key is removed, Notation will not automatically assign a new default signing key. User needs to update the default signing key explicitly.

--- a/specs/commandline/key.md
+++ b/specs/commandline/key.md
@@ -16,7 +16,7 @@ Usage:
 
 Available Commands:
   add         Add key to signing key list
-  delete      Delete key from signing key list
+  remove      Remove key from signing key list
   list        List keys used for signing
   update      Update key in signing key list
 
@@ -45,10 +45,10 @@ Flags:
 ### notation key delete
 
 ```text
-Delete key from signing key list
+Remove key from signing key list
 
 Usage:
-  notation key delete [flags] <key_name>...
+  notation key remove [flags] <key_name>...
 
 Flags:
   -d, --debug     debug mode
@@ -115,10 +115,22 @@ notation key list
 
 Upon successful execution, a list of keys is printed out with information of name, key path, certificate path, key id and plugin name. The default signing key name is preceded by an asterisk. The key id and plugin name are used together to provide the information of the key identifier for the remote key and the plugin associated with it.
 
-### Delete two keys from signing key list
+### Remove a specified key from signing key list
 
 ```shell
-notation key delete <key_name_1> <key_name_2>
+notation key remove <key_name>
 ```
 
-Upon successful execution, the names of deleted signing keys are printed out. Please be noted if default signing key is deleted, Notation will not automatically assign a new default signing key. User needs to update the default signing key explicitly.
+Upon successful execution, the output message is printed out as following:
+
+```text
+Removed <key_name> from signing key list. You still need to delete the key file from <key_path> and delete the certificate from <cert_path>.
+```
+
+### Remove two keys from signing key list
+
+```shell
+notation key remove <key_name_1> <key_name_2>
+```
+
+Upon successful execution, the names of removed signing keys are printed out. Please be noted if default signing key is removed, Notation will not automatically assign a new default signing key. User needs to update the default signing key explicitly.

--- a/specs/commandline/key.md
+++ b/specs/commandline/key.md
@@ -124,12 +124,12 @@ notation key delete <key_name>
 - Upon successful removal of a local testing key created by notation, the output message is printed out as follows:
 
 ```text
-Removed <key_name> from Notation signing key list. The source key file still exists.
+Removed <key_name> from Notation signing key list. The source key still exists.
 ```
 - Upon successful removal of a key associated with a KMS, the output message is printed out as follows:
 
 ```text
-Removed <key_name> from Notation signing key list. The source key files still exist.
+Removed <key_name> from Notation signing key list. The source key still exists.
 ```
 
 ### Remove two keys from Notation signing key list
@@ -141,7 +141,7 @@ notation key delete <key_name_1> <key_name_2>
 Upon successful execution, the output message is printed out as follows. Please be noted if default signing key is removed, Notation will not automatically assign a new default signing key. User needs to update the default signing key explicitly.
 
 ```text
-Removed the following keys from Notation signing key list. The source key files still exist.
+Removed the following keys from Notation signing key list. The source keys still exist.
 <key_name_1>
 <key_name_2>
 ```

--- a/specs/commandline/key.md
+++ b/specs/commandline/key.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Use ```notation key``` command to manage keys used for signing. User can add/update/list/remove key to/from signing key list. Please be noted this command doesn't manage the lifecycle of signing key itself, it manages the signing key list only.
+Use ```notation key``` command to manage keys used for signing. User can add/update/list/remove key to/from Notation signing key list. Please be noted this command doesn't manage the lifecycle of signing key itself, it manages the Notation signing key list only.
 
 ## Outline
 
@@ -15,10 +15,10 @@ Usage:
   notation key [command]
 
 Available Commands:
-  add         Add key to signing key list
-  remove      Remove key from signing key list
+  add         Add key to Notation signing key list
+  remove      Remove key from Notation signing key list
   list        List keys used for signing
-  update      Update key in signing key list
+  update      Update key in Notation signing key list
 
 Flags:
   -h, --help  help for key
@@ -27,7 +27,7 @@ Flags:
 ### notation key add
 
 ```text
-Add key to signing key list
+Add key to Notation signing key list
 
 Usage:
   notation key add --plugin <plugin_name> [flags] <key_name>
@@ -45,7 +45,7 @@ Flags:
 ### notation key delete
 
 ```text
-Remove key from signing key list
+Remove key from Notation signing key list
 
 Usage:
   notation key remove [flags] <key_name>...
@@ -74,7 +74,7 @@ Flags:
 ### notation key update
 
 ```text
-Update key in signing key list
+Update key in Notation signing key list
 
 Usage:
   notation key update [flags] <key_name>
@@ -115,7 +115,7 @@ notation key list
 
 Upon successful execution, a list of keys is printed out with information of name, key path, certificate path, key id and plugin name. The default signing key name is preceded by an asterisk. The key id and plugin name are used together to provide the information of the key identifier for the remote key and the plugin associated with it.
 
-### Remove a specified key from signing key list
+### Remove a specified key from Notation signing key list
 
 ```shell
 notation key remove <key_name>
@@ -124,15 +124,15 @@ notation key remove <key_name>
 - Upon successful removal of a local testing key created by notation, the output message is printed out as follows:
 
 ```text
-Removed <key_name> from signing key list. The source key file is still existed in <key_path>.
+Removed <key_name> from Notation signing key list. The source key file is still existed in <key_path>.
 ```
 - Upon successful removal of a key associated with a KMS, the output message is printed out as follows:
 
 ```text
-Removed <key_name> from signing key list.
+Removed <key_name> from Notation signing key list.
 ```
 
-### Remove two keys from signing key list
+### Remove two keys from Notation signing key list
 
 ```shell
 notation key remove <key_name_1> <key_name_2>
@@ -141,7 +141,7 @@ notation key remove <key_name_1> <key_name_2>
 Upon successful execution, the output message is printed out as follows. Please be noted if default signing key is removed, Notation will not automatically assign a new default signing key. User needs to update the default signing key explicitly.
 
 ```text
-Removed the following keys from signing key list. The source key files are still existed in <key_path>.
+Removed the following keys from Notation signing key list. The source key files are still existed in <key_path>.
 <key_name_1>
 <key_name_2>
 ```


### PR DESCRIPTION
Update CLI spec to improve error output in `notation key` and `notation cert` and resolve the UX problem in #604