### PR TITLE
Added cli doc generation and refactored examples 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ test/e2e/coverage.txt
 **/covcounters.*
 **/covmeta.*
 dist/
+**/.DS_Store

--- a/cmd/notation/cert/add.go
+++ b/cmd/notation/cert/add.go
@@ -33,7 +33,7 @@ func certAddCommand(opts *certAddOpts) *cobra.Command {
 	}
 	command := &cobra.Command{
 		Use:   "add --type <type> --store <name> [flags] <cert_path>...",
-		Short: "Add certificates to the trust store.",
+		Short: "Add certificates to the trust store",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return errors.New("missing certificate path")
@@ -41,14 +41,12 @@ func certAddCommand(opts *certAddOpts) *cobra.Command {
 			opts.path = args
 			return nil
 		},
-		Long: `Add certificates to the trust store
+		Long: `Add certificates to the trust store`,
+		Example: `# Add a certificate to the "ca" type of a named store "acme-rockets":
+notation cert add --type ca --store acme-rockets acme-rockets.crt
 
-Example - Add a certificate to the "ca" type of a named store "acme-rockets":
-  notation cert add --type ca --store acme-rockets acme-rockets.crt
-
-Example - Add a certificate to the "signingAuthority" type of a named store "wabbit-networks":
-  notation cert add --type signingAuthority --store wabbit-networks wabbit-networks.pem
-`,
+# Add a certificate to the "signingAuthority" type of a named store "wabbit-networks":
+notation cert add --type signingAuthority --store wabbit-networks wabbit-networks.pem`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return addCerts(opts)
 		},

--- a/cmd/notation/cert/delete.go
+++ b/cmd/notation/cert/delete.go
@@ -35,7 +35,7 @@ func certDeleteCommand(opts *certDeleteOpts) *cobra.Command {
 	}
 	command := &cobra.Command{
 		Use:   "delete --type <type> --store <name> [flags] (--all | <cert_fileName>)",
-		Short: "Delete certificates from the trust store.",
+		Short: "Delete certificates from the trust store",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if opts.all {
 				if len(args) != 0 {
@@ -49,17 +49,15 @@ func certDeleteCommand(opts *certDeleteOpts) *cobra.Command {
 			opts.cert = args[0]
 			return nil
 		},
-		Long: `Delete certificates from the trust store
+		Long: `Delete certificates from the trust store`,
+		Example: `# Delete all certificates with "ca" type from the trust store "acme-rockets":
+notation cert delete --type ca --store acme-rockets --all
 
-Example - Delete all certificates with "ca" type from the trust store "acme-rockets":
-  notation cert delete --type ca --store acme-rockets --all
+# Delete certificate "cert1.pem" with "signingAuthority" type from trust store wabbit-networks:
+notation cert delete --type signingAuthority --store wabbit-networks cert1.pem
 
-Example - Delete certificate "cert1.pem" with "signingAuthority" type from trust store wabbit-networks:
-  notation cert delete --type signingAuthority --store wabbit-networks cert1.pem
-
-Example - Delete all certificates with "ca" type from the trust store "acme-rockets", without prompt for confirmation:
-  notation cert delete --type ca --store acme-rockets -y --all 
-`,
+# Delete all certificates with "ca" type from the trust store "acme-rockets", without prompt for confirmation:
+notation cert delete --type ca --store acme-rockets -y --all`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deleteCerts(opts)
 		},

--- a/cmd/notation/cert/list.go
+++ b/cmd/notation/cert/list.go
@@ -38,21 +38,19 @@ func certListCommand(opts *certListOpts) *cobra.Command {
 	command := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "List certificates in the trust store.",
-		Long: `List certificates in the trust store
+		Short:   "List certificates in the trust store",
+		Long: `List certificates in the trust store`,
+		Example: `# List all certificate files stored in the trust store
+notation cert ls
 
-Example - List all certificate files stored in the trust store
-  notation cert ls
+# List all certificate files of trust store "acme-rockets"
+notation cert ls --store "acme-rockets"
 
-Example - List all certificate files of trust store "acme-rockets"
-  notation cert ls --store "acme-rockets"
+# List all certificate files from trust store of type "ca"
+notation cert ls --type ca
 
-Example - List all certificate files from trust store of type "ca"
-  notation cert ls --type ca
-
-Example - List all certificate files from trust store "wabbit-networks" of type "signingAuthority"
-  notation cert ls --type signingAuthority --store "wabbit-networks"
-`,
+# List all certificate files from trust store "wabbit-networks" of type "signingAuthority"
+notation cert ls --type signingAuthority --store "wabbit-networks"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listCerts(cmd.Context(), opts)
 		},

--- a/cmd/notation/cert/show.go
+++ b/cmd/notation/cert/show.go
@@ -39,7 +39,7 @@ func certShowCommand(opts *certShowOpts) *cobra.Command {
 	}
 	command := &cobra.Command{
 		Use:   "show --type <type> --store <name> [flags] <cert_fileName>",
-		Short: "Show certificate details given trust store type, named store, and certificate file name. If the certificate file contains multiple certificates, then all certificates are displayed.",
+		Short: "Show certificate details given trust store type, named store, and certificate file name. If the certificate file contains multiple certificates, then all certificates are displayed",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return errors.New("missing certificate file name")
@@ -50,14 +50,12 @@ func certShowCommand(opts *certShowOpts) *cobra.Command {
 			opts.cert = args[0]
 			return nil
 		},
-		Long: `Show certificate details of given trust store name, trust store type, and certificate file name. If the certificate file contains multiple certificates, then all certificates are displayed
+		Long: `Show certificate details of given trust store name, trust store type, and certificate file name. If the certificate file contains multiple certificates, then all certificates are displayed`,
+		Example: `# Show details of certificate "cert1.pem" with type "ca" from trust store "acme-rockets":
+notation cert show --type ca --store acme-rockets cert1.pem
 
-Example - Show details of certificate "cert1.pem" with type "ca" from trust store "acme-rockets":
-  notation cert show --type ca --store acme-rockets cert1.pem
-
-Example - Show details of certificate "cert2.pem" with type "signingAuthority" from trust store "wabbit-networks":
-  notation cert show --type signingAuthority --store wabbit-networks cert2.pem
-`,
+# Show details of certificate "cert2.pem" with type "signingAuthority" from trust store "wabbit-networks":
+notation cert show --type signingAuthority --store wabbit-networks cert2.pem`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return showCerts(cmd.Context(), opts)
 		},

--- a/cmd/notation/generate_docs.go
+++ b/cmd/notation/generate_docs.go
@@ -1,0 +1,84 @@
+// Copyright The Notary Project Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/notaryproject/notation/internal/cmd"
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc" // Add this line to import cobra doc lib
+)
+
+type generateDocsOpts struct {
+	cmd.LoggingFlagOpts
+	SecureFlagOpts
+	outputDir string
+}
+
+func generateDocsCommand(opts *generateDocsOpts) *cobra.Command {
+	if opts == nil {
+		opts = &generateDocsOpts{
+			outputDir: ".",
+		}
+	}
+	command := &cobra.Command{
+		Use:   "generateDocs <outputDir>",
+		Short: "Generate reference documentation for Notation CLI",
+		Long:  "Generate reference documentation for Notation CLI",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return errors.New("no output directory specified")
+			}
+			opts.outputDir = args[0]
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runGenerateDocs(cmd, opts)
+		},
+	}
+
+	return command
+}
+
+func runGenerateDocs(cmd *cobra.Command, opts *generateDocsOpts) error {
+
+	const fmTemplate = `---
+title: "%s"
+---
+
+`
+
+	filePrepender := func(filename string) string {
+		name := strings.TrimSuffix(filename, filepath.Ext(filename))
+		name = strings.TrimPrefix(name, opts.outputDir)
+		return fmt.Sprintf(fmTemplate, strings.Replace(name, "_", " ", -1))
+	}
+
+	linkHandler := func(filename string) string {
+		link := strings.TrimSuffix(filename, filepath.Ext(filename))
+		return fmt.Sprintf("{{< ref \"/docs/cli-reference/%s\" >}}", link)
+	}
+
+	fmt.Println("Generating reference documentation for Notation CLI...")
+	if err := doc.GenMarkdownTreeCustom(cmd.Root(), opts.outputDir, filePrepender, linkHandler); err != nil {
+		return err
+	}
+	fmt.Println("Reference documentation for Notation CLI generated successfully at", opts.outputDir)
+
+	return nil
+}

--- a/cmd/notation/inspect.go
+++ b/cmd/notation/inspect.go
@@ -73,25 +73,29 @@ func inspectCommand(opts *inspectOpts) *cobra.Command {
 	if opts == nil {
 		opts = &inspectOpts{}
 	}
-	longMessage := `Inspect all signatures associated with the signed artifact.
+	longMessage := `Inspect all signatures associated with the signed artifact`
+	exampleMessage := `# Inspect signatures on an OCI artifact identified by a digest:
+notation inspect <registry>/<repository>@<digest>
 
-Example - Inspect signatures on an OCI artifact identified by a digest:
-  notation inspect <registry>/<repository>@<digest>
+# Inspect signatures on an OCI artifact identified by a tag  (Notation will resolve tag to digest):
+notation inspect <registry>/<repository>:<tag>
 
-Example - Inspect signatures on an OCI artifact identified by a tag  (Notation will resolve tag to digest):
-  notation inspect <registry>/<repository>:<tag>
-
-Example - Inspect signatures on an OCI artifact identified by a digest and output as json:
-  notation inspect --output json <registry>/<repository>@<digest>
+# Inspect signatures on an OCI artifact identified by a digest and output as json:
+notation inspect --output json <registry>/<repository>@<digest>
 `
 	experimentalExamples := `
-Example - [Experimental] Inspect signatures on an OCI artifact identified by a digest using the Referrers API, if not supported (returns 404), fallback to the Referrers tag schema
-  notation inspect --allow-referrers-api <registry>/<repository>@<digest>
+# [Experimental] Inspect signatures on an OCI artifact identified by a digest using the Referrers API, if not supported (returns 404), fallback to the Referrers tag schema
+notation inspect --allow-referrers-api <registry>/<repository>@<digest>
 `
+	if(!experimental.IsDisabled())	{
+		exampleMessage += experimentalExamples
+	}
+
 	command := &cobra.Command{
 		Use:   "inspect [reference]",
 		Short: "Inspect all signatures associated with the signed artifact",
 		Long:  longMessage,
+		Example: exampleMessage,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return errors.New("missing reference")

--- a/cmd/notation/key.go
+++ b/cmd/notation/key.go
@@ -62,20 +62,18 @@ func keyCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "key",
 		Short: "Manage keys used for signing",
-		Long: `Manage keys used for signing
+		Long: `Manage keys used for signing`,
+		Example: `# Add a key to signing key list:
+notation key add --plugin <plugin_name> --id <key_id> <key_name>
 
-Example - Add a key to signing key list:
-  notation key add --plugin <plugin_name> --id <key_id> <key_name>
+# List keys used for signing:
+notation key ls
 
-Example - List keys used for signing:
-  notation key ls
+# Update the default signing key:
+notation key set --default <key_name>
 
-Example - Update the default signing key:
-  notation key set --default <key_name>
-
-Example - Delete the key from signing key list:
-  notation key delete <key_name>...
-`,
+# Delete the key from signing key list:
+notation key delete <key_name>...`,
 	}
 	command.AddCommand(keyAddCommand(nil), keyUpdateCommand(nil), keyListCommand(), keyDeleteCommand(nil))
 

--- a/cmd/notation/login.go
+++ b/cmd/notation/login.go
@@ -46,13 +46,12 @@ func loginCommand(opts *loginOpts) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "login [flags] <server>",
 		Short: "Login to registry",
-		Long: `Log in to an OCI registry
+		Long: `Log in to an OCI registry`,
+		Example: `# Login with provided username and password:
+notation login -u <user> -p <password> registry.example.com
 
-Example - Login with provided username and password:
-	notation login -u <user> -p <password> registry.example.com
-
-Example - Login using $NOTATION_USERNAME $NOTATION_PASSWORD variables:
-	notation login registry.example.com`,
+# Login using $NOTATION_USERNAME $NOTATION_PASSWORD variables:
+notation login registry.example.com`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return errors.New("no hostname specified")

--- a/cmd/notation/main.go
+++ b/cmd/notation/main.go
@@ -45,6 +45,7 @@ func main() {
 		logoutCommand(nil),
 		versionCommand(),
 		inspectCommand(nil),
+		generateDocsCommand(nil),
 	)
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)

--- a/cmd/notation/plugin.go
+++ b/cmd/notation/plugin.go
@@ -38,11 +38,9 @@ func pluginListCommand() *cobra.Command {
 		Use:     "list [flags]",
 		Aliases: []string{"ls"},
 		Short:   "List installed plugins",
-		Long: `List installed plugins
-
-Example - List installed Notation plugins:
-  notation plugin ls
-`,
+		Long: `List installed plugins`,
+		Example: `# List installed Notation plugins:
+notation plugin ls`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listPlugins(cmd)
 		},

--- a/cmd/notation/policy/import.go
+++ b/cmd/notation/policy/import.go
@@ -35,13 +35,11 @@ func importCmd() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "import [flags] <file_path>",
 		Short: "Import trust policy configuration from a JSON file",
-		Long: `Import trust policy configuration from a JSON file.
+		Long: `Import trust policy configuration from a JSON file
 
-** This command is in preview and under development. **
-
-Example - Import trust policy configuration from a file:
-  notation policy import my_policy.json
-`,
+** This command is in preview and under development. **`,
+		Example: `# Import trust policy configuration from a file:
+notation policy import my_policy.json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.filePath = args[0]

--- a/cmd/notation/policy/show.go
+++ b/cmd/notation/policy/show.go
@@ -31,16 +31,14 @@ func showCmd() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "show [flags]",
 		Short: "Show trust policy configuration",
-		Long: `Show trust policy configuration.
+		Long: `Show trust policy configuration
 
-** This command is in preview and under development. **
+** This command is in preview and under development. **`,
+		Example: `# Show current trust policy configuration:
+notation policy show
 
-Example - Show current trust policy configuration:
-  notation policy show
-
-Example - Save current trust policy configuration to a file:
-  notation policy show > my_policy.json
-`,
+# Save current trust policy configuration to a file:
+notation policy show > my_policy.json`,
 		Args: cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runShow(cmd, opts)

--- a/cmd/notation/sign.go
+++ b/cmd/notation/sign.go
@@ -53,41 +53,44 @@ func signCommand(opts *signOpts) *cobra.Command {
 	}
 	longMessage := `Sign artifacts
 
-Note: a signing key must be specified. This can be done temporarily by specifying a key ID, or a new key can be configured using the command "notation key add"
-
-Example - Sign an OCI artifact using the default signing key, with the default JWS envelope, and use OCI image manifest to store the signature:
-  notation sign <registry>/<repository>@<digest>
-
-Example - Sign an OCI artifact using the default signing key, with the COSE envelope:
-  notation sign --signature-format cose <registry>/<repository>@<digest> 
-
-Example - Sign an OCI artifact with a specified plugin and signing key stored in KMS 
-  notation sign --plugin <plugin_name> --id <remote_key_id> <registry>/<repository>@<digest>
-
-Example - Sign an OCI artifact using a specified key
-  notation sign --key <key_name> <registry>/<repository>@<digest>
-
-Example - Sign an OCI artifact identified by a tag (Notation will resolve tag to digest)
-  notation sign <registry>/<repository>:<tag>
-
-Example - Sign an OCI artifact stored in a registry and specify the signature expiry duration, for example 24 hours
-  notation sign --expiry 24h <registry>/<repository>@<digest>
+	Note: a signing key must be specified. This can be done temporarily by specifying a key ID, or a new key can be configured using the command "notation key add"`
+	exampleMessage := `# Sign an OCI artifact using the default signing key, with the default JWS envelope, and use OCI image manifest to store the signature:
+notation sign <registry>/<repository>@<digest>
+	
+# Sign an OCI artifact using the default signing key, with the COSE envelope:
+notation sign --signature-format cose <registry>/<repository>@<digest> 
+	
+# Sign an OCI artifact with a specified plugin and signing key stored in KMS 
+notation sign --plugin <plugin_name> --id <remote_key_id> <registry>/<repository>@<digest>
+	
+# Sign an OCI artifact using a specified key
+notation sign --key <key_name> <registry>/<repository>@<digest>
+	
+# Sign an OCI artifact identified by a tag (Notation will resolve tag to digest)
+notation sign <registry>/<repository>:<tag>
+	
+# Sign an OCI artifact stored in a registry and specify the signature expiry duration, for example 24 hours
+notation sign --expiry 24h <registry>/<repository>@<digest>
 `
-	experimentalExamples := `
-Example - [Experimental] Sign an OCI artifact and store signature using the Referrers API. If it's not supported (returns 404), fallback to the Referrers tag schema
-  notation sign --allow-referrers-api <registry>/<repository>@<digest>
+		experimentalExamples := `
+# [Experimental] Sign an OCI artifact and store signature using the Referrers API. If it's not supported (returns 404), fallback to the Referrers tag schema
+notation sign --allow-referrers-api <registry>/<repository>@<digest>
+	
+# [Experimental] Sign an OCI artifact referenced in an OCI layout
+notation sign --oci-layout "<oci_layout_path>@<digest>"
+	
+# [Experimental] Sign an OCI artifact identified by a tag and referenced in an OCI layout
+notation sign --oci-layout "<oci_layout_path>:<tag>"`
 
-Example - [Experimental] Sign an OCI artifact referenced in an OCI layout
-  notation sign --oci-layout "<oci_layout_path>@<digest>"
-
-Example - [Experimental] Sign an OCI artifact identified by a tag and referenced in an OCI layout
-  notation sign --oci-layout "<oci_layout_path>:<tag>"
-`
+	if(!experimental.IsDisabled())	{
+		exampleMessage += experimentalExamples
+	}
 
 	command := &cobra.Command{
 		Use:   "sign [flags] <reference>",
 		Short: "Sign artifacts",
 		Long:  longMessage,
+		Example: exampleMessage,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return errors.New("missing reference")

--- a/cmd/notation/verify.go
+++ b/cmd/notation/verify.go
@@ -49,28 +49,32 @@ func verifyCommand(opts *verifyOpts) *cobra.Command {
 	}
 	longMessage := `Verify OCI artifacts
 
-Prerequisite: added a certificate into trust store and created a trust policy.
+Prerequisite: added a certificate into trust store and created a trust policy.`
+	exampleMessage := `# Verify a signature on an OCI artifact identified by a digest:
+notation verify <registry>/<repository>@<digest>
 
-Example - Verify a signature on an OCI artifact identified by a digest:
-  notation verify <registry>/<repository>@<digest>
-
-Example - Verify a signature on an OCI artifact identified by a tag  (Notation will resolve tag to digest):
-  notation verify <registry>/<repository>:<tag>
+# Verify a signature on an OCI artifact identified by a tag  (Notation will resolve tag to digest):
+notation verify <registry>/<repository>:<tag>
 `
 	experimentalExamples := `
-Example - [Experimental] Verify an OCI artifact using the Referrers API, if not supported (returns 404), fallback to the Referrers tag schema
-  notation verify --allow-referrers-api <registry>/<repository>@<digest>
+# [Experimental] Verify an OCI artifact using the Referrers API, if not supported (returns 404), fallback to the Referrers tag schema
+notation verify --allow-referrers-api <registry>/<repository>@<digest>
 
-Example - [Experimental] Verify a signature on an OCI artifact referenced in an OCI layout using trust policy statement specified by scope.
-  notation verify --oci-layout <registry>/<repository>@<digest> --scope <trust_policy_scope>
+# [Experimental] Verify a signature on an OCI artifact referenced in an OCI layout using trust policy statement specified by scope.
+notation verify --oci-layout <registry>/<repository>@<digest> --scope <trust_policy_scope>
 
-Example - [Experimental] Verify a signature on an OCI artifact identified by a tag and referenced in an OCI layout using trust policy statement specified by scope.
-  notation verify --oci-layout <registry>/<repository>:<tag> --scope <trust_policy_scope>
+# [Experimental] Verify a signature on an OCI artifact identified by a tag and referenced in an OCI layout using trust policy statement specified by scope.
+notation verify --oci-layout <registry>/<repository>:<tag> --scope <trust_policy_scope>
 `
+	if(!experimental.IsDisabled())	{
+		exampleMessage += experimentalExamples
+	}
+
 	command := &cobra.Command{
 		Use:   "verify [reference]",
 		Short: "Verify OCI artifacts",
 		Long:  longMessage,
+		Example: exampleMessage,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return errors.New("missing reference")

--- a/go.mod
+++ b/go.mod
@@ -17,15 +17,18 @@ require (
 
 require (
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/fxamacker/cbor/v2 v2.4.0 // indirect
 	github.com/go-asn1-ber/asn1-ber v1.5.4 // indirect
 	github.com/go-ldap/ldap/v3 v3.4.5 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/veraison/go-cose v1.1.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/crypto v0.11.0 // indirect
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/sync v0.3.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 h1:mFRzDkZVAjdal+
 github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/alexbrainman/sspi v0.0.0-20210105120005-909beea2cc74 h1:Kk6a4nehpJ3UuJRqlA3JxYxBZEqCeOmATOvrbT4p9RA=
 github.com/alexbrainman/sspi v0.0.0-20210105120005-909beea2cc74/go.mod h1:cEWa1LVoE5KvSD9ONXsZrj0z6KqySlCCNKHlLzbqAt4=
+github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -28,6 +29,7 @@ github.com/oras-project/oras-credentials-go v0.3.0 h1:Bg1d9iAmgo50RlaIy2XI5MQs7q
 github.com/oras-project/oras-credentials-go v0.3.0/go.mod h1:fFCebDQo0Do+gnM96uV9YUnRay0pwuRQupypvofsp4s=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
@@ -91,6 +93,7 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
…Examples field

Here is a `launch.json` for testing:

```json
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Generate Docs",
            "type": "go",
            "request": "launch",
            "mode": "auto",
            "program": "${fileDirname}",
            "env": 
                {
                    "GEN_CLI_DOCS": "true"
                },
        }
    ]
}
```

MD files are generated in `notation-reference-doc` but have been added to `.gitignore` to avoid adding them to the repo

If environment variable is absent, behavior should be normal.