### PR TITLE
test: generate e2e coverage profile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,11 @@ jobs:
       - name: Run unit tests
         run: make test
       - name: Run e2e tests
-        run:  make e2e
+        run:  |
+          if [[ $GITHUB_REF_NAME == v* && $GITHUB_REF_TYPE == tag ]]; then
+            make e2e
+          else
+            make e2e-covdata
+          fi
       - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,7 @@
 bin/
 vendor/
 coverage.txt
+test/e2e/coverage.txt
+**/covcounters.*
+**/covmeta.*
 dist/

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ all: build
 FORCE:
 
 bin/%: cmd/% FORCE
-	go build $(GO_BUILD_FLAGS) -o $@ ./$<
+	go build $(GO_INSTRUMENT_FLAGS) $(GO_BUILD_FLAGS) -o $@ ./$<
 
 .PHONY: download
 download: ## download dependencies via go mod
@@ -48,7 +48,16 @@ test: vendor check-line-endings ## run unit tests
 e2e: build ## build notation cli and run e2e test
 	NOTATION_BIN_PATH=`pwd`/bin/$(COMMANDS); \
 	cd ./test/e2e; \
-	./run.sh zot $$NOTATION_BIN_PATH
+	./run.sh zot $$NOTATION_BIN_PATH; \
+
+.PHONY: e2e-covdata
+e2e-covdata:
+	export GOCOVERDIR=$(CURDIR)/test/e2e/.cover; \
+	rm -rf $$GOCOVERDIR; \
+	mkdir -p $$GOCOVERDIR; \
+	export GO_INSTRUMENT_FLAGS='-coverpkg "github.com/notaryproject/notation/internal/...,github.com/notaryproject/notation/pkg/...,github.com/notaryproject/notation/cmd/..."'; \
+	$(MAKE) e2e; \
+	go tool covdata textfmt -i=$$GOCOVERDIR -o "$(CURDIR)/test/e2e/coverage.txt"
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
This PR uses the [new Golang feature](https://github.com/golang/proposal/blob/master/design/51430-revamp-code-coverage.md#running-instrumented-applications) to generate coverage report for e2e tests.

For release tagging, the e2e test will be ran based on non-instrumented binary.

To run E2E with test coverage.txt generated locally, try
```bash
 make e2e-covdata
```
Resolves #667