### PR TITLE
bump: tag and release v1.0.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ package version
 
 var (
 	// Version shows the current notation version, optionally with pre-release.
-	Version = "v1.0.0-rc.7"
+	Version = "v1.0.0"
 
 	// BuildMetadata stores the build metadata.
 	//


### PR DESCRIPTION
## Release

This would mean tagging 80e3fc4e2eeb43ac00bc888cf41101f5c56f1535 as `v1.0.0` to release.

## Vote

We need at least `4` approvals from `6` maintainers to release `notation v1.0.0`.

- [x] Junjie Gao (@JeyJeyGao)
- [ ] Milind Gokarn (@gokarnm)
- [x] Patrick Zheng (@Two-Hearts)
- [x] Pritesh Bandi (@priteshbandi)
- [ ] Rakesh Gariganti (@rgnote)
- [x] Shiwei Zhang (@shizhMSFT)

## Changes

The code changes compared to `v1.0.0-rc.7` include:

- #692
- #702
- #703
- #710
- #711
- #712
- #594
- #717
- #716
- #727
- #724
- #731
- #730
- #735
- #739
- #734
- #737
- #745
- #742
- #746
- #744
- #752
- #751
- #754
- #750

**Full Changelog**: https://github.com/notaryproject/notation/compare/v1.0.0-rc.7...80e3fc4e2eeb43ac00bc888cf41101f5c56f1535

## Action Requested

Please respond LGTM (approve) or REJECT (request for changes).