### PR TITLE
update: align Notation with OCI specs

### DIFF
--- a/cmd/notation/inspect.go
+++ b/cmd/notation/inspect.go
@@ -70,7 +70,7 @@ Example - Inspect signatures on an OCI artifact identified by a digest and outpu
   notation inspect --output json <registry>/<repository>@<digest>
 `
 	experimentalExamples := `
-Example - [Experimental] Inspect signatures on an OCI artifact identified by a digest using the Referrers API, if not supported, fallback to the Referrers tag schema
+Example - [Experimental] Inspect signatures on an OCI artifact identified by a digest using the Referrers API, if not supported (returns 404), fallback to the Referrers tag schema
   notation inspect --allow-referrers-api <registry>/<repository>@<digest>
 `
 	command := &cobra.Command{
@@ -95,7 +95,7 @@ Example - [Experimental] Inspect signatures on an OCI artifact identified by a d
 	opts.LoggingFlagOpts.ApplyFlags(command.Flags())
 	opts.SecureFlagOpts.ApplyFlags(command.Flags())
 	cmd.SetPflagOutput(command.Flags(), &opts.outputFormat, cmd.PflagOutputUsage)
-	command.Flags().BoolVar(&opts.allowReferrersAPI, "allow-referrers-api", false, "[Experimental] use the Referrers API to inspect signatures, if not supported, fallback to the Referrers tag schema")
+	cmd.SetPflagReferrersAPI(command.Flags(), &opts.allowReferrersAPI, cmd.PflagReferrersAPIInspectUsage)
 	experimental.HideFlags(command, experimentalExamples, []string{"allow-referrers-api"})
 	return command
 }

--- a/cmd/notation/inspect.go
+++ b/cmd/notation/inspect.go
@@ -61,17 +61,17 @@ func inspectCommand(opts *inspectOpts) *cobra.Command {
 	longMessage := `Inspect all signatures associated with the signed artifact.
 
 Example - Inspect signatures on an OCI artifact identified by a digest:
-	notation inspect <registry>/<repository>@<digest>
+  notation inspect <registry>/<repository>@<digest>
 
 Example - Inspect signatures on an OCI artifact identified by a tag  (Notation will resolve tag to digest):
-	notation inspect <registry>/<repository>:<tag>
+  notation inspect <registry>/<repository>:<tag>
 
 Example - Inspect signatures on an OCI artifact identified by a digest and output as json:
-	notation inspect --output json <registry>/<repository>@<digest>
+  notation inspect --output json <registry>/<repository>@<digest>
 `
 	experimentalExamples := `
 Example - [Experimental] Inspect signatures on an OCI artifact identified by a digest using the Referrers API, if not supported, fallback to the Referrers tag schema
-	notation inspect --allow-referrers-api <registry>/<repository>@<digest>
+  notation inspect --allow-referrers-api <registry>/<repository>@<digest>
 `
 	command := &cobra.Command{
 		Use:   "inspect [reference]",

--- a/cmd/notation/inspect.go
+++ b/cmd/notation/inspect.go
@@ -95,7 +95,7 @@ Example - [Experimental] Inspect signatures on an OCI artifact identified by a d
 	opts.LoggingFlagOpts.ApplyFlags(command.Flags())
 	opts.SecureFlagOpts.ApplyFlags(command.Flags())
 	cmd.SetPflagOutput(command.Flags(), &opts.outputFormat, cmd.PflagOutputUsage)
-	cmd.SetPflagReferrersAPI(command.Flags(), &opts.allowReferrersAPI, cmd.PflagReferrersAPIInspectUsage)
+	cmd.SetPflagReferrersAPI(command.Flags(), &opts.allowReferrersAPI, fmt.Sprintf(cmd.PflagReferrersUsageFormat, "inspect"))
 	experimental.HideFlags(command, experimentalExamples, []string{"allow-referrers-api"})
 	return command
 }

--- a/cmd/notation/inspect.go
+++ b/cmd/notation/inspect.go
@@ -14,6 +14,7 @@ import (
 	"github.com/notaryproject/notation-core-go/signature"
 	"github.com/notaryproject/notation-go/plugin/proto"
 	"github.com/notaryproject/notation-go/registry"
+	"github.com/notaryproject/notation/cmd/notation/internal/experimental"
 	"github.com/notaryproject/notation/internal/cmd"
 	"github.com/notaryproject/notation/internal/envelope"
 	"github.com/notaryproject/notation/internal/ioutil"
@@ -25,8 +26,9 @@ import (
 type inspectOpts struct {
 	cmd.LoggingFlagOpts
 	SecureFlagOpts
-	reference    string
-	outputFormat string
+	reference         string
+	outputFormat      string
+	allowReferrersAPI bool
 }
 
 type inspectOutput struct {
@@ -56,26 +58,34 @@ func inspectCommand(opts *inspectOpts) *cobra.Command {
 	if opts == nil {
 		opts = &inspectOpts{}
 	}
+	longMessage := `Inspect all signatures associated with the signed artifact.
+
+Example - Inspect signatures on an OCI artifact identified by a digest:
+	notation inspect <registry>/<repository>@<digest>
+
+Example - Inspect signatures on an OCI artifact identified by a tag  (Notation will resolve tag to digest):
+	notation inspect <registry>/<repository>:<tag>
+
+Example - Inspect signatures on an OCI artifact identified by a digest and output as json:
+	notation inspect --output json <registry>/<repository>@<digest>
+`
+	experimentalExamples := `
+Example - [Experimental] Inspect signatures on an OCI artifact identified by a digest using the Referrers API, if not supported, fallback to the Referrers tag schema
+	notation inspect --allow-referrers-api <registry>/<repository>@<digest>
+`
 	command := &cobra.Command{
 		Use:   "inspect [reference]",
 		Short: "Inspect all signatures associated with the signed artifact",
-		Long: `Inspect all signatures associated with the signed artifact.
-
-Example - Inspect signatures on an OCI artifact identified by a digest:
-  notation inspect <registry>/<repository>@<digest>
-
-Example - Inspect signatures on an OCI artifact identified by a tag  (Notation will resolve tag to digest):
-  notation inspect <registry>/<repository>:<tag>
-
-Example - Inspect signatures on an OCI artifact identified by a digest and output as json:
-  notation inspect --output json <registry>/<repository>@<digest>
-`,
+		Long:  longMessage,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return errors.New("missing reference")
 			}
 			opts.reference = args[0]
 			return nil
+		},
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return experimental.CheckFlagsAndWarn(cmd, "allow-referrers-api")
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runInspect(cmd, opts)
@@ -85,6 +95,8 @@ Example - Inspect signatures on an OCI artifact identified by a digest and outpu
 	opts.LoggingFlagOpts.ApplyFlags(command.Flags())
 	opts.SecureFlagOpts.ApplyFlags(command.Flags())
 	cmd.SetPflagOutput(command.Flags(), &opts.outputFormat, cmd.PflagOutputUsage)
+	command.Flags().BoolVar(&opts.allowReferrersAPI, "allow-referrers-api", false, "[Experimental] use the Referrers API to inspect signatures, if not supported, fallback to the Referrers tag schema")
+	experimental.HideFlags(command, experimentalExamples, []string{"allow-referrers-api"})
 	return command
 }
 
@@ -98,7 +110,7 @@ func runInspect(command *cobra.Command, opts *inspectOpts) error {
 
 	// initialize
 	reference := opts.reference
-	sigRepo, err := getRemoteRepository(ctx, &opts.SecureFlagOpts, reference)
+	sigRepo, err := getRemoteRepository(ctx, &opts.SecureFlagOpts, reference, opts.allowReferrersAPI)
 	if err != nil {
 		return err
 	}

--- a/cmd/notation/list.go
+++ b/cmd/notation/list.go
@@ -52,7 +52,7 @@ func listCommand(opts *listOpts) *cobra.Command {
 	}
 	opts.LoggingFlagOpts.ApplyFlags(command.Flags())
 	opts.SecureFlagOpts.ApplyFlags(command.Flags())
-	cmd.SetPflagReferrersAPI(command.Flags(), &opts.allowReferrersAPI, cmd.PflagReferrersAPIListUsage)
+	cmd.SetPflagReferrersAPI(command.Flags(), &opts.allowReferrersAPI, fmt.Sprintf(cmd.PflagReferrersUsageFormat, "list"))
 	command.Flags().BoolVar(&opts.ociLayout, "oci-layout", false, "[Experimental] list signatures stored in OCI image layout")
 	experimental.HideFlags(command, "", []string{"allow-referrers-api", "oci-layout"})
 	return command

--- a/cmd/notation/list.go
+++ b/cmd/notation/list.go
@@ -28,7 +28,7 @@ func listCommand(opts *listOpts) *cobra.Command {
 			inputType: inputTypeRegistry, // remote registry by default
 		}
 	}
-	cmd := &cobra.Command{
+	command := &cobra.Command{
 		Use:     "list [flags] <reference>",
 		Aliases: []string{"ls"},
 		Short:   "List signatures of the signed artifact",
@@ -50,12 +50,12 @@ func listCommand(opts *listOpts) *cobra.Command {
 			return runList(cmd.Context(), opts)
 		},
 	}
-	opts.LoggingFlagOpts.ApplyFlags(cmd.Flags())
-	opts.SecureFlagOpts.ApplyFlags(cmd.Flags())
-	cmd.Flags().BoolVar(&opts.allowReferrersAPI, "allow-referrers-api", false, "[Experimental] use the Referrers API to list signatures, if not supported, fallback to the Referrers tag schema")
-	cmd.Flags().BoolVar(&opts.ociLayout, "oci-layout", false, "[Experimental] list signatures stored in OCI image layout")
-	experimental.HideFlags(cmd, "", []string{"allow-referrers-api", "oci-layout"})
-	return cmd
+	opts.LoggingFlagOpts.ApplyFlags(command.Flags())
+	opts.SecureFlagOpts.ApplyFlags(command.Flags())
+	cmd.SetPflagReferrersAPI(command.Flags(), &opts.allowReferrersAPI, cmd.PflagReferrersAPIListUsage)
+	command.Flags().BoolVar(&opts.ociLayout, "oci-layout", false, "[Experimental] list signatures stored in OCI image layout")
+	experimental.HideFlags(command, "", []string{"allow-referrers-api", "oci-layout"})
+	return command
 }
 
 func runList(ctx context.Context, opts *listOpts) error {

--- a/cmd/notation/manifest.go
+++ b/cmd/notation/manifest.go
@@ -104,7 +104,7 @@ func parseOCILayoutReference(raw string) (string, string, error) {
 	return path, ref, nil
 }
 
-// getManifestDescriptor returns target artifact manifest descriptor given
+// getManifestDescriptor returns target artifact's manifest descriptor given
 // reference (digest or tag) and Repository.
 func getManifestDescriptor(ctx context.Context, reference string, sigRepo notationregistry.Repository) (ocispec.Descriptor, error) {
 	logger := log.GetLogger(ctx)

--- a/cmd/notation/registry.go
+++ b/cmd/notation/registry.go
@@ -68,13 +68,13 @@ func getRemoteRepository(ctx context.Context, opts *SecureFlagOpts, reference st
 		return nil, err
 	}
 
-	if experimental.IsDisabled() || !allowReferrersAPI {
-		logger.Info("By default, using the Referrers tag schema")
+	if !experimental.IsDisabled() && allowReferrersAPI {
+		logger.Info("Using the Referrers API, if not supported, automatically fallback to the Referrers tag schema")
+	} else {
+		logger.Info("Using the Referrers tag schema")
 		if err := remoteRepo.SetReferrersCapability(false); err != nil {
 			return nil, err
 		}
-	} else {
-		logger.Info("Using the Referrers API, if not supported, automatically fallback to the Referrers tag schema")
 	}
 	return notationregistry.NewRepository(remoteRepo), nil
 }

--- a/cmd/notation/registry.go
+++ b/cmd/notation/registry.go
@@ -69,7 +69,7 @@ func getRemoteRepository(ctx context.Context, opts *SecureFlagOpts, reference st
 	}
 
 	if !experimental.IsDisabled() && allowReferrersAPI {
-		logger.Info("Using the Referrers API, if not supported, automatically fallback to the Referrers tag schema")
+		logger.Info("Trying to use referrers API")
 	} else {
 		logger.Info("Using the Referrers tag schema")
 		if err := remoteRepo.SetReferrersCapability(false); err != nil {

--- a/cmd/notation/registry.go
+++ b/cmd/notation/registry.go
@@ -69,9 +69,9 @@ func getRemoteRepository(ctx context.Context, opts *SecureFlagOpts, reference st
 	}
 
 	if !experimental.IsDisabled() && allowReferrersAPI {
-		logger.Info("Trying to use referrers API")
+		logger.Info("Trying to use the referrers API")
 	} else {
-		logger.Info("Using the Referrers tag schema")
+		logger.Info("Using the referrers tag schema")
 		if err := remoteRepo.SetReferrersCapability(false); err != nil {
 			return nil, err
 		}

--- a/cmd/notation/registry_test.go
+++ b/cmd/notation/registry_test.go
@@ -2,19 +2,23 @@ package main
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"reflect"
 	"testing"
 
-	notationerrors "github.com/notaryproject/notation/cmd/notation/internal/errors"
-	"oras.land/oras-go/v2/registry/remote"
-	"oras.land/oras-go/v2/registry/remote/errcode"
+	"github.com/notaryproject/notation/cmd/notation/internal/experimental"
 )
 
-func TestRegistry_pingReferrersAPI_Success(t *testing.T) {
+const (
+	zeroDigest = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+)
+
+func TestRegistry_getRemoteRepositoryWithReferrersAPISupported(t *testing.T) {
+	t.Setenv("NOTATION_EXPERIMENTAL", "1")
+	if experimental.IsDisabled() {
+		t.Fatal("failed to enable experimental")
+	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/v2/test/referrers/"+zeroDigest {
 			w.WriteHeader(http.StatusOK)
@@ -29,23 +33,23 @@ func TestRegistry_pingReferrersAPI_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("invalid test http server: %v", err)
 	}
-	repo, err := remote.NewRepository(uri.Host + "/test")
-	if err != nil {
-		t.Fatalf("NewRepository() error = %v", err)
+	secureOpts := SecureFlagOpts{
+		PlainHTTP: true,
 	}
-	repo.PlainHTTP = true
-	ctx := context.Background()
-	err = pingReferrersAPI(ctx, repo)
+	_, err = getRemoteRepository(context.Background(), &secureOpts, uri.Host+"/test", true)
 	if err != nil {
-		t.Errorf("pingReferrersAPI() expected nil error, but got error: %v", err)
+		t.Errorf("getRemoteRepository() expected nil error, but got error: %v", err)
 	}
 }
 
-func TestRegistry_pingReferrersAPI_ReferrersAPINotSupported(t *testing.T) {
+func TestRegistry_getRemoteRepositoryWithReferrersAPINotSupported(t *testing.T) {
+	t.Setenv("NOTATION_EXPERIMENTAL", "1")
+	if experimental.IsDisabled() {
+		t.Fatal("failed to enable experimental")
+	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/v2/test/referrers/"+zeroDigest {
 			w.WriteHeader(http.StatusNotFound)
-			w.Write([]byte(`{ "errorresponse": { "method": "GET", "statuscode": 404 } }`))
 			return
 		}
 		t.Errorf("unexpected access: %s %q", r.Method, r.URL)
@@ -56,23 +60,20 @@ func TestRegistry_pingReferrersAPI_ReferrersAPINotSupported(t *testing.T) {
 	if err != nil {
 		t.Fatalf("invalid test http server: %v", err)
 	}
-	ctx := context.Background()
-	repo, err := remote.NewRepository(uri.Host + "/test")
-	if err != nil {
-		t.Fatalf("NewRepository() error = %v", err)
+	secureOpts := SecureFlagOpts{
+		PlainHTTP: true,
 	}
-	repo.PlainHTTP = true
-	err = pingReferrersAPI(ctx, repo)
-	var errorReferrersAPINotSupported notationerrors.ErrorReferrersAPINotSupported
-	if err == nil || !errors.As(err, &errorReferrersAPINotSupported) {
-		t.Errorf("pingReferrersAPI() expected ErrorReferrersAPINotSupported, but got: %v", err)
+	_, err = getRemoteRepository(context.Background(), &secureOpts, uri.Host+"/test", true)
+	if err != nil {
+		t.Errorf("getRemoteRepository() expected nil error, but got error: %v", err)
 	}
 }
 
-func TestRegistry_pingReferrersAPI_Failed(t *testing.T) {
+func TestRegistry_getRemoteRepositoryWithReferrersTagSchema(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/v2/test/referrers/"+zeroDigest {
 			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{ "test": "TEST" }`))
 			return
 		}
 		t.Errorf("unexpected access: %s %q", r.Method, r.URL)
@@ -83,53 +84,11 @@ func TestRegistry_pingReferrersAPI_Failed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("invalid test http server: %v", err)
 	}
-	ctx := context.Background()
-	repo, err := remote.NewRepository(uri.Host + "/test")
+	secureOpts := SecureFlagOpts{
+		PlainHTTP: true,
+	}
+	_, err = getRemoteRepository(context.Background(), &secureOpts, uri.Host+"/test", false)
 	if err != nil {
-		t.Fatalf("NewRepository() error = %v", err)
-	}
-	repo.PlainHTTP = true
-	err = pingReferrersAPI(ctx, repo)
-	if err == nil {
-		t.Errorf("pingReferrersAPI expected to get error but got nil")
-	}
-}
-
-func TestRegistry_pingReferrersAPI_RepositoryNotFound(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodGet && r.URL.Path == "/v2/test/referrers/"+zeroDigest {
-			w.WriteHeader(http.StatusNotFound)
-			w.Write([]byte(`{ "errors": [ { "code": "NAME_UNKNOWN", "message": "repository name not known to registry" } ] }`))
-			return
-		}
-		t.Errorf("unexpected access: %s %q", r.Method, r.URL)
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer ts.Close()
-	uri, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Fatalf("invalid test http server: %v", err)
-	}
-	ctx := context.Background()
-	expectedErr := errcode.Error{
-		Code:    errcode.ErrorCodeNameUnknown,
-		Message: "repository name not known to registry",
-	}
-
-	repo, err := remote.NewRepository(uri.Host + "/test")
-	if err != nil {
-		t.Fatalf("NewRepository() error = %v", err)
-	}
-	repo.PlainHTTP = true
-	err = pingReferrersAPI(ctx, repo)
-	if err == nil {
-		t.Fatalf("pingReferrersAPI() expected error but got nil")
-	}
-	var ec errcode.Error
-	if !errors.As(err, &ec) {
-		t.Errorf("pingReferrersAPI() expected errcode.Error")
-	}
-	if !reflect.DeepEqual(ec, expectedErr) {
-		t.Errorf("pingReferrersAPI() expected error: %v, but got: %v", expectedErr, err)
+		t.Errorf("getRemoteRepository() expected nil error, but got error: %v", err)
 	}
 }

--- a/cmd/notation/sign.go
+++ b/cmd/notation/sign.go
@@ -61,7 +61,7 @@ Example - Sign an OCI artifact stored in a registry and specify the signature ex
   notation sign --expiry 24h <registry>/<repository>@<digest>
 `
 	experimentalExamples := `
-Example - [Experimental] Sign an OCI artifact and store signature using the Referrers API. If it's not supported, fallback to the Referrers tag schema
+Example - [Experimental] Sign an OCI artifact and store signature using the Referrers API. If it's not supported (returns 404), fallback to the Referrers tag schema
   notation sign --allow-referrers-api <registry>/<repository>@<digest>
 
 Example - [Experimental] Sign an OCI artifact referenced in an OCI layout
@@ -98,7 +98,7 @@ Example - [Experimental] Sign an OCI artifact identified by a tag and referenced
 	cmd.SetPflagExpiry(command.Flags(), &opts.expiry)
 	cmd.SetPflagPluginConfig(command.Flags(), &opts.pluginConfig)
 	cmd.SetPflagUserMetadata(command.Flags(), &opts.userMetadata, cmd.PflagUserMetadataSignUsage)
-	command.Flags().BoolVar(&opts.allowReferrersAPI, "allow-referrers-api", false, "[Experimental] use the Referrers API to store signatures in the registry, if not supported, fallback to the Referrers tag schema")
+	cmd.SetPflagReferrersAPI(command.Flags(), &opts.allowReferrersAPI, cmd.PflagReferrersAPISignUsage)
 	command.Flags().BoolVar(&opts.ociLayout, "oci-layout", false, "[Experimental] sign the artifact stored as OCI image layout")
 	experimental.HideFlags(command, experimentalExamples, []string{"allow-referrers-api", "oci-layout"})
 	return command

--- a/cmd/notation/sign.go
+++ b/cmd/notation/sign.go
@@ -134,7 +134,6 @@ func runSign(command *cobra.Command, cmdOpts *signOpts) error {
 
 	// core process
 	_, err = notation.Sign(ctx, signer, sigRepo, signOpts)
-
 	if err != nil {
 		var errorPushSignatureFailed notation.ErrorPushSignatureFailed
 		if errors.As(err, &errorPushSignatureFailed) && strings.Contains(err.Error(), referrersTagSchemaDeleteError) {

--- a/cmd/notation/sign.go
+++ b/cmd/notation/sign.go
@@ -61,8 +61,8 @@ Example - Sign an OCI artifact stored in a registry and specify the signature ex
   notation sign --expiry 24h <registry>/<repository>@<digest>
 `
 	experimentalExamples := `
-Example - [Experimental] Sign an OCI artifact and store signature using the Referrers API, if not supported, fallback to the Referrers tag schema
-	notation sign --allow-referrers-api <registry>/<repository>@<digest>
+Example - [Experimental] Sign an OCI artifact and store signature using the Referrers API. If it's not supported, fallback to the Referrers tag schema
+  notation sign --allow-referrers-api <registry>/<repository>@<digest>
 
 Example - [Experimental] Sign an OCI artifact referenced in an OCI layout
   notation sign --oci-layout "<oci_layout_path>@<digest>"

--- a/cmd/notation/sign.go
+++ b/cmd/notation/sign.go
@@ -134,6 +134,7 @@ func runSign(command *cobra.Command, cmdOpts *signOpts) error {
 
 	// core process
 	_, err = notation.Sign(ctx, signer, sigRepo, signOpts)
+
 	if err != nil {
 		var errorPushSignatureFailed notation.ErrorPushSignatureFailed
 		if errors.As(err, &errorPushSignatureFailed) && strings.Contains(err.Error(), referrersTagSchemaDeleteError) {

--- a/cmd/notation/sign.go
+++ b/cmd/notation/sign.go
@@ -98,7 +98,7 @@ Example - [Experimental] Sign an OCI artifact identified by a tag and referenced
 	cmd.SetPflagExpiry(command.Flags(), &opts.expiry)
 	cmd.SetPflagPluginConfig(command.Flags(), &opts.pluginConfig)
 	cmd.SetPflagUserMetadata(command.Flags(), &opts.userMetadata, cmd.PflagUserMetadataSignUsage)
-	cmd.SetPflagReferrersAPI(command.Flags(), &opts.allowReferrersAPI, cmd.PflagReferrersAPISignUsage)
+	cmd.SetPflagReferrersAPI(command.Flags(), &opts.allowReferrersAPI, fmt.Sprintf(cmd.PflagReferrersUsageFormat, "sign"))
 	command.Flags().BoolVar(&opts.ociLayout, "oci-layout", false, "[Experimental] sign the artifact stored as OCI image layout")
 	experimental.HideFlags(command, experimentalExamples, []string{"allow-referrers-api", "oci-layout"})
 	return command

--- a/cmd/notation/sign_test.go
+++ b/cmd/notation/sign_test.go
@@ -23,7 +23,6 @@ func TestSignCommand_BasicArgs(t *testing.T) {
 			Key:             "key",
 			SignatureFormat: envelope.JWS,
 		},
-		signatureManifest: "image",
 	}
 	if err := command.ParseFlags([]string{
 		expected.reference,
@@ -55,7 +54,7 @@ func TestSignCommand_MoreArgs(t *testing.T) {
 			SignatureFormat: envelope.COSE,
 		},
 		expiry:            24 * time.Hour,
-		signatureManifest: signatureManifestImage,
+		allowReferrersAPI: true,
 	}
 	if err := command.ParseFlags([]string{
 		expected.reference,
@@ -65,7 +64,7 @@ func TestSignCommand_MoreArgs(t *testing.T) {
 		"--plain-http",
 		"--signature-format", expected.SignerFlagOpts.SignatureFormat,
 		"--expiry", expected.expiry.String(),
-		"--signature-manifest", signatureManifestImage}); err != nil {
+		"--allow-referrers-api"}); err != nil {
 		t.Fatalf("Parse Flag failed: %v", err)
 	}
 	if err := command.Args(command, command.Flags().Args()); err != nil {
@@ -85,9 +84,8 @@ func TestSignCommand_CorrectConfig(t *testing.T) {
 			Key:             "key",
 			SignatureFormat: envelope.COSE,
 		},
-		expiry:            365 * 24 * time.Hour,
-		pluginConfig:      []string{"key0=val0", "key1=val1"},
-		signatureManifest: "image",
+		expiry:       365 * 24 * time.Hour,
+		pluginConfig: []string{"key0=val0", "key1=val1"},
 	}
 	if err := command.ParseFlags([]string{
 		expected.reference,
@@ -137,7 +135,6 @@ func TestSignCommmand_OnDemandKeyOptions(t *testing.T) {
 			PluginName:      "pluginName",
 			SignatureFormat: envelope.JWS,
 		},
-		signatureManifest: "image",
 	}
 	if err := command.ParseFlags([]string{
 		expected.reference,
@@ -171,7 +168,6 @@ func TestSignCommmand_OnDemandKeyBadOptions(t *testing.T) {
 				Key:             "keyName",
 				SignatureFormat: envelope.JWS,
 			},
-			signatureManifest: "image",
 		}
 		if err := command.ParseFlags([]string{
 			expected.reference,
@@ -207,7 +203,6 @@ func TestSignCommmand_OnDemandKeyBadOptions(t *testing.T) {
 				Key:             "keyName",
 				SignatureFormat: envelope.JWS,
 			},
-			signatureManifest: "image",
 		}
 		if err := command.ParseFlags([]string{
 			expected.reference,
@@ -242,7 +237,6 @@ func TestSignCommmand_OnDemandKeyBadOptions(t *testing.T) {
 				Key:             "keyName",
 				SignatureFormat: envelope.JWS,
 			},
-			signatureManifest: "image",
 		}
 		if err := command.ParseFlags([]string{
 			expected.reference,
@@ -276,7 +270,6 @@ func TestSignCommmand_OnDemandKeyBadOptions(t *testing.T) {
 				KeyID:           "keyID",
 				SignatureFormat: envelope.JWS,
 			},
-			signatureManifest: "image",
 		}
 		if err := command.ParseFlags([]string{
 			expected.reference,
@@ -309,7 +302,6 @@ func TestSignCommmand_OnDemandKeyBadOptions(t *testing.T) {
 				PluginName:      "pluginName",
 				SignatureFormat: envelope.JWS,
 			},
-			signatureManifest: "image",
 		}
 		if err := command.ParseFlags([]string{
 			expected.reference,

--- a/cmd/notation/verify.go
+++ b/cmd/notation/verify.go
@@ -50,7 +50,7 @@ Example - Verify a signature on an OCI artifact identified by a tag  (Notation w
 `
 	experimentalExamples := `
 Example - [Experimental] Verify an OCI artifact using the Referrers API, if not supported, fallback to the Referrers tag schema
-	notation verify --allow-referrers-api <registry>/<repository>@<digest>
+  notation verify --allow-referrers-api <registry>/<repository>@<digest>
 
 Example - [Experimental] Verify a signature on an OCI artifact referenced in an OCI layout using trust policy statement specified by scope.
   notation verify --oci-layout <registry>/<repository>@<digest> --scope <trust_policy_scope>

--- a/cmd/notation/verify.go
+++ b/cmd/notation/verify.go
@@ -49,7 +49,7 @@ Example - Verify a signature on an OCI artifact identified by a tag  (Notation w
   notation verify <registry>/<repository>:<tag>
 `
 	experimentalExamples := `
-Example - [Experimental] Verify an OCI artifact using the Referrers API, if not supported, fallback to the Referrers tag schema
+Example - [Experimental] Verify an OCI artifact using the Referrers API, if not supported (returns 404), fallback to the Referrers tag schema
   notation verify --allow-referrers-api <registry>/<repository>@<digest>
 
 Example - [Experimental] Verify a signature on an OCI artifact referenced in an OCI layout using trust policy statement specified by scope.
@@ -83,7 +83,7 @@ Example - [Experimental] Verify a signature on an OCI artifact identified by a t
 	opts.SecureFlagOpts.ApplyFlags(command.Flags())
 	command.Flags().StringArrayVar(&opts.pluginConfig, "plugin-config", nil, "{key}={value} pairs that are passed as it is to a plugin, if the verification is associated with a verification plugin, refer plugin documentation to set appropriate values")
 	cmd.SetPflagUserMetadata(command.Flags(), &opts.userMetadata, cmd.PflagUserMetadataVerifyUsage)
-	command.Flags().BoolVar(&opts.allowReferrersAPI, "allow-referrers-api", false, "[Experimental] use the Referrers API to verify signatures, if not supported, fallback to the Referrers tag schema")
+	cmd.SetPflagReferrersAPI(command.Flags(), &opts.allowReferrersAPI, cmd.PflagReferrersAPIVerifyUsage)
 	command.Flags().BoolVar(&opts.ociLayout, "oci-layout", false, "[Experimental] verify the artifact stored as OCI image layout")
 	command.Flags().StringVar(&opts.trustPolicyScope, "scope", "", "[Experimental] set trust policy scope for artifact verification, required and can only be used when flag \"--oci-layout\" is set")
 	command.MarkFlagsRequiredTogether("oci-layout", "scope")

--- a/cmd/notation/verify.go
+++ b/cmd/notation/verify.go
@@ -83,7 +83,7 @@ Example - [Experimental] Verify a signature on an OCI artifact identified by a t
 	opts.SecureFlagOpts.ApplyFlags(command.Flags())
 	command.Flags().StringArrayVar(&opts.pluginConfig, "plugin-config", nil, "{key}={value} pairs that are passed as it is to a plugin, if the verification is associated with a verification plugin, refer plugin documentation to set appropriate values")
 	cmd.SetPflagUserMetadata(command.Flags(), &opts.userMetadata, cmd.PflagUserMetadataVerifyUsage)
-	cmd.SetPflagReferrersAPI(command.Flags(), &opts.allowReferrersAPI, cmd.PflagReferrersAPIVerifyUsage)
+	cmd.SetPflagReferrersAPI(command.Flags(), &opts.allowReferrersAPI, fmt.Sprintf(cmd.PflagReferrersUsageFormat, "verify"))
 	command.Flags().BoolVar(&opts.ociLayout, "oci-layout", false, "[Experimental] verify the artifact stored as OCI image layout")
 	command.Flags().StringVar(&opts.trustPolicyScope, "scope", "", "[Experimental] set trust policy scope for artifact verification, required and can only be used when flag \"--oci-layout\" is set")
 	command.MarkFlagsRequiredTogether("oci-layout", "scope")

--- a/cmd/notation/verify.go
+++ b/cmd/notation/verify.go
@@ -23,12 +23,13 @@ const maxSignatureAttempts = math.MaxInt64
 type verifyOpts struct {
 	cmd.LoggingFlagOpts
 	SecureFlagOpts
-	reference        string
-	pluginConfig     []string
-	userMetadata     []string
-	ociLayout        bool
-	trustPolicyScope string
-	inputType        inputType
+	reference         string
+	pluginConfig      []string
+	userMetadata      []string
+	allowReferrersAPI bool
+	ociLayout         bool
+	trustPolicyScope  string
+	inputType         inputType
 }
 
 func verifyCommand(opts *verifyOpts) *cobra.Command {
@@ -48,6 +49,9 @@ Example - Verify a signature on an OCI artifact identified by a tag  (Notation w
   notation verify <registry>/<repository>:<tag>
 `
 	experimentalExamples := `
+Example - [Experimental] Verify an OCI artifact using the Referrers API, if not supported, fallback to the Referrers tag schema
+	notation verify --allow-referrers-api <registry>/<repository>@<digest>
+
 Example - [Experimental] Verify a signature on an OCI artifact referenced in an OCI layout using trust policy statement specified by scope.
   notation verify --oci-layout <registry>/<repository>@<digest> --scope <trust_policy_scope>
 
@@ -69,7 +73,7 @@ Example - [Experimental] Verify a signature on an OCI artifact identified by a t
 			if opts.ociLayout {
 				opts.inputType = inputTypeOCILayout
 			}
-			return experimental.CheckFlagsAndWarn(cmd, "oci-layout", "scope")
+			return experimental.CheckFlagsAndWarn(cmd, "allow-referrers-api", "oci-layout", "scope")
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runVerify(cmd, opts)
@@ -79,10 +83,11 @@ Example - [Experimental] Verify a signature on an OCI artifact identified by a t
 	opts.SecureFlagOpts.ApplyFlags(command.Flags())
 	command.Flags().StringArrayVar(&opts.pluginConfig, "plugin-config", nil, "{key}={value} pairs that are passed as it is to a plugin, if the verification is associated with a verification plugin, refer plugin documentation to set appropriate values")
 	cmd.SetPflagUserMetadata(command.Flags(), &opts.userMetadata, cmd.PflagUserMetadataVerifyUsage)
+	command.Flags().BoolVar(&opts.allowReferrersAPI, "allow-referrers-api", false, "[Experimental] use the Referrers API to verify signatures, if not supported, fallback to the Referrers tag schema")
 	command.Flags().BoolVar(&opts.ociLayout, "oci-layout", false, "[Experimental] verify the artifact stored as OCI image layout")
 	command.Flags().StringVar(&opts.trustPolicyScope, "scope", "", "[Experimental] set trust policy scope for artifact verification, required and can only be used when flag \"--oci-layout\" is set")
 	command.MarkFlagsRequiredTogether("oci-layout", "scope")
-	experimental.HideFlags(command, experimentalExamples, []string{"oci-layout", "scope"})
+	experimental.HideFlags(command, experimentalExamples, []string{"allow-referrers-api", "oci-layout", "scope"})
 	return command
 }
 
@@ -110,7 +115,7 @@ func runVerify(command *cobra.Command, opts *verifyOpts) error {
 
 	// core verify process
 	reference := opts.reference
-	sigRepo, err := getRepository(ctx, opts.inputType, reference, &opts.SecureFlagOpts)
+	sigRepo, err := getRepository(ctx, opts.inputType, reference, &opts.SecureFlagOpts, opts.allowReferrersAPI)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,14 +5,14 @@ go 1.20
 require (
 	github.com/docker/docker-credential-helpers v0.7.0
 	github.com/notaryproject/notation-core-go v1.0.0-rc.3
-	github.com/notaryproject/notation-go v1.0.0-rc.4
+	github.com/notaryproject/notation-go v1.0.0-rc.4.0.20230511062925-4e790cea6bad
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc2
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/term v0.7.0
-	oras.land/oras-go/v2 v2.0.2
+	oras.land/oras-go/v2 v2.1.0
 )
 
 require (
@@ -24,7 +24,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/veraison/go-cose v1.0.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
-	golang.org/x/crypto v0.7.0 // indirect
+	golang.org/x/crypto v0.8.0 // indirect
 	golang.org/x/mod v0.10.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/notaryproject/notation-core-go v1.0.0-rc.3 h1:ukRBOwctPF0bWLFs+ThDHwgj+L3+AHdyaOqmziLp8w0=
 github.com/notaryproject/notation-core-go v1.0.0-rc.3/go.mod h1:XWAlhOksW+c9AA/TyobkPv5Xoz8RWGwOAoDdybZLEiI=
-github.com/notaryproject/notation-go v1.0.0-rc.4 h1:thTDY0wD6YS4EJeHt9kF0bZF9Z9Vin0tidalhJt1Q9o=
-github.com/notaryproject/notation-go v1.0.0-rc.4/go.mod h1:UEEAyBOSlx2yDDiMoofBz635ewcL/KU48AX1WDd5Les=
+github.com/notaryproject/notation-go v1.0.0-rc.4.0.20230511062925-4e790cea6bad h1:g8pg9gtX82+i4ovfd3VWiCTcqdVktfrtpXWyXRWt6DE=
+github.com/notaryproject/notation-go v1.0.0-rc.4.0.20230511062925-4e790cea6bad/go.mod h1:Z362SLw4xyXXuWcmXbtxwFJq/lecVDlbdMfpHLKIa6c=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0-rc2 h1:2zx/Stx4Wc5pIPDvIxHXvXtQFW/7XWJGmnM7r3wg034=
@@ -43,8 +43,8 @@ github.com/veraison/go-cose v1.0.0/go.mod h1:7ziE85vSq4ScFTg6wyoMXjucIGOf4JkFEZi
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.7.0 h1:AvwMYaRytfdeVt3u6mLaxYtErKYjxA2OXjJ1HHq6t3A=
-golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=
+golang.org/x/crypto v0.8.0 h1:pd9TJtTueMTVQXzk8E2XESSMQDj/U7OUu0PqJqPXQjQ=
+golang.org/x/crypto v0.8.0/go.mod h1:mRqEX+O9/h5TFCrQhkgjo2yKi0yYA+9ecGkdQoHrywE=
 golang.org/x/mod v0.10.0 h1:lFO9qtOdlre5W1jxS3r/4szv2/6iXxScdzjoBMXNhYk=
 golang.org/x/mod v0.10.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -65,5 +65,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-oras.land/oras-go/v2 v2.0.2 h1:3aSQdJ7EUC0ft2e9PjJB9Jzastz5ojPA4LzZ3Q4YbUc=
-oras.land/oras-go/v2 v2.0.2/go.mod h1:PWnWc/Kyyg7wUTUsDHshrsJkzuxXzreeMd6NrfdnFSo=
+oras.land/oras-go/v2 v2.1.0 h1:1nS8BIeEP6CBVQifwxrsth2bkuD+cYfjp7Hf7smUcS8=
+oras.land/oras-go/v2 v2.1.0/go.mod h1:v5ZSAPIMEJYnZjZ6rTGPAyaonH+rCFmbE95IAzCTeGU=

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -96,11 +96,8 @@ var (
 	PflagReferrersAPI = &pflag.Flag{
 		Name: "allow-referrers-api",
 	}
-	PflagReferrersAPISignUsage    = "[Experimental] use the Referrers API to store signatures in the registry, if not supported (returns 404), fallback to the Referrers tag schema"
-	PflagReferrersAPIVerifyUsage  = "[Experimental] use the Referrers API to verify signatures, if not supported (returns 404), fallback to the Referrers tag schema"
-	PflagReferrersAPIListUsage    = "[Experimental] use the Referrers API to list signatures, if not supported (returns 404), fallback to the Referrers tag schema"
-	PflagReferrersAPIInspectUsage = "[Experimental] use the Referrers API to inspect signatures, if not supported (returns 404), fallback to the Referrers tag schema"
-	SetPflagReferrersAPI          = func(fs *pflag.FlagSet, p *bool, usage string) {
+	PflagReferrersUsageFormat = "[Experimental] use the Referrers API to %s signatures, if not supported (returns 404), fallback to the Referrers tag schema"
+	SetPflagReferrersAPI      = func(fs *pflag.FlagSet, p *bool, usage string) {
 		fs.BoolVar(p, PflagReferrersAPI.Name, false, usage)
 	}
 

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -93,6 +93,17 @@ var (
 		fs.StringArrayVarP(p, PflagUserMetadata.Name, PflagUserMetadata.Shorthand, nil, usage)
 	}
 
+	PflagReferrersAPI = &pflag.Flag{
+		Name: "allow-referrers-api",
+	}
+	PflagReferrersAPISignUsage    = "[Experimental] use the Referrers API to store signatures in the registry, if not supported (returns 404), fallback to the Referrers tag schema"
+	PflagReferrersAPIVerifyUsage  = "[Experimental] use the Referrers API to verify signatures, if not supported (returns 404), fallback to the Referrers tag schema"
+	PflagReferrersAPIListUsage    = "[Experimental] use the Referrers API to list signatures, if not supported (returns 404), fallback to the Referrers tag schema"
+	PflagReferrersAPIInspectUsage = "[Experimental] use the Referrers API to inspect signatures, if not supported (returns 404), fallback to the Referrers tag schema"
+	SetPflagReferrersAPI          = func(fs *pflag.FlagSet, p *bool, usage string) {
+		fs.BoolVar(p, PflagReferrersAPI.Name, false, usage)
+	}
+
 	PflagOutput = &pflag.Flag{
 		Name:      "output",
 		Shorthand: "o",

--- a/specs/commandline/inspect.md
+++ b/specs/commandline/inspect.md
@@ -33,11 +33,14 @@ Usage:
     notation inspect [flags] <reference>
   
 Flags:
-   -h, --help              help for describing the signature
-   -o, --output json       output on command line sets the output to json
-   -p, --password string   password for registry operations (default to $NOTATION_PASSWORD if not specified)
-       --plain-http        registry access via plain HTTP
-   -u, --username string   username for registry operations (default to $NOTATION_USERNAME if not specified)
+      --allow-referrers-api   [Experimental] use the Referrers API to inspect signatures, if not supported, fallback to the Referrers tag schema
+  -d, --debug                 debug mode
+  -h, --help                  help for inspect
+  -o, --output string         output format, options: 'json', 'text' (default "text")
+  -p, --password string       password for registry operations (default to $NOTATION_PASSWORD if not specified)
+      --plain-http            registry access via plain HTTP
+  -u, --username string       username for registry operations (default to $NOTATION_USERNAME if not specified)
+  -v, --verbose               verbose mode
 ```
 
 ## Usage

--- a/specs/commandline/inspect.md
+++ b/specs/commandline/inspect.md
@@ -33,7 +33,7 @@ Usage:
     notation inspect [flags] <reference>
   
 Flags:
-      --allow-referrers-api   [Experimental] use the Referrers API to inspect signatures, if not supported, fallback to the Referrers tag schema
+      --allow-referrers-api   [Experimental] use the Referrers API to inspect signatures, if not supported (returns 404), fallback to the Referrers tag schema
   -d, --debug                 debug mode
   -h, --help                  help for inspect
   -o, --output string         output format, options: 'json', 'text' (default "text")

--- a/specs/commandline/list.md
+++ b/specs/commandline/list.md
@@ -27,7 +27,7 @@ Aliases:
   list, ls
 
 Flags:
-      --allow-referrers-api   [Experimental] use the Referrers API to list signatures, if not supported, fallback to the Referrers tag schema
+      --allow-referrers-api   [Experimental] use the Referrers API to list signatures, if not supported (returns 404), fallback to the Referrers tag schema
   -d, --debug                 debug mode
   -h, --help                  help for list
       --oci-layout            [Experimental] list signatures stored in OCI image layout

--- a/specs/commandline/list.md
+++ b/specs/commandline/list.md
@@ -27,13 +27,14 @@ Aliases:
   list, ls
 
 Flags:
-  -d, --debug             debug mode
-  -h, --help              help for list
-      --oci-layout        [Experimental] list signatures stored in OCI image layout
-  -p, --password string   password for registry operations (default to $NOTATION_PASSWORD if not specified)
-      --plain-http        registry access via plain HTTP
-  -u, --username string   username for registry operations (default to $NOTATION_USERNAME if not specified)
-  -v, --verbose           verbose mode
+      --allow-referrers-api   [Experimental] use the Referrers API to list signatures, if not supported, fallback to the Referrers tag schema
+  -d, --debug                 debug mode
+  -h, --help                  help for list
+      --oci-layout            [Experimental] list signatures stored in OCI image layout
+  -p, --password string       password for registry operations (default to $NOTATION_PASSWORD if not specified)
+      --plain-http            registry access via plain HTTP
+  -u, --username string       username for registry operations (default to $NOTATION_USERNAME if not specified)
+  -v, --verbose               verbose mode
 ```
 
 ## Usage

--- a/specs/commandline/sign.md
+++ b/specs/commandline/sign.md
@@ -28,7 +28,7 @@ Usage:
   notation sign [flags] <reference>
 
 Flags:
-       --allow-referrers-api        [Experimental] use the Referrers API to store signatures in the registry, if not supported, fallback to the Referrers tag schema
+       --allow-referrers-api        [Experimental] use the Referrers API to store signatures in the registry, if not supported (returns 404), fallback to the Referrers tag schema
   -d,  --debug                      debug mode
   -e,  --expiry duration            optional expiry that provides a "best by use" time for the artifact. The duration is specified in minutes(m) and/or hours(h). For example: 12h, 30m, 3h20m
   -h,  --help                       help for sign

--- a/specs/commandline/sign.md
+++ b/specs/commandline/sign.md
@@ -28,6 +28,7 @@ Usage:
   notation sign [flags] <reference>
 
 Flags:
+       --allow-referrers-api        [Experimental] use the Referrers API to store signatures in the registry, if not supported, fallback to the Referrers tag schema
   -d,  --debug                      debug mode
   -e,  --expiry duration            optional expiry that provides a "best by use" time for the artifact. The duration is specified in minutes(m) and/or hours(h). For example: 12h, 30m, 3h20m
   -h,  --help                       help for sign
@@ -39,23 +40,14 @@ Flags:
        --plugin string              signing plugin name. This is mutually exclusive with the --key flag
        --plugin-config stringArray  {key}={value} pairs that are passed as it is to a plugin, refer plugin's documentation to set appropriate values.
        --signature-format string    signature envelope format, options: "jws", "cose" (default "jws")
-       --signature-manifest string  [Experimental] manifest type for signature, options: "image", "artifact" (default "image")
   -u,  --username string            username for registry operations (default to $NOTATION_USERNAME if not specified)
   -m,  --user-metadata stringArray  {key}={value} pairs that are added to the signature payload
   -v,  --verbose                    verbose mode
 ```
 
-## Use OCI image manifest to store signatures
-
-By default, Notation uses [OCI image manifest][oci-image-spec] to store signatures in registries. Users can use [OCI artifact manifest][oci-artifact-manifest] by enabling the `--signature-manifest artifact` flag. This is an experimental feature, which is not intended for production use and may change or be removed in future versions. When using OCI artifact manifest to store the signature, the registry is REQUIRED to support both `OCI artifact` and [Referrers API][oci-referers-api].
-
-Note that there is no deterministic way to determine whether a registry supports `OCI artifact` or not. The following response status contained in error messages MAY indicate that the registry doesn't support `OCI artifact`.
-
-- Response status `400 BAD Request` with error code `MANIFEST_INVALID` or `UNSUPPORTED`
-
 ### Set config property for OCI image manifest
 
-OCI image manifest requires additional property `config` of type `descriptor`, which is not required by OCI artifact manifest. When signing with OCI image manifest, Notation uses empty JSON object `{}` as the default configuration content, and thus the `config` property is fixed, as following:
+Notation uses [OCI image manifest][oci-image-spec] to store signatures in registries. The empty JSON object `{}` is used as the default configuration content, and thus the `config` property is fixed, as following:
 
 ```json
 "config": {
@@ -159,15 +151,6 @@ An example for a successful signing:
 $ notation sign localhost:5000/net-monitor:v1
 Warning: Always sign the artifact using digest(`@sha256:...`) rather than a tag(`:v1`) because tags are mutable and a tag reference can point to a different artifact than the one signed.
 Successfully signed localhost:5000/net-monitor@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
-```
-
-### [Experimental] Sign an artifact and store the signature using OCI artifact manifest
-
-To access this flag `--signature-manifest`, set the environment variable `NOTATION_EXPERIMENTAL=1`.
-
-```shell
-export NOTATION_EXPERIMENTAL=1 
-notation sign --signature-manifest artifact <registry>/<repository>@<digest>
 ```
 
 ### [Experimental] Sign container images stored in OCI layout directory

--- a/specs/commandline/verify.md
+++ b/specs/commandline/verify.md
@@ -35,7 +35,7 @@ Usage:
   notation verify [flags] <reference>
 
 Flags:
-       --allow-referrers-api         [Experimental] use the Referrers API to verify signatures, if not supported, fallback to the Referrers tag schema
+       --allow-referrers-api         [Experimental] use the Referrers API to verify signatures, if not supported (returns 404), fallback to the Referrers tag schema
   -d,  --debug                       debug mode
   -h,  --help                        help for verify
        --oci-layout                  [Experimental] verify the artifact stored as OCI image layout

--- a/specs/commandline/verify.md
+++ b/specs/commandline/verify.md
@@ -35,6 +35,7 @@ Usage:
   notation verify [flags] <reference>
 
 Flags:
+       --allow-referrers-api         [Experimental] use the Referrers API to verify signatures, if not supported, fallback to the Referrers tag schema
   -d,  --debug                       debug mode
   -h,  --help                        help for verify
        --oci-layout                  [Experimental] verify the artifact stored as OCI image layout

--- a/test/e2e/suite/command/verify.go
+++ b/test/e2e/suite/command/verify.go
@@ -12,7 +12,7 @@ import (
 var _ = Describe("notation verify", func() {
 	It("by digest", func() {
 		Host(BaseOptions(), func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
-			OldNotation().Exec("sign", artifact.ReferenceWithDigest()).
+			notation.Exec("sign", artifact.ReferenceWithDigest()).
 				MatchKeyWords(SignSuccessfully)
 
 			notation.Exec("verify", artifact.ReferenceWithDigest(), "-v").
@@ -22,7 +22,7 @@ var _ = Describe("notation verify", func() {
 
 	It("by tag", func() {
 		Host(BaseOptions(), func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
-			OldNotation().Exec("sign", artifact.ReferenceWithDigest()).
+			notation.Exec("sign", artifact.ReferenceWithDigest()).
 				MatchKeyWords(SignSuccessfully)
 
 			notation.Exec("verify", artifact.ReferenceWithTag(), "-v").
@@ -32,7 +32,7 @@ var _ = Describe("notation verify", func() {
 
 	It("with debug log", func() {
 		Host(BaseOptions(), func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
-			OldNotation().Exec("sign", artifact.ReferenceWithDigest()).
+			notation.Exec("sign", artifact.ReferenceWithDigest()).
 				MatchKeyWords(SignSuccessfully)
 
 			notation.Exec("verify", artifact.ReferenceWithDigest(), "-d").
@@ -46,6 +46,26 @@ var _ = Describe("notation verify", func() {
 					"Validating authentic timestamp",
 					"Validating revocation",
 				).
+				MatchKeyWords(VerifySuccessfully)
+		})
+	})
+
+	It("by digest with the Referrers API", func() {
+		Host(BaseOptionsWithExperimental(), func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+			notation.Exec("sign", "--allow-referrers-api", artifact.ReferenceWithDigest()).
+				MatchKeyWords(SignSuccessfully)
+
+			notation.Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
+				MatchKeyWords(VerifySuccessfully)
+		})
+	})
+
+	It("by digest, sign with the Referrers tag schema, verify with the Referrers API", func() {
+		Host(BaseOptionsWithExperimental(), func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+			notation.Exec("sign", artifact.ReferenceWithDigest()).
+				MatchKeyWords(SignSuccessfully)
+
+			notation.Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
 				MatchKeyWords(VerifySuccessfully)
 		})
 	})

--- a/test/e2e/suite/trustpolicy/multi_statements.go
+++ b/test/e2e/suite/trustpolicy/multi_statements.go
@@ -15,7 +15,7 @@ var _ = Describe("notation trust policy multi-statements test", func() {
 			vhost.SetOption(AddTrustPolicyOption("multi_statements_with_the_same_registry_scope_trustpolicy.json"))
 
 			// test localhost:5000/test-repo
-			OldNotation().Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
+			notation.Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
 			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest()).
 				MatchErrContent("Error: registry scope \"localhost:5000/test-repo8\" is present in multiple trust policy statements, one registry scope value can only be associated with one statement\n")
 		})
@@ -28,7 +28,7 @@ var _ = Describe("notation trust policy multi-statements test", func() {
 			vhost.SetOption(AddTrustPolicyOption("multi_statements_with_wildcard_registry_scope_trustpolicy.json"))
 
 			// test localhost:5000/test-repo
-			OldNotation().Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
+			notation.Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
 			notation.Exec("verify", artifact.ReferenceWithDigest()).
 				MatchKeyWords(VerifySuccessfully)
 		})
@@ -41,7 +41,7 @@ var _ = Describe("notation trust policy multi-statements test", func() {
 			vhost.SetOption(AddTrustPolicyOption("multi_statements_with_the_same_name_trustpolicy.json"))
 
 			// test localhost:5000/test-repo
-			OldNotation().Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
+			notation.Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
 			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest()).
 				MatchErrContent("Error: multiple trust policy statements use the same name \"e2e\", statement names must be unique\n")
 		})
@@ -53,7 +53,7 @@ var _ = Describe("notation trust policy multi-statements test", func() {
 			vhost.SetOption(AddTrustPolicyOption("multi_statements_with_multi_wildcard_registry_scope_trustpolicy.json"))
 
 			// test localhost:5000/test-repo
-			OldNotation().Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
+			notation.Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
 			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest()).
 				MatchErrContent("Error: registry scope \"*\" is present in multiple trust policy statements, one registry scope value can only be associated with one statement\n")
 		})

--- a/test/e2e/suite/trustpolicy/registry_scope.go
+++ b/test/e2e/suite/trustpolicy/registry_scope.go
@@ -27,7 +27,7 @@ var _ = Describe("notation trust policy registryScope test", func() {
 			// update trustpolicy.json
 			vhost.SetOption(AddTrustPolicyOption("malformed_registry_scope_trustpolicy.json"))
 
-			notation.Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
+			OldNotation().Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
 			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest()).
 				MatchErrKeyWords(`registry scope "localhost:5000\\test-repo" is not valid, make sure it is a fully qualified registry URL without the scheme/protocol, e.g domain.com/my/repository OR a local trust policy scope, e.g local/myOCILayout`)
 		})
@@ -93,7 +93,7 @@ var _ = Describe("notation trust policy registryScope test", func() {
 			artifact := GenerateArtifact("", "test-repo6")
 
 			// test localhost:5000/test-repo
-			notation.Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
+			OldNotation().Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
 			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest()).
 				MatchErrKeyWords("registry scope \"localhost:5000/test-repo6\" is present in multiple trust policy statements")
 		})
@@ -107,7 +107,7 @@ var _ = Describe("notation trust policy registryScope test", func() {
 			artifact := GenerateArtifact("", "test-repo7")
 
 			// test localhost:5000/test-repo
-			notation.Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
+			OldNotation().Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
 			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest()).
 				MatchErrKeyWords("trust policy statement \"e2e\" uses wildcard registry scope '*', a wildcard scope cannot be used in conjunction with other scope values")
 		})
@@ -119,7 +119,7 @@ var _ = Describe("notation trust policy registryScope test", func() {
 			vhost.SetOption(AddTrustPolicyOption("invalid_registry_scope_trustpolicy.json"))
 
 			// test localhost:5000/test-repo
-			notation.Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
+			OldNotation().Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
 			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest()).
 				MatchErrContent(fmt.Sprintf("Error: signature verification failed: artifact %q has no applicable trust policy\n", artifact.ReferenceWithDigest()))
 		})

--- a/test/e2e/suite/trustpolicy/registry_scope.go
+++ b/test/e2e/suite/trustpolicy/registry_scope.go
@@ -16,7 +16,7 @@ var _ = Describe("notation trust policy registryScope test", func() {
 			vhost.SetOption(AddTrustPolicyOption("empty_registry_scope_trustpolicy.json"))
 
 			// test localhost:5000/test-repo
-			notation.Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
+			OldNotation().Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
 			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest()).
 				MatchErrKeyWords("trust policy statement \"e2e\" has zero registry scopes")
 		})

--- a/test/e2e/suite/trustpolicy/registry_scope.go
+++ b/test/e2e/suite/trustpolicy/registry_scope.go
@@ -16,7 +16,7 @@ var _ = Describe("notation trust policy registryScope test", func() {
 			vhost.SetOption(AddTrustPolicyOption("empty_registry_scope_trustpolicy.json"))
 
 			// test localhost:5000/test-repo
-			OldNotation().Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
+			notation.Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
 			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest()).
 				MatchErrKeyWords("trust policy statement \"e2e\" has zero registry scopes")
 		})
@@ -27,7 +27,7 @@ var _ = Describe("notation trust policy registryScope test", func() {
 			// update trustpolicy.json
 			vhost.SetOption(AddTrustPolicyOption("malformed_registry_scope_trustpolicy.json"))
 
-			OldNotation().Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
+			notation.Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
 			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest()).
 				MatchErrKeyWords(`registry scope "localhost:5000\\test-repo" is not valid, make sure it is a fully qualified registry URL without the scheme/protocol, e.g domain.com/my/repository OR a local trust policy scope, e.g local/myOCILayout`)
 		})
@@ -42,7 +42,7 @@ var _ = Describe("notation trust policy registryScope test", func() {
 			artifact := GenerateArtifact("", "test-repo")
 
 			// test localhost:5000/test-repo
-			OldNotation().Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
+			notation.Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
 			notation.Exec("verify", artifact.ReferenceWithDigest()).MatchKeyWords(VerifySuccessfully)
 		})
 	})
@@ -57,11 +57,11 @@ var _ = Describe("notation trust policy registryScope test", func() {
 			artifact3 := GenerateArtifact("", "test-repo3")
 
 			// test localhost:5000/test-repo2
-			OldNotation().Exec("sign", artifact2.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
+			notation.Exec("sign", artifact2.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
 			notation.Exec("verify", artifact2.ReferenceWithDigest()).MatchKeyWords(VerifySuccessfully)
 
 			// test localhost:5000/test-repo3
-			OldNotation().Exec("sign", artifact3.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
+			notation.Exec("sign", artifact3.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
 			notation.Exec("verify", artifact3.ReferenceWithDigest()).MatchKeyWords(VerifySuccessfully)
 		})
 	})
@@ -76,11 +76,11 @@ var _ = Describe("notation trust policy registryScope test", func() {
 			artifact5 := GenerateArtifact("", "test-repo5")
 
 			// test localhost:5000/test-repo4
-			OldNotation().Exec("sign", artifact4.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
+			notation.Exec("sign", artifact4.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
 			notation.Exec("verify", artifact4.ReferenceWithDigest()).MatchKeyWords(VerifySuccessfully)
 
 			// test localhost:5000/test-repo5
-			OldNotation().Exec("sign", artifact5.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
+			notation.Exec("sign", artifact5.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
 			notation.Exec("verify", artifact5.ReferenceWithDigest()).MatchKeyWords(VerifySuccessfully)
 		})
 	})
@@ -93,7 +93,7 @@ var _ = Describe("notation trust policy registryScope test", func() {
 			artifact := GenerateArtifact("", "test-repo6")
 
 			// test localhost:5000/test-repo
-			OldNotation().Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
+			notation.Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
 			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest()).
 				MatchErrKeyWords("registry scope \"localhost:5000/test-repo6\" is present in multiple trust policy statements")
 		})
@@ -107,7 +107,7 @@ var _ = Describe("notation trust policy registryScope test", func() {
 			artifact := GenerateArtifact("", "test-repo7")
 
 			// test localhost:5000/test-repo
-			OldNotation().Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
+			notation.Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
 			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest()).
 				MatchErrKeyWords("trust policy statement \"e2e\" uses wildcard registry scope '*', a wildcard scope cannot be used in conjunction with other scope values")
 		})
@@ -119,7 +119,7 @@ var _ = Describe("notation trust policy registryScope test", func() {
 			vhost.SetOption(AddTrustPolicyOption("invalid_registry_scope_trustpolicy.json"))
 
 			// test localhost:5000/test-repo
-			OldNotation().Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
+			notation.Exec("sign", artifact.ReferenceWithDigest()).MatchKeyWords(SignSuccessfully)
 			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest()).
 				MatchErrContent(fmt.Sprintf("Error: signature verification failed: artifact %q has no applicable trust policy\n", artifact.ReferenceWithDigest()))
 		})

--- a/test/e2e/suite/trustpolicy/trust_store.go
+++ b/test/e2e/suite/trustpolicy/trust_store.go
@@ -70,14 +70,15 @@ var _ = Describe("notation trust policy trust store test", func() {
 			vhost.SetOption(AuthOption("", ""),
 				AddTrustPolicyOption("multiple_trust_store_trustpolicy.json"),
 				AddTrustStoreOption("e2e-new", filepath.Join(NotationE2ELocalKeysDir, "new_e2e.crt")),
-				AddTrustStoreOption("e2e", filepath.Join(NotationE2ELocalKeysDir, "e2e.crt")))
+				AddTrustStoreOption("e2e", filepath.Join(NotationE2ELocalKeysDir, "e2e.crt")),
+				EnableExperimental())
 
 			notation.WithDescription("verify artifact1 with trust store ca/e2e-new").
-				Exec("verify", artifact1.ReferenceWithDigest(), "-v").
+				Exec("verify", "--allow-referrers-api", artifact1.ReferenceWithDigest(), "-v").
 				MatchKeyWords(VerifySuccessfully)
 
 			notation.WithDescription("verify artifact2 with trust store ca/e2e").
-				Exec("verify", artifact2.ReferenceWithDigest(), "-v").
+				Exec("verify", "--allow-referrers-api", artifact2.ReferenceWithDigest(), "-v").
 				MatchKeyWords(VerifySuccessfully)
 		})
 	})
@@ -86,7 +87,7 @@ var _ = Describe("notation trust policy trust store test", func() {
 		Skip("overlapped trust stores were not checked")
 		Host(nil, func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
 			// artifact signed with new_e2e.crt
-			OldNotation().Exec("sign", artifact.ReferenceWithDigest(), "-v").
+			notation.Exec("sign", artifact.ReferenceWithDigest(), "-v").
 				MatchKeyWords(SignSuccessfully)
 
 			// setup overlapped trust store

--- a/test/e2e/suite/trustpolicy/trust_store.go
+++ b/test/e2e/suite/trustpolicy/trust_store.go
@@ -22,12 +22,12 @@ var _ = Describe("notation trust policy trust store test", func() {
 	})
 
 	It("invalid trust store", func() {
-		Host(BaseOptions(), func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
+		Host(BaseOptionsWithExperimental(), func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
 			vhost.SetOption(AddTrustPolicyOption("invalid_trust_store_trustpolicy.json"))
 
 			artifact := GenerateArtifact("e2e-valid-signature", "")
 
-			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest(), "-v").
+			notation.ExpectFailure().Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
 				MatchErrKeyWords("authenticity validation failed",
 					"truststore/x509/ca/invalid_store\\\" does not exist",
 					VerifyFailed)

--- a/test/e2e/suite/trustpolicy/trusted_identity.go
+++ b/test/e2e/suite/trustpolicy/trusted_identity.go
@@ -31,11 +31,11 @@ var _ = Describe("notation trust policy trusted identity test", func() {
 	})
 
 	It("with invalid trusted identity", func() {
-		Host(BaseOptions(), func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
+		Host(BaseOptionsWithExperimental(), func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
 			vhost.SetOption(AddTrustPolicyOption("invalid_trusted_identity_trustpolicy.json"))
 			artifact := GenerateArtifact("e2e-valid-signature", "")
 
-			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest(), "-v").
+			notation.ExpectFailure().Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
 				MatchErrKeyWords("Failure reason: signing certificate from the digital signature does not match the X.509 trusted identities",
 					VerifyFailed)
 		})

--- a/test/e2e/suite/trustpolicy/trusted_identity.go
+++ b/test/e2e/suite/trustpolicy/trusted_identity.go
@@ -21,11 +21,11 @@ var _ = Describe("notation trust policy trusted identity test", func() {
 	})
 
 	It("with valid trusted identity", func() {
-		Host(BaseOptions(), func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
+		Host(BaseOptionsWithExperimental(), func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
 			vhost.SetOption(AddTrustPolicyOption("valid_trusted_identity_trustpolicy.json"))
 			artifact := GenerateArtifact("e2e-valid-signature", "")
 
-			notation.Exec("verify", artifact.ReferenceWithDigest(), "-v").
+			notation.Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
 				MatchKeyWords(VerifySuccessfully)
 		})
 	})
@@ -76,12 +76,13 @@ var _ = Describe("notation trust policy trusted identity test", func() {
 				AddTrustPolicyOption("multiple_trusted_identity_trustpolicy.json"),
 				AddTrustStoreOption("e2e", filepath.Join(NotationE2ELocalKeysDir, "new_e2e.crt")),
 				AddTrustStoreOption("e2e", filepath.Join(NotationE2ELocalKeysDir, "e2e.crt")),
+				EnableExperimental(),
 			)
 
-			notation.Exec("verify", artifact1.ReferenceWithDigest(), "-v").
+			notation.Exec("verify", "--allow-referrers-api", artifact1.ReferenceWithDigest(), "-v").
 				MatchKeyWords(VerifySuccessfully)
 
-			notation.Exec("verify", artifact2.ReferenceWithDigest(), "-v").
+			notation.Exec("verify", "--allow-referrers-api", artifact2.ReferenceWithDigest(), "-v").
 				MatchKeyWords(VerifySuccessfully)
 		})
 	})

--- a/test/e2e/suite/trustpolicy/verification_level.go
+++ b/test/e2e/suite/trustpolicy/verification_level.go
@@ -11,10 +11,10 @@ import (
 
 var _ = Describe("notation trust policy verification level test", func() {
 	It("strict level with expired signature", func() {
-		Host(BaseOptions(), func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
+		Host(BaseOptionsWithExperimental(), func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
 			artifact := GenerateArtifact("e2e-expired-signature", "")
 
-			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest(), "-v").
+			notation.ExpectFailure().Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
 				MatchErrKeyWords("expiry validation failed.",
 					VerifyFailed)
 		})
@@ -26,9 +26,10 @@ var _ = Describe("notation trust policy verification level test", func() {
 
 			vhost.SetOption(AuthOption("", ""),
 				AddTrustPolicyOption("trustpolicy.json"),
-				AddTrustStoreOption("e2e", filepath.Join(NotationE2EConfigPath, "localkeys", "expired_e2e.crt")))
+				AddTrustStoreOption("e2e", filepath.Join(NotationE2EConfigPath, "localkeys", "expired_e2e.crt")),
+				EnableExperimental())
 
-			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest(), "-v").
+			notation.ExpectFailure().Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
 				MatchErrKeyWords("authenticTimestamp validation failed",
 					VerifyFailed)
 		})
@@ -38,35 +39,36 @@ var _ = Describe("notation trust policy verification level test", func() {
 		Host(nil, func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
 			vhost.SetOption(AuthOption("", ""),
 				AddTrustPolicyOption("trustpolicy.json"),
-				AddTrustStoreOption("e2e", filepath.Join(NotationE2ELocalKeysDir, "new_e2e.crt")))
+				AddTrustStoreOption("e2e", filepath.Join(NotationE2ELocalKeysDir, "new_e2e.crt")),
+				EnableExperimental())
 
 			// the artifact signed with a different cert from the cert in
 			// trust store.
 			artifact := GenerateArtifact("e2e-valid-signature", "")
 
-			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest(), "-v").
+			notation.ExpectFailure().Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
 				MatchErrKeyWords("authenticity validation failed",
 					VerifyFailed)
 		})
 	})
 
 	It("strict level with invalid integrity", func() {
-		Host(BaseOptions(), func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
+		Host(BaseOptionsWithExperimental(), func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
 			artifact := GenerateArtifact("e2e-invalid-signature", "")
 
-			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest(), "-v").
+			notation.ExpectFailure().Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
 				MatchErrKeyWords("integrity validation failed",
 					VerifyFailed)
 		})
 	})
 
 	It("permissive level with expired signature", func() {
-		Host(BaseOptions(), func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
+		Host(BaseOptionsWithExperimental(), func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
 			vhost.SetOption(AddTrustPolicyOption("permissive_trustpolicy.json"))
 
 			artifact := GenerateArtifact("e2e-expired-signature", "")
 
-			notation.Exec("verify", artifact.ReferenceWithDigest(), "-v").
+			notation.Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
 				MatchErrKeyWords("expiry was set to \"log\" and failed with error: digital signature has expired").
 				MatchKeyWords(VerifySuccessfully)
 		})
@@ -78,9 +80,10 @@ var _ = Describe("notation trust policy verification level test", func() {
 
 			vhost.SetOption(AuthOption("", ""),
 				AddTrustPolicyOption("permissive_trustpolicy.json"),
-				AddTrustStoreOption("e2e", filepath.Join(NotationE2EConfigPath, "localkeys", "expired_e2e.crt")))
+				AddTrustStoreOption("e2e", filepath.Join(NotationE2EConfigPath, "localkeys", "expired_e2e.crt")),
+				EnableExperimental())
 
-			notation.Exec("verify", artifact.ReferenceWithDigest(), "-v").
+			notation.Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
 				MatchErrKeyWords("Warning: authenticTimestamp was set to \"log\"",
 					"error: certificate \"O=Internet Widgits Pty Ltd,ST=Some-State,C=AU\" is not valid anymore, it was expired").
 				MatchKeyWords(VerifySuccessfully)
@@ -91,37 +94,38 @@ var _ = Describe("notation trust policy verification level test", func() {
 		Host(nil, func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
 			vhost.SetOption(AuthOption("", ""),
 				AddTrustPolicyOption("permissive_trustpolicy.json"),
-				AddTrustStoreOption("e2e", filepath.Join(NotationE2ELocalKeysDir, "new_e2e.crt")))
+				AddTrustStoreOption("e2e", filepath.Join(NotationE2ELocalKeysDir, "new_e2e.crt")),
+				EnableExperimental())
 
 			// the artifact signed with a different cert from the cert in
 			// trust store.
 			artifact := GenerateArtifact("e2e-valid-signature", "")
 
-			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest(), "-v").
+			notation.ExpectFailure().Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
 				MatchErrKeyWords("authenticity validation failed",
 					VerifyFailed)
 		})
 	})
 
 	It("permissive level with invalid integrity", func() {
-		Host(BaseOptions(), func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
+		Host(BaseOptionsWithExperimental(), func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
 			vhost.SetOption(AddTrustPolicyOption("permissive_trustpolicy.json"))
 
 			artifact := GenerateArtifact("e2e-invalid-signature", "")
 
-			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest(), "-v").
+			notation.ExpectFailure().Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
 				MatchErrKeyWords("integrity validation failed",
 					VerifyFailed)
 		})
 	})
 
 	It("audit level with expired signature", func() {
-		Host(BaseOptions(), func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
+		Host(BaseOptionsWithExperimental(), func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
 			vhost.SetOption(AddTrustPolicyOption("audit_trustpolicy.json"))
 
 			artifact := GenerateArtifact("e2e-expired-signature", "")
 
-			notation.Exec("verify", artifact.ReferenceWithDigest(), "-v").
+			notation.Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
 				MatchErrKeyWords("digital signature has expired",
 					"expiry was set to \"log\"").
 				MatchKeyWords(VerifySuccessfully)
@@ -134,9 +138,10 @@ var _ = Describe("notation trust policy verification level test", func() {
 
 			vhost.SetOption(AuthOption("", ""),
 				AddTrustPolicyOption("audit_trustpolicy.json"),
-				AddTrustStoreOption("e2e", filepath.Join(NotationE2EConfigPath, "localkeys", "expired_e2e.crt")))
+				AddTrustStoreOption("e2e", filepath.Join(NotationE2EConfigPath, "localkeys", "expired_e2e.crt")),
+				EnableExperimental())
 
-			notation.Exec("verify", artifact.ReferenceWithDigest(), "-v").
+			notation.Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
 				MatchErrKeyWords("Warning: authenticTimestamp was set to \"log\"",
 					"error: certificate \"O=Internet Widgits Pty Ltd,ST=Some-State,C=AU\" is not valid anymore, it was expired").
 				MatchKeyWords(VerifySuccessfully)
@@ -147,13 +152,14 @@ var _ = Describe("notation trust policy verification level test", func() {
 		Host(nil, func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
 			vhost.SetOption(AuthOption("", ""),
 				AddTrustPolicyOption("audit_trustpolicy.json"),
-				AddTrustStoreOption("e2e", filepath.Join(NotationE2ELocalKeysDir, "new_e2e.crt")))
+				AddTrustStoreOption("e2e", filepath.Join(NotationE2ELocalKeysDir, "new_e2e.crt")),
+				EnableExperimental())
 
 			// the artifact signed with a different cert from the cert in
 			// trust store.
 			artifact := GenerateArtifact("e2e-valid-signature", "")
 
-			notation.Exec("verify", artifact.ReferenceWithDigest(), "-v").
+			notation.Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
 				MatchErrKeyWords("Warning: authenticity was set to \"log\"",
 					"signature is not produced by a trusted signer").
 				MatchKeyWords(VerifySuccessfully)
@@ -161,35 +167,35 @@ var _ = Describe("notation trust policy verification level test", func() {
 	})
 
 	It("audit level with invalid integrity", func() {
-		Host(BaseOptions(), func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
+		Host(BaseOptionsWithExperimental(), func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
 			vhost.SetOption(AddTrustPolicyOption("audit_trustpolicy.json"))
 
 			artifact := GenerateArtifact("e2e-invalid-signature", "")
 
-			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest(), "-v").
+			notation.ExpectFailure().Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
 				MatchErrKeyWords("integrity validation failed",
 					VerifyFailed)
 		})
 	})
 
 	It("skip level with invalid integrity", func() {
-		Host(BaseOptions(), func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
+		Host(BaseOptionsWithExperimental(), func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
 			vhost.SetOption(AddTrustPolicyOption("skip_trustpolicy.json"))
 
 			artifact := GenerateArtifact("e2e-invalid-signature", "")
 
-			notation.Exec("verify", artifact.ReferenceWithDigest(), "-v").
+			notation.Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
 				MatchKeyWords("Trust policy is configured to skip signature verification")
 		})
 	})
 
 	It("strict level with Expiry overridden as log level", func() {
-		Host(BaseOptions(), func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
+		Host(BaseOptionsWithExperimental(), func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
 			vhost.SetOption(AddTrustPolicyOption("override_strict_trustpolicy.json"))
 
 			artifact := GenerateArtifact("e2e-expired-signature", "")
 
-			notation.Exec("verify", artifact.ReferenceWithDigest(), "-v").
+			notation.Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
 				MatchErrKeyWords("digital signature has expired",
 					"expiry was set to \"log\"").
 				MatchKeyWords(VerifySuccessfully)
@@ -202,9 +208,10 @@ var _ = Describe("notation trust policy verification level test", func() {
 
 			vhost.SetOption(AuthOption("", ""),
 				AddTrustPolicyOption("override_strict_trustpolicy.json"),
-				AddTrustStoreOption("e2e", filepath.Join(NotationE2EConfigPath, "localkeys", "expired_e2e.crt")))
+				AddTrustStoreOption("e2e", filepath.Join(NotationE2EConfigPath, "localkeys", "expired_e2e.crt")),
+				EnableExperimental())
 
-			notation.Exec("verify", artifact.ReferenceWithDigest(), "-v").
+			notation.Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
 				MatchErrKeyWords("Warning: authenticTimestamp was set to \"log\"",
 					"error: certificate \"O=Internet Widgits Pty Ltd,ST=Some-State,C=AU\" is not valid anymore, it was expired").
 				MatchKeyWords(VerifySuccessfully)
@@ -215,12 +222,14 @@ var _ = Describe("notation trust policy verification level test", func() {
 		Host(nil, func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
 			vhost.SetOption(AuthOption("", ""),
 				AddTrustPolicyOption("override_strict_trustpolicy.json"),
-				AddTrustStoreOption("e2e", filepath.Join(NotationE2ELocalKeysDir, "new_e2e.crt")))
+				AddTrustStoreOption("e2e", filepath.Join(NotationE2ELocalKeysDir, "new_e2e.crt")),
+				EnableExperimental())
+
 			// the artifact signed with a different cert from the cert in
 			// trust store.
 			artifact := GenerateArtifact("e2e-valid-signature", "")
 
-			notation.Exec("verify", artifact.ReferenceWithDigest(), "-v").
+			notation.Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
 				MatchErrKeyWords("Warning: authenticity was set to \"log\"",
 					"signature is not produced by a trusted signer").
 				MatchKeyWords(VerifySuccessfully)
@@ -228,12 +237,12 @@ var _ = Describe("notation trust policy verification level test", func() {
 	})
 
 	It("permissive level with Expiry overridden as enforce level", func() {
-		Host(BaseOptions(), func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
+		Host(BaseOptionsWithExperimental(), func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
 			vhost.SetOption(AddTrustPolicyOption("override_permissive_trustpolicy.json"))
 
 			artifact := GenerateArtifact("e2e-expired-signature", "")
 
-			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest(), "-v").
+			notation.ExpectFailure().Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
 				MatchErrKeyWords("expiry validation failed.",
 					VerifyFailed)
 		})
@@ -247,9 +256,10 @@ var _ = Describe("notation trust policy verification level test", func() {
 
 			vhost.SetOption(AuthOption("", ""),
 				AddTrustPolicyOption("trustpolicy.json"),
-				AddTrustStoreOption("e2e", filepath.Join(NotationE2EConfigPath, "localkeys", "expired_e2e.crt")))
+				AddTrustStoreOption("e2e", filepath.Join(NotationE2EConfigPath, "localkeys", "expired_e2e.crt")),
+				EnableExperimental())
 
-			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest(), "-v").
+			notation.ExpectFailure().Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
 				MatchErrKeyWords("authenticTimestamp validation failed",
 					VerifyFailed)
 		})
@@ -259,11 +269,12 @@ var _ = Describe("notation trust policy verification level test", func() {
 		Host(nil, func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
 			vhost.SetOption(AuthOption("", ""),
 				AddTrustPolicyOption("override_permissive_trustpolicy.json"),
-				AddTrustStoreOption("e2e", filepath.Join(NotationE2ELocalKeysDir, "new_e2e.crt")))
+				AddTrustStoreOption("e2e", filepath.Join(NotationE2ELocalKeysDir, "new_e2e.crt")),
+				EnableExperimental())
 
 			artifact := GenerateArtifact("e2e-valid-signature", "")
 
-			notation.Exec("verify", artifact.ReferenceWithDigest(), "-v").
+			notation.Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
 				MatchErrKeyWords("Warning: authenticity was set to \"log\"",
 					"signature is not produced by a trusted signer").
 				MatchKeyWords(VerifySuccessfully)
@@ -274,22 +285,23 @@ var _ = Describe("notation trust policy verification level test", func() {
 		Host(nil, func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
 			vhost.SetOption(AuthOption("", ""),
 				AddTrustPolicyOption("override_integrity_for_permissive_trustpolicy.json"),
-				AddTrustStoreOption("e2e", filepath.Join(NotationE2ELocalKeysDir, "new_e2e.crt")))
+				AddTrustStoreOption("e2e", filepath.Join(NotationE2ELocalKeysDir, "new_e2e.crt")),
+				EnableExperimental())
 
 			artifact := GenerateArtifact("e2e-valid-signature", "")
 
-			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest(), "-v").
+			notation.ExpectFailure().Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
 				MatchErrKeyWords(`"integrity" verification can not be overridden in custom signature verification`)
 		})
 	})
 
 	It("audit level with Expiry overridden as enforce level", func() {
-		Host(BaseOptions(), func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
+		Host(BaseOptionsWithExperimental(), func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
 			vhost.SetOption(AddTrustPolicyOption("override_audit_trustpolicy.json"))
 
 			artifact := GenerateArtifact("e2e-expired-signature", "")
 
-			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest(), "-v").
+			notation.ExpectFailure().Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
 				MatchErrKeyWords("expiry validation failed.",
 					VerifyFailed)
 		})
@@ -303,9 +315,10 @@ var _ = Describe("notation trust policy verification level test", func() {
 
 			vhost.SetOption(AuthOption("", ""),
 				AddTrustPolicyOption("trustpolicy.json"),
-				AddTrustStoreOption("e2e", filepath.Join(NotationE2EConfigPath, "localkeys", "expired_e2e.crt")))
+				AddTrustStoreOption("e2e", filepath.Join(NotationE2EConfigPath, "localkeys", "expired_e2e.crt")),
+				EnableExperimental())
 
-			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest(), "-v").
+			notation.ExpectFailure().Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
 				MatchErrKeyWords("authenticTimestamp validation failed",
 					VerifyFailed)
 		})
@@ -315,13 +328,14 @@ var _ = Describe("notation trust policy verification level test", func() {
 		Host(nil, func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
 			vhost.SetOption(AuthOption("", ""),
 				AddTrustPolicyOption("override_audit_trustpolicy.json"),
-				AddTrustStoreOption("e2e", filepath.Join(NotationE2ELocalKeysDir, "new_e2e.crt")))
+				AddTrustStoreOption("e2e", filepath.Join(NotationE2ELocalKeysDir, "new_e2e.crt")),
+				EnableExperimental())
 
 			// the artifact signed with a different cert from the cert in
 			// trust store.
 			artifact := GenerateArtifact("e2e-valid-signature", "")
 
-			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest(), "-v").
+			notation.ExpectFailure().Exec("verify", "--allow-referrers-api", artifact.ReferenceWithDigest(), "-v").
 				MatchErrKeyWords("authenticity validation failed",
 					VerifyFailed)
 		})


### PR DESCRIPTION
In this PR:
1. Removed Notation's support of signing with OCI artifact manifest. (One can still consume signatures in this type.)
2.  Moved the Referrers API behind experimental as discussed in community meeting. This change takes effect on `sign`, `list`, `inspect`, and `verify` commands. When a user wants to try the Referrers API, they need to set both `NOTATION_EXPERIMENTAL=1` AND `--allow-referrers-api`; if the Referrers API is not supported, fallback to the Referrers tag schema automatically. Otherwise, by default, Notation would use the Referrers tag schema in all commands deterministically.
References: 
https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#listing-referrers
https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#referrers-tag-schema

This PR has been tested and:
resolves #659
resolves #660 