### PR TITLE
test: skip non-applicable unit tests on Windows

### DIFF
--- a/internal/osutil/file_test.go
+++ b/internal/osutil/file_test.go
@@ -199,6 +199,29 @@ func TestCopyToDir(t *testing.T) {
 		if err := WriteFile(filename, data); err != nil {
 			t.Fatal(err)
 		}
+		// forbid dest directory operation
+		if err := os.Chmod(destTempDir, 0000); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chmod(destTempDir, 0700)
+		if _, err := CopyToDir(filename, filepath.Join(destTempDir, "a")); err == nil {
+			t.Fatal("should have error")
+		}
+	})
+
+	t.Run("dest directory permission error 2", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("skipping test on Windows")
+		}
+
+		tempDir := t.TempDir()
+		destTempDir := t.TempDir()
+		data := []byte("data")
+		// prepare file
+		filename := filepath.Join(tempDir, "a", "file.txt")
+		if err := WriteFile(filename, data); err != nil {
+			t.Fatal(err)
+		}
 		// forbid writing to destTempDir
 		if err := os.Chmod(destTempDir, 0000); err != nil {
 			t.Fatal(err)

--- a/internal/osutil/file_test.go
+++ b/internal/osutil/file_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -29,6 +30,10 @@ func TestWriteFile(t *testing.T) {
 	})
 
 	t.Run("write file with directory permission error", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("skipping test on Windows")
+		}
+
 		tempDir := t.TempDir()
 		data := []byte("data")
 		// forbid writing to tempDir
@@ -80,6 +85,10 @@ func TestWriteFileWithPermission(t *testing.T) {
 	})
 
 	t.Run("write with directory permission error", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("skipping test on Windows")
+		}
+
 		tempDir := t.TempDir()
 		data := []byte("data")
 		filename := filepath.Join(tempDir, "a", "file.txt")
@@ -124,6 +133,10 @@ func TestCopyToDir(t *testing.T) {
 	})
 
 	t.Run("source directory permission error", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("skipping test on Windows")
+		}
+
 		tempDir := t.TempDir()
 		destDir := t.TempDir()
 		data := []byte("data")
@@ -151,6 +164,10 @@ func TestCopyToDir(t *testing.T) {
 	})
 
 	t.Run("source file permission error", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("skipping test on Windows")
+		}
+
 		tempDir := t.TempDir()
 		destDir := t.TempDir()
 		data := []byte("data")
@@ -170,25 +187,10 @@ func TestCopyToDir(t *testing.T) {
 	})
 
 	t.Run("dest directory permission error", func(t *testing.T) {
-		tempDir := t.TempDir()
-		destTempDir := t.TempDir()
-		data := []byte("data")
-		// prepare file
-		filename := filepath.Join(tempDir, "a", "file.txt")
-		if err := WriteFile(filename, data); err != nil {
-			t.Fatal(err)
+		if runtime.GOOS == "windows" {
+			t.Skip("skipping test on Windows")
 		}
-		// forbid dest directory operation
-		if err := os.Chmod(destTempDir, 0000); err != nil {
-			t.Fatal(err)
-		}
-		defer os.Chmod(destTempDir, 0700)
-		if _, err := CopyToDir(filename, filepath.Join(destTempDir, "a")); err == nil {
-			t.Fatal("should have error")
-		}
-	})
 
-	t.Run("dest directory permission error 2", func(t *testing.T) {
 		tempDir := t.TempDir()
 		destTempDir := t.TempDir()
 		data := []byte("data")
@@ -197,7 +199,7 @@ func TestCopyToDir(t *testing.T) {
 		if err := WriteFile(filename, data); err != nil {
 			t.Fatal(err)
 		}
-		// forbid dest directory operation
+		// forbid writing to destTempDir
 		if err := os.Chmod(destTempDir, 0000); err != nil {
 			t.Fatal(err)
 		}
@@ -207,7 +209,7 @@ func TestCopyToDir(t *testing.T) {
 		}
 	})
 
-	t.Run("valid file content", func(t *testing.T) {
+	t.Run("copy file and check content", func(t *testing.T) {
 		tempDir := t.TempDir()
 		data := []byte("data")
 		filename := filepath.Join(tempDir, "a", "file.txt")

--- a/pkg/configutil/util_test.go
+++ b/pkg/configutil/util_test.go
@@ -3,6 +3,7 @@ package configutil
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -71,6 +72,9 @@ func TestIsRegistryInsecureMissingConfig(t *testing.T) {
 }
 
 func TestIsRegistryInsecureConfigPermissionError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping test on Windows")
+	}
 	configDir := "./testdata"
 	// for restore dir
 	defer func(oldDir string) error {
@@ -121,6 +125,9 @@ func TestResolveKey(t *testing.T) {
 	})
 
 	t.Run("signingkeys.json without read permission", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("skipping test on Windows")
+		}
 		dir.UserConfigDir = "./testdata/valid_signingkeys"
 		defer func() error {
 			// restore the permission


### PR DESCRIPTION
Fix unit test:
- skip some unit test cases because Windows handles file permissions differently from Unix-based systems, and therefore, using file permissions like 0000, 0600, 0644, or 0700 in tests may not work as expected on Windows.

Test:
- unit test on Windows
- unit test on Linux

Test output:
```
?       github.com/notaryproject/notation/cmd/notation/internal/cmdutil [no test files]
?       github.com/notaryproject/notation/cmd/notation/internal/errors  [no test files]
?       github.com/notaryproject/notation/internal/cmd  [no test files]
?       github.com/notaryproject/notation/cmd/notation/policy   [no test files]
?       github.com/notaryproject/notation/internal/experimental [no test files]
?       github.com/notaryproject/notation/internal/ioutil       [no test files]
ok      github.com/notaryproject/notation/cmd/notation  (cached)
ok      github.com/notaryproject/notation/cmd/notation/cert     (cached)
ok      github.com/notaryproject/notation/cmd/notation/internal/truststore      (cached)
ok      github.com/notaryproject/notation/internal/envelope     (cached)
ok      github.com/notaryproject/notation/internal/osutil       (cached)
ok      github.com/notaryproject/notation/internal/slices       (cached)
ok      github.com/notaryproject/notation/internal/trace        (cached)
ok      github.com/notaryproject/notation/internal/tree (cached)
ok      github.com/notaryproject/notation/internal/version      (cached)
ok      github.com/notaryproject/notation/pkg/auth      (cached)
ok      github.com/notaryproject/notation/pkg/configutil        (cached)
```

Signed-off-by: Junjie Gao <junjiegao@microsoft.com>