### PR TITLE
update: renamed --plain-http to --insecure-registry

### DIFF
--- a/cmd/notation/common.go
+++ b/cmd/notation/common.go
@@ -31,27 +31,27 @@ var (
 		fs.StringVarP(p, flagPassword.Name, flagPassword.Shorthand, "", flagPassword.Usage)
 	}
 
-	flagPlainHTTP = &pflag.Flag{
-		Name:     "plain-http",
-		Usage:    "registry access via plain HTTP",
+	flagInsecureRegistry = &pflag.Flag{
+		Name:     "insecure-registry",
+		Usage:    "use HTTP protocol while connecting to registries. Use it only for testing purposes",
 		DefValue: "false",
 	}
-	setFlagPlainHTTP = func(fs *pflag.FlagSet, p *bool) {
-		fs.BoolVar(p, flagPlainHTTP.Name, false, flagPlainHTTP.Usage)
+	setFlagInsecureRegistry = func(fs *pflag.FlagSet, p *bool) {
+		fs.BoolVar(p, flagInsecureRegistry.Name, false, flagInsecureRegistry.Usage)
 	}
 )
 
 type SecureFlagOpts struct {
-	Username  string
-	Password  string
-	PlainHTTP bool
+	Username         string
+	Password         string
+	InsecureRegistry bool
 }
 
 // ApplyFlags set flags and their default values for the FlagSet
 func (opts *SecureFlagOpts) ApplyFlags(fs *pflag.FlagSet) {
 	setflagUsername(fs, &opts.Username)
 	setFlagPassword(fs, &opts.Password)
-	setFlagPlainHTTP(fs, &opts.PlainHTTP)
+	setFlagInsecureRegistry(fs, &opts.InsecureRegistry)
 	opts.Username = os.Getenv(defaultUsernameEnv)
 	opts.Password = os.Getenv(defaultPasswordEnv)
 }

--- a/cmd/notation/inspect_test.go
+++ b/cmd/notation/inspect_test.go
@@ -12,9 +12,9 @@ func TestInspectCommand_SecretsFromArgs(t *testing.T) {
 	expected := &inspectOpts{
 		reference: "ref",
 		SecureFlagOpts: SecureFlagOpts{
-			Password:  "password",
-			PlainHTTP: true,
-			Username:  "user",
+			Password:         "password",
+			InsecureRegistry: true,
+			Username:         "user",
 		},
 		outputFormat: cmd.OutputPlaintext,
 	}
@@ -22,7 +22,7 @@ func TestInspectCommand_SecretsFromArgs(t *testing.T) {
 		"--password", expected.Password,
 		expected.reference,
 		"-u", expected.Username,
-		"--plain-http",
+		"--insecure-registry",
 		"--output", "text"}); err != nil {
 		t.Fatalf("Parse Flag failed: %v", err)
 	}

--- a/cmd/notation/list_test.go
+++ b/cmd/notation/list_test.go
@@ -10,16 +10,16 @@ func TestListCommand_SecretsFromArgs(t *testing.T) {
 	expected := &listOpts{
 		reference: "ref",
 		SecureFlagOpts: SecureFlagOpts{
-			Password:  "password",
-			PlainHTTP: true,
-			Username:  "user",
+			Password:         "password",
+			InsecureRegistry: true,
+			Username:         "user",
 		},
 	}
 	if err := cmd.ParseFlags([]string{
 		"--password", expected.Password,
 		expected.reference,
 		"-u", expected.Username,
-		"--plain-http"}); err != nil {
+		"--insecure-registry"}); err != nil {
 		t.Fatalf("Parse Flag failed: %v", err)
 	}
 	if err := cmd.Args(cmd, cmd.Flags().Args()); err != nil {

--- a/cmd/notation/registry.go
+++ b/cmd/notation/registry.go
@@ -80,7 +80,7 @@ func getRemoteRepository(ctx context.Context, opts *SecureFlagOpts, reference st
 }
 
 func getRepositoryClient(ctx context.Context, opts *SecureFlagOpts, ref registry.Reference) (*remote.Repository, error) {
-	authClient, plainHTTP, err := getAuthClient(ctx, opts, ref)
+	authClient, insecureRegistry, err := getAuthClient(ctx, opts, ref)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func getRepositoryClient(ctx context.Context, opts *SecureFlagOpts, ref registry
 	return &remote.Repository{
 		Client:    authClient,
 		Reference: ref,
-		PlainHTTP: plainHTTP,
+		PlainHTTP: insecureRegistry,
 	}, nil
 }
 
@@ -119,15 +119,15 @@ func setHttpDebugLog(ctx context.Context, authClient *auth.Client) {
 }
 
 func getAuthClient(ctx context.Context, opts *SecureFlagOpts, ref registry.Reference) (*auth.Client, bool, error) {
-	var plainHTTP bool
+	var insecureRegistry bool
 
-	if opts.PlainHTTP {
-		plainHTTP = opts.PlainHTTP
+	if opts.InsecureRegistry {
+		insecureRegistry = opts.InsecureRegistry
 	} else {
-		plainHTTP = configutil.IsRegistryInsecure(ref.Registry)
-		if !plainHTTP {
+		insecureRegistry = configutil.IsRegistryInsecure(ref.Registry)
+		if !insecureRegistry {
 			if host, _, _ := net.SplitHostPort(ref.Registry); host == "localhost" {
-				plainHTTP = true
+				insecureRegistry = true
 			}
 		}
 	}
@@ -166,7 +166,7 @@ func getAuthClient(ctx context.Context, opts *SecureFlagOpts, ref registry.Refer
 	// update authClient
 	setHttpDebugLog(ctx, authClient)
 
-	return authClient, plainHTTP, nil
+	return authClient, insecureRegistry, nil
 }
 
 func getSavedCreds(ctx context.Context, serverAddress string) (auth.Credential, error) {

--- a/cmd/notation/registry_test.go
+++ b/cmd/notation/registry_test.go
@@ -34,7 +34,7 @@ func TestRegistry_getRemoteRepositoryWithReferrersAPISupported(t *testing.T) {
 		t.Fatalf("invalid test http server: %v", err)
 	}
 	secureOpts := SecureFlagOpts{
-		PlainHTTP: true,
+		InsecureRegistry: true,
 	}
 	_, err = getRemoteRepository(context.Background(), &secureOpts, uri.Host+"/test", true)
 	if err != nil {
@@ -61,7 +61,7 @@ func TestRegistry_getRemoteRepositoryWithReferrersAPINotSupported(t *testing.T) 
 		t.Fatalf("invalid test http server: %v", err)
 	}
 	secureOpts := SecureFlagOpts{
-		PlainHTTP: true,
+		InsecureRegistry: true,
 	}
 	_, err = getRemoteRepository(context.Background(), &secureOpts, uri.Host+"/test", true)
 	if err != nil {
@@ -85,7 +85,7 @@ func TestRegistry_getRemoteRepositoryWithReferrersTagSchema(t *testing.T) {
 		t.Fatalf("invalid test http server: %v", err)
 	}
 	secureOpts := SecureFlagOpts{
-		PlainHTTP: true,
+		InsecureRegistry: true,
 	}
 	_, err = getRemoteRepository(context.Background(), &secureOpts, uri.Host+"/test", false)
 	if err != nil {

--- a/cmd/notation/sign_test.go
+++ b/cmd/notation/sign_test.go
@@ -45,9 +45,9 @@ func TestSignCommand_MoreArgs(t *testing.T) {
 	expected := &signOpts{
 		reference: "ref",
 		SecureFlagOpts: SecureFlagOpts{
-			Username:  "user",
-			Password:  "password",
-			PlainHTTP: true,
+			Username:         "user",
+			Password:         "password",
+			InsecureRegistry: true,
 		},
 		SignerFlagOpts: cmd.SignerFlagOpts{
 			Key:             "key",
@@ -61,7 +61,7 @@ func TestSignCommand_MoreArgs(t *testing.T) {
 		"-u", expected.Username,
 		"-p", expected.Password,
 		"--key", expected.Key,
-		"--plain-http",
+		"--insecure-registry",
 		"--signature-format", expected.SignerFlagOpts.SignatureFormat,
 		"--expiry", expected.expiry.String(),
 		"--allow-referrers-api"}); err != nil {

--- a/cmd/notation/verify_test.go
+++ b/cmd/notation/verify_test.go
@@ -37,13 +37,13 @@ func TestVerifyCommand_MoreArgs(t *testing.T) {
 	expected := &verifyOpts{
 		reference: "ref",
 		SecureFlagOpts: SecureFlagOpts{
-			PlainHTTP: true,
+			InsecureRegistry: true,
 		},
 		pluginConfig: []string{"key1=val1", "key2=val2"},
 	}
 	if err := command.ParseFlags([]string{
 		expected.reference,
-		"--plain-http",
+		"--insecure-registry",
 		"--plugin-config", "key1=val1",
 		"--plugin-config", "key2=val2"}); err != nil {
 		t.Fatalf("Parse Flag failed: %v", err)

--- a/specs/commandline/inspect.md
+++ b/specs/commandline/inspect.md
@@ -36,9 +36,9 @@ Flags:
       --allow-referrers-api   [Experimental] use the Referrers API to inspect signatures, if not supported (returns 404), fallback to the Referrers tag schema
   -d, --debug                 debug mode
   -h, --help                  help for inspect
+      --insecure-registry     use HTTP protocol while connecting to registries. Use it only for testing purposes
   -o, --output string         output format, options: 'json', 'text' (default "text")
   -p, --password string       password for registry operations (default to $NOTATION_PASSWORD if not specified)
-      --plain-http            registry access via plain HTTP
   -u, --username string       username for registry operations (default to $NOTATION_USERNAME if not specified)
   -v, --verbose               verbose mode
 ```

--- a/specs/commandline/list.md
+++ b/specs/commandline/list.md
@@ -30,9 +30,9 @@ Flags:
       --allow-referrers-api   [Experimental] use the Referrers API to list signatures, if not supported (returns 404), fallback to the Referrers tag schema
   -d, --debug                 debug mode
   -h, --help                  help for list
+      --insecure-registry     use HTTP protocol while connecting to registries. Use it only for testing purposes
       --oci-layout            [Experimental] list signatures stored in OCI image layout
   -p, --password string       password for registry operations (default to $NOTATION_PASSWORD if not specified)
-      --plain-http            registry access via plain HTTP
   -u, --username string       username for registry operations (default to $NOTATION_USERNAME if not specified)
   -v, --verbose               verbose mode
 ```

--- a/specs/commandline/login.md
+++ b/specs/commandline/login.md
@@ -13,13 +13,13 @@ Usage:
   notation login [flags] <server>
 
 Flags:
-  -d, --debug             debug mode
-  -h, --help              help for login
-  -p, --password string   password for registry operations (default to $NOTATION_PASSWORD if not specified)
-      --password-stdin    take the password from stdin
-      --plain-http        registry access via plain HTTP
-  -u, --username string   username for registry operations (default to $NOTATION_USERNAME if not specified)
-  -v, --verbose           verbose mode
+  -d, --debug               debug mode
+  -h, --help                help for login
+      --insecure-registry   use HTTP protocol while connecting to registries. Use it only for testing purposes
+  -p, --password string     password for registry operations (default to $NOTATION_PASSWORD if not specified)
+      --password-stdin      take the password from stdin
+  -u, --username string     username for registry operations (default to $NOTATION_USERNAME if not specified)
+  -v, --verbose             verbose mode
 ```
 
 ## Usage

--- a/specs/commandline/sign.md
+++ b/specs/commandline/sign.md
@@ -33,10 +33,10 @@ Flags:
   -e,  --expiry duration            optional expiry that provides a "best by use" time for the artifact. The duration is specified in minutes(m) and/or hours(h). For example: 12h, 30m, 3h20m
   -h,  --help                       help for sign
        --id string                  key id (required if --plugin is set). This is mutually exclusive with the --key flag
+       --insecure-registry          use HTTP protocol while connecting to registries. Use it only for testing purposes       
   -k,  --key string                 signing key name, for a key previously added to notation's key list. This is mutually exclusive with the --id and --plugin flags
        --oci-layout                 [Experimental] sign the artifact stored as OCI image layout
   -p,  --password string            password for registry operations (default to $NOTATION_PASSWORD if not specified)
-       --plain-http                 registry access via plain HTTP
        --plugin string              signing plugin name. This is mutually exclusive with the --key flag
        --plugin-config stringArray  {key}={value} pairs that are passed as it is to a plugin, refer plugin's documentation to set appropriate values.
        --signature-format string    signature envelope format, options: "jws", "cose" (default "jws")

--- a/specs/commandline/verify.md
+++ b/specs/commandline/verify.md
@@ -38,9 +38,9 @@ Flags:
        --allow-referrers-api         [Experimental] use the Referrers API to verify signatures, if not supported (returns 404), fallback to the Referrers tag schema
   -d,  --debug                       debug mode
   -h,  --help                        help for verify
+       --insecure-registry           use HTTP protocol while connecting to registries. Use it only for testing purposes
        --oci-layout                  [Experimental] verify the artifact stored as OCI image layout
   -p,  --password string             password for registry operations (default to $NOTATION_PASSWORD if not specified)
-       --plain-http                  registry access via plain HTTP
        --plugin-config stringArray   {key}={value} pairs that are passed as it is to a plugin, if the verification is associated with a verification plugin, refer plugin documentation to set appropriate values
        --scope string                [Experimental] set trust policy scope for artifact verification, required and can only be used when flag "--oci-layout" is set
   -u,  --username string             username for registry operations (default to $NOTATION_USERNAME if not specified)


### PR DESCRIPTION
This PR is based on discussions in issue #623 with following changes:
1. Renamed flag `--plain-http` to `--insecure-registry` for notation `sign`, `verify`, `list`, `inspect` and `login`.
2. Updated the flag's description to `use HTTP protocol while connecting to registries. Use it only for testing purposes`. Related specs are updated as well.

Resolves #623.