### PR TITLE
fix: Improve output when there is no signature associated

### DIFF
--- a/cmd/notation/inspect.go
+++ b/cmd/notation/inspect.go
@@ -102,9 +102,7 @@ func runInspect(command *cobra.Command, opts *inspectOpts) error {
 	if err != nil {
 		return err
 	}
-	manifestDesc, resolvedRef, err := resolveReference(ctx, inputTypeRegistry, reference, sigRepo, func(ref string, manifestDesc ocispec.Descriptor) {
-		fmt.Fprintf(os.Stderr, "Warning: Always inspect the artifact using digest(@sha256:...) rather than a tag(:%s) because resolved digest may not point to the same signed artifact, as tags are mutable.\n", ref)
-	})
+	manifestDesc, resolvedRef, err := resolveReferenceWithWarning(ctx, inputTypeRegistry, reference, sigRepo, "inspect")
 	if err != nil {
 		return err
 	}
@@ -247,6 +245,11 @@ func getCertificates(outputFormat string, envContent *signature.EnvelopeContent)
 func printOutput(outputFormat string, ref string, output inspectOutput) error {
 	if outputFormat == cmd.OutputJSON {
 		return ioutil.PrintObjectAsJSON(output)
+	}
+
+	if len(output.Signatures) == 0 {
+		fmt.Printf("%s has no associated signature\n", ref)
+		return nil
 	}
 
 	fmt.Println("Inspecting all signatures for signed artifact")

--- a/cmd/notation/list.go
+++ b/cmd/notation/list.go
@@ -66,7 +66,7 @@ func runList(ctx context.Context, opts *listOpts) error {
 	if err != nil {
 		return err
 	}
-	targetDesc, resolvedRef, err := resolveReference(ctx, opts.inputType, reference, sigRepo, nil)
+	targetDesc, resolvedRef, err := resolveReferenceWithWarning(ctx, opts.inputType, reference, sigRepo, "list")
 	if err != nil {
 		return err
 	}
@@ -111,6 +111,10 @@ func printSignatureManifestDigests(ctx context.Context, targetDesc ocispec.Descr
 
 		// print last signature digest
 		fmt.Printf("    └── %s\n", prevDigest)
+	}
+
+	if !titlePrinted {
+		fmt.Printf("%s has no associated signature\n", ref)
 	}
 	return nil
 }

--- a/cmd/notation/manifest.go
+++ b/cmd/notation/manifest.go
@@ -16,6 +16,12 @@ import (
 	"oras.land/oras-go/v2/registry"
 )
 
+func resolveReferenceWithWarning(ctx context.Context, inputType inputType, reference string, sigRepo notationregistry.Repository, operation string) (ocispec.Descriptor, string, error) {
+	return resolveReference(ctx, inputType, reference, sigRepo, func(ref string, manifestDesc ocispec.Descriptor) {
+		fmt.Fprintf(os.Stderr, "Warning: Always %s the artifact using digest(@sha256:...) rather than a tag(:%s) because resolved digest may not point to the same signed artifact, as tags are mutable.\n", operation, ref)
+	})
+}
+
 // resolveReference resolves user input reference based on user input type.
 // Returns the resolved manifest descriptor and resolvedRef in digest
 func resolveReference(ctx context.Context, inputType inputType, reference string, sigRepo notationregistry.Repository, fn func(string, ocispec.Descriptor)) (ocispec.Descriptor, string, error) {

--- a/cmd/notation/verify.go
+++ b/cmd/notation/verify.go
@@ -13,8 +13,6 @@ import (
 	"github.com/notaryproject/notation/cmd/notation/internal/experimental"
 	"github.com/notaryproject/notation/internal/cmd"
 	"github.com/notaryproject/notation/internal/ioutil"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-
 	"github.com/spf13/cobra"
 )
 
@@ -115,9 +113,7 @@ func runVerify(command *cobra.Command, opts *verifyOpts) error {
 		return err
 	}
 	// resolve the given reference and set the digest
-	_, resolvedRef, err := resolveReference(ctx, opts.inputType, reference, sigRepo, func(ref string, manifestDesc ocispec.Descriptor) {
-		fmt.Fprintf(os.Stderr, "Warning: Always verify the artifact using digest(@sha256:...) rather than a tag(:%s) because resolved digest may not point to the same signed artifact, as tags are mutable.\n", ref)
-	})
+	_, resolvedRef, err := resolveReferenceWithWarning(ctx, opts.inputType, reference, sigRepo, "verify")
 	if err != nil {
 		return err
 	}

--- a/test/e2e/suite/scenario/quickstart.go
+++ b/test/e2e/suite/scenario/quickstart.go
@@ -32,7 +32,7 @@ var _ = Describe("notation quickstart E2E test", Ordered, func() {
 
 	It("list the signatures associated with the container image", func() {
 		notation.Exec("ls", artifact.ReferenceWithTag()).
-			MatchContent("")
+			MatchKeyWords("has no associated signature")
 	})
 
 	It("generate a test key and self-signed certificate", func() {


### PR DESCRIPTION
Fixes: https://github.com/notaryproject/notation/issues/624
```
➜  notation git:(no-sig) ✗ ./notation inspect $IMAGE 
Warning: Always inspect the artifact using digest(@sha256:...) rather than a tag(:v1) because resolved digest may not point to the same signed artifact, as tags are mutable.
localhost:6000/net-monitor@sha256:52cc9cf0f2e0cadf49337acc7a45a07a2ce5a0ef37702efb0a851884bc32b7b1 has no associated signature

➜  notation git:(no-sig) ✗ ./notation ls $IMAGE      
Warning: Always list the artifact using digest(@sha256:...) rather than a tag(:v1) because resolved digest may not point to the same signed artifact, as tags are mutable.
localhost:6000/net-monitor@sha256:52cc9cf0f2e0cadf49337acc7a45a07a2ce5a0ef37702efb0a851884bc32b7b1 has no associated signature

➜  notation git:(no-sig) ✗ ./notation sign $IMAGE -e 123h
Warning: Always sign the artifact using digest(@sha256:...) rather than a tag(:v1) because tags are mutable and a tag reference can point to a different artifact than the one signed.
Successfully signed localhost:6000/net-monitor@sha256:52cc9cf0f2e0cadf49337acc7a45a07a2ce5a0ef37702efb0a851884bc32b7b1

➜  notation git:(no-sig) ✗ ./notation ls $IMAGE          
Warning: Always list the artifact using digest(@sha256:...) rather than a tag(:v1) because resolved digest may not point to the same signed artifact, as tags are mutable.
localhost:6000/net-monitor@sha256:52cc9cf0f2e0cadf49337acc7a45a07a2ce5a0ef37702efb0a851884bc32b7b1
└── application/vnd.cncf.notary.signature
    └── sha256:be23f992f68a6b3003c83506eb9275188355a451294006e4cac651d2a1b7c716

➜  notation git:(no-sig) ✗ ./notation inspect $IMAGE     
Warning: Always inspect the artifact using digest(@sha256:...) rather than a tag(:v1) because resolved digest may not point to the same signed artifact, as tags are mutable.
Inspecting all signatures for signed artifact
localhost:6000/net-monitor@sha256:52cc9cf0f2e0cadf49337acc7a45a07a2ce5a0ef37702efb0a851884bc32b7b1
└── application/vnd.cncf.notary.signature
    └── sha256:be23f992f68a6b3003c83506eb9275188355a451294006e4cac651d2a1b7c716
        ├── media type: application/jose+json
        ├── signature algorithm: RSASSA-PSS-SHA-256
        ├── signed attributes
        │   ├── signingTime: Fri May 12 20:16:27 2023
        │   ├── expiry: Wed May 17 23:16:27 2023
        │   └── signingScheme: notary.x509
        ├── user defined attributes
        │   └── (empty)
        ├── unsigned attributes
        │   └── signingAgent: Notation/1.0.0
        ├── certificates
        │   └── SHA1 fingerprint: 091c1a5e57aa401de7fb22ac52b56d79f211bd03
        │       ├── issued to: CN=wabbit-networks.io,O=Notary,L=Seattle,ST=WA,C=US
        │       ├── issued by: CN=wabbit-networks.io,O=Notary,L=Seattle,ST=WA,C=US
        │       └── expiry: Sun May 14 00:58:40 2023
        └── signed artifact
            ├── media type: application/vnd.docker.distribution.manifest.v2+json
            ├── digest: sha256:52cc9cf0f2e0cadf49337acc7a45a07a2ce5a0ef37702efb0a851884bc32b7b1
            └── size: 942

```