### PR TITLE
chore: updated warning printout logic for Sign with --allow-referrers-api flag

### DIFF
--- a/cmd/notation/sign.go
+++ b/cmd/notation/sign.go
@@ -100,6 +100,7 @@ Example - [Experimental] Sign an OCI artifact identified by a tag and referenced
 	cmd.SetPflagUserMetadata(command.Flags(), &opts.userMetadata, cmd.PflagUserMetadataSignUsage)
 	cmd.SetPflagReferrersAPI(command.Flags(), &opts.allowReferrersAPI, fmt.Sprintf(cmd.PflagReferrersUsageFormat, "sign"))
 	command.Flags().BoolVar(&opts.ociLayout, "oci-layout", false, "[Experimental] sign the artifact stored as OCI image layout")
+	command.MarkFlagsMutuallyExclusive("oci-layout", "allow-referrers-api")
 	experimental.HideFlags(command, experimentalExamples, []string{"allow-referrers-api", "oci-layout"})
 	return command
 }

--- a/cmd/notation/sign.go
+++ b/cmd/notation/sign.go
@@ -114,7 +114,7 @@ func runSign(command *cobra.Command, cmdOpts *signOpts) error {
 	if err != nil {
 		return err
 	}
-	if cmdOpts.allowReferrersAPI && !cmdOpts.ociLayout {
+	if cmdOpts.allowReferrersAPI {
 		fmt.Fprintln(os.Stderr, "Warning: using the Referrers API to store signature. On success, must set the `--allow-referrers-api` flag to list, inspect, and verify the signature.")
 	}
 	sigRepo, err := getRepository(ctx, cmdOpts.inputType, cmdOpts.reference, &cmdOpts.SecureFlagOpts, cmdOpts.allowReferrersAPI)

--- a/cmd/notation/sign.go
+++ b/cmd/notation/sign.go
@@ -113,7 +113,7 @@ func runSign(command *cobra.Command, cmdOpts *signOpts) error {
 	if err != nil {
 		return err
 	}
-	if cmdOpts.allowReferrersAPI {
+	if cmdOpts.allowReferrersAPI && !cmdOpts.ociLayout {
 		fmt.Fprintln(os.Stderr, "Warning: using the Referrers API to store signature. On success, must set the `--allow-referrers-api` flag to list, inspect, and verify the signature.")
 	}
 	sigRepo, err := getRepository(ctx, cmdOpts.inputType, cmdOpts.reference, &cmdOpts.SecureFlagOpts, cmdOpts.allowReferrersAPI)


### PR DESCRIPTION
This quick PR updates the printout logic for `sign`, when user enables `--allow-referrers-api`.
The warning should be valid only when target artifact is stored in a `registry`. 
If the user enables `--oci-layout`, i.e., target artifact is stored in an OCI layout, enabling `--allow-referrers-api` won't take any effect (this is because [oci.Store](https://github.com/oras-project/oras-go/blob/0e20275bbbd71f4619d9c1b9da150c4f586dff3b/content/oci/oci.go#L49) does not support Referrers API yet). In this case, we shouldn't print out the warning.

The fix: During `Sign`, mark flags `--oci-layout` and `--allow-referrers-api` mutually exclusive.

Resolves #683.