### PR TITLE
fix: add timeout for registry request

### DIFF
--- a/cmd/notation/registry.go
+++ b/cmd/notation/registry.go
@@ -128,8 +128,6 @@ func setHttpDebugLog(ctx context.Context, authClient *auth.Client) {
 	if authClient.Client == nil {
 		authClient.Client = http.DefaultClient
 	}
-	authClient.Client.Timeout = 20 * time.Second
-
 	if authClient.Client.Transport == nil {
 		authClient.Client.Transport = http.DefaultTransport
 	}
@@ -159,6 +157,9 @@ func getAuthClient(ctx context.Context, opts *SecureFlagOpts, ref registry.Refer
 
 	// build authClient
 	authClient := &auth.Client{
+		Client: &http.Client{
+			Timeout: 20 * time.Second,
+		},
 		Cache:    auth.NewCache(),
 		ClientID: "notation",
 	}

--- a/cmd/notation/registry.go
+++ b/cmd/notation/registry.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/notaryproject/notation-go/log"
 	notationregistry "github.com/notaryproject/notation-go/registry"
@@ -127,6 +128,8 @@ func setHttpDebugLog(ctx context.Context, authClient *auth.Client) {
 	if authClient.Client == nil {
 		authClient.Client = http.DefaultClient
 	}
+	authClient.Client.Timeout = 20 * time.Second
+
 	if authClient.Client.Transport == nil {
 		authClient.Client.Transport = http.DefaultTransport
 	}


### PR DESCRIPTION
Fix:
- added timeout

Test:
```sh
./bin/notation sign localhost:5003/hello:v1 --key e2e -d
INFO[2023-07-25T21:13:11+08:00] Using the referrers tag schema               
DEBU[2023-07-25T21:13:11+08:00] > Request: "HEAD" "http://localhost:5003/v2/hello/manifests/v1" 
DEBU[2023-07-25T21:13:11+08:00] > Request headers:                           
DEBU[2023-07-25T21:13:11+08:00]    "Accept": "application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.oci.image.index.v1+json, application/vnd.oci.artifact.manifest.v1+json" 
DEBU[2023-07-25T21:13:11+08:00]    "User-Agent": "notation/v1.0.0-rc.7+unreleased" 
ERRO[2023-07-25T21:13:31+08:00] Error in getting response: %!w(*errors.errorString=&{net/http: request canceled}) 
Error: failed to get manifest descriptor: Head "http://localhost:5003/v2/hello/manifests/v1": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```

server script:
```python
from flask import Flask, request
import time

app = Flask(__name__)

@app.route('/', defaults={'path': ''}, methods=['GET', 'POST', 'PUT', 'DELETE'])
@app.route('/<path:path>', methods=['GET', 'POST', 'PUT', 'DELETE'])
def delay_response(path):
    while True:
        time.sleep(1)

if __name__ == "__main__":
    app.run(host='0.0.0.0', port=5003)
```


Resolves #707 
Signed-off-by: Junjie Gao <junjiegao@microsoft.com>