### PR TITLE
fix: `login` and `logout` will leverage docker config and os default store

### DIFF
--- a/cmd/notation/login.go
+++ b/cmd/notation/login.go
@@ -133,7 +133,7 @@ func runLogin(ctx context.Context, opts *loginOpts) error {
 				registryName, urlDocHowToAuthenticate)
 		}
 
-		// the credential already exists somewhere, ignore the saving error
+		// the credential already exists but is in plaintext, ignore the saving error
 		fmt.Fprintf(os.Stderr, "Warning: The credentials store is not set up. It is recommended to configure the credentials store to securely store your credentials. See %s.\n", urlDocHowToAuthenticate)
 		fmt.Println("Authenticated with existing credentials")
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/notaryproject/notation-go v1.0.0-rc.6
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc3
-	github.com/oras-project/oras-credentials-go v0.1.1
+	github.com/oras-project/oras-credentials-go v0.1.2-0.20230609082027-b60b11bcba14
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
@@ -17,7 +17,6 @@ require (
 
 require (
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 // indirect
-	github.com/docker/docker-credential-helpers v0.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.4.0 // indirect
 	github.com/go-asn1-ber/asn1-ber v1.5.4 // indirect
 	github.com/go-ldap/ldap/v3 v3.4.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/notaryproject/notation-go v1.0.0-rc.6
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc3
-	github.com/oras-project/oras-credentials-go v0.1.2-0.20230609082027-b60b11bcba14
+	github.com/oras-project/oras-credentials-go v0.1.2-0.20230609092929-bf5244c85f2a
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0-rc3 h1:fzg1mXZFj8YdPeNkRXMg+zb88BFV0Ys52cJydRwBkb8=
 github.com/opencontainers/image-spec v1.1.0-rc3/go.mod h1:X4pATf0uXsnn3g5aiGIsVnJBR4mxhKzfwmvK/B2NTm8=
-github.com/oras-project/oras-credentials-go v0.1.2-0.20230609082027-b60b11bcba14 h1:BOJuf9pyj3KAUsR9ZLDjgzXWPbhuaIUi+gvK2aiT5AQ=
-github.com/oras-project/oras-credentials-go v0.1.2-0.20230609082027-b60b11bcba14/go.mod h1:JVdg7a5k7hzTrEeeouwag0aCv7OLrS77r7/6w3gVirU=
+github.com/oras-project/oras-credentials-go v0.1.2-0.20230609092929-bf5244c85f2a h1:9EfGz03gbAnD3kZaHxUZUphSMYpxzzPs3NtaUomxMOo=
+github.com/oras-project/oras-credentials-go v0.1.2-0.20230609092929-bf5244c85f2a/go.mod h1:JVdg7a5k7hzTrEeeouwag0aCv7OLrS77r7/6w3gVirU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=
-github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNkFR1R1V12OJRRO5lzt2D1b5X0=
 github.com/fxamacker/cbor/v2 v2.4.0 h1:ri0ArlOR+5XunOP8CRUowT0pSJOwhW098ZCUyskZD88=
 github.com/fxamacker/cbor/v2 v2.4.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/go-asn1-ber/asn1-ber v1.5.4 h1:vXT6d/FNDiELJnLb6hGNa309LMsrCoYFvpwHDF0+Y1A=
@@ -25,8 +23,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0-rc3 h1:fzg1mXZFj8YdPeNkRXMg+zb88BFV0Ys52cJydRwBkb8=
 github.com/opencontainers/image-spec v1.1.0-rc3/go.mod h1:X4pATf0uXsnn3g5aiGIsVnJBR4mxhKzfwmvK/B2NTm8=
-github.com/oras-project/oras-credentials-go v0.1.1 h1:9EHrcJ1LcC7N9w2rfB9n8c1be+6IacnmFxywltQHecI=
-github.com/oras-project/oras-credentials-go v0.1.1/go.mod h1:188MBZBQQbrLlrOZY37hc8Z4Xjl+wP3PaIJkJuk94JM=
+github.com/oras-project/oras-credentials-go v0.1.2-0.20230609082027-b60b11bcba14 h1:BOJuf9pyj3KAUsR9ZLDjgzXWPbhuaIUi+gvK2aiT5AQ=
+github.com/oras-project/oras-credentials-go v0.1.2-0.20230609082027-b60b11bcba14/go.mod h1:JVdg7a5k7hzTrEeeouwag0aCv7OLrS77r7/6w3gVirU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
Fixes: #696 

---
## Behaviors of this PR
- If the notation config has auth configuration
  - Use the notation config for credentials GET, PUT and DELETE
- If the notation config does not have auth configuration, or the the notation config file does not exist
  - If the docker config has auth configuration
    - Use the notation config for credentials GET, PUT and DELETE
  - If there is no authentication configured in the docker config, or the the docker config file does not exist
    - If there is a platform-default native keychain installed
      - Use the platform-default native keychain for credentials GET, PUT and DELETE
    - If there is no platform-default native keychain installed
      - GET will always return an empty credential
      - PUT will always fail (ErrPlaintextPutDisabled)
      - DELETE will result in no operation