### PR TITLE
doc: remove preview mark from policy commands

### DIFF
--- a/cmd/notation/policy/cmd.go
+++ b/cmd/notation/policy/cmd.go
@@ -5,8 +5,8 @@ import "github.com/spf13/cobra"
 func Cmd() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "policy [command]",
-		Short: "[Preview] Manage trust policy configuration",
-		Long:  "[Preview] Manage trust policy configuration for signature verification.",
+		Short: "Manage trust policy configuration",
+		Long:  "Manage trust policy configuration for signature verification.",
 	}
 
 	command.AddCommand(

--- a/cmd/notation/policy/import.go
+++ b/cmd/notation/policy/import.go
@@ -21,8 +21,8 @@ func importCmd() *cobra.Command {
 	var opts importOpts
 	command := &cobra.Command{
 		Use:   "import [flags] <file_path>",
-		Short: "[Preview] Import trust policy configuration from a JSON file",
-		Long: `[Preview] Import trust policy configuration from a JSON file.
+		Short: "Import trust policy configuration from a JSON file",
+		Long: `Import trust policy configuration from a JSON file.
 
 ** This command is in preview and under development. **
 

--- a/cmd/notation/policy/show.go
+++ b/cmd/notation/policy/show.go
@@ -17,8 +17,8 @@ func showCmd() *cobra.Command {
 	var opts showOpts
 	command := &cobra.Command{
 		Use:   "show [flags]",
-		Short: "[Preview] Show trust policy configuration",
-		Long: `[Preview] Show trust policy configuration.
+		Short: "Show trust policy configuration",
+		Long: `Show trust policy configuration.
 
 ** This command is in preview and under development. **
 

--- a/specs/notation-cli.md
+++ b/specs/notation-cli.md
@@ -13,7 +13,7 @@ This spec contains reference information on using notation commands. Each comman
 | [login](./commandline/login.md)             | Login to registries                                                    |
 | [logout](./commandline/logout.md)           | Log out from the logged in registries                                  |
 | [plugin](./commandline/plugin.md)           | Manage plugins                                                         |
-| [policy](./commandline/policy.md)           | [Preview] Manage trust policy configuration for signature verification |
+| [policy](./commandline/policy.md)           | Manage trust policy configuration for signature verification |
 | [sign](./commandline/sign.md)               | Sign artifacts                                                         |
 | [verify](./commandline/verify.md)           | Verify artifacts                                                       |
 | [version](./commandline/version.md)         | Print the version of notation CLI                                      |
@@ -34,7 +34,7 @@ Available Commands:
   login       Login to registry
   logout      Log out from the logged in registries
   plugin      Manage plugins
-  policy      [Preview] Manage trust policy configuration for signature verification
+  policy      Manage trust policy configuration for signature verification
   sign        Sign artifacts
   verify      Verify artifacts
   version     Show the notation version information


### PR DESCRIPTION
This PR removes the preview marks for all policy-related commands.