### PR TITLE
docs: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can find the Notary Project [README](https://github.com/notaryproject/.githu
 
 ## Quick Start
 
-- [Quick start: Sign and validate a container image](https://notaryproject.dev/docs/quickstart/)
+- [Quick start: Sign and validate a container image](https://notaryproject.dev/docs/quickstart-guides/quickstart/)
 - [Try out Notation in this Killercoda interactive sandbox environment](https://killercoda.com/notaryproject/scenario/notation)
 - Build, sign, and verify container images using Notation with [Azure Key Vault](https://docs.microsoft.com/azure/container-registry/container-registry-tutorial-sign-build-push?wt.mc_id=azurelearn_inproduct_oss_notaryproject) or [AWS Signer](https://docs.aws.amazon.com/signer/latest/developerguide/container-workflow.html)
  

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Notation is a CLI project to add signatures as standard items in the OCI registr
 You can find the Notary Project [README](https://github.com/notaryproject/.github/blob/main/README.md) to learn about the overall Notary Project.
 
 > [!NOTE]
-> The documentation for installing Notation CLI is available [here](https://notaryproject.dev/docs/installation/cli/).
+> The documentation for installing Notation CLI is available [here](https://notaryproject.dev/docs/user-guides/installation/cli/).
 
 ## Table of Contents
 

--- a/specs/commandline/verify.md
+++ b/specs/commandline/verify.md
@@ -59,7 +59,7 @@ Use `notation certificate` command to configure trust stores.
 
 ### Configure Trust Policy
 
-Users who consume signed artifact from a registry use the trust policy to specify trusted identities which sign the artifacts, and level of signature verification to use. The trust policy is a JSON document. User needs to create a file named `trustpolicy.json` under `{NOTATION_CONFIG}`. See [Notation Directory Structure](https://notaryproject.dev/docs/tutorials/directory-structure/) for `{NOTATION_CONFIG}`.
+Users who consume signed artifact from a registry use the trust policy to specify trusted identities which sign the artifacts, and level of signature verification to use. The trust policy is a JSON document. User needs to create a file named `trustpolicy.json` under `{NOTATION_CONFIG}`. See [Notation Directory Structure](https://notaryproject.dev/docs/user-guides/how-to/directory-structure/) for `{NOTATION_CONFIG}`.
 
 An example of `trustpolicy.json`:
 


### PR DESCRIPTION
The link is broken.

https://notaryproject.dev/docs/quickstart/

<img width="638" alt="image" src="https://github.com/notaryproject/notation/assets/13323303/2ba91685-13ed-4104-befe-ed74fec60ff3">

> The page that you requested doesn't exist.
> 
> Check the URL's spelling.
> 
> If you think that the page should exist, [create an issue.](https://github.com/notaryproject/notaryproject.dev/issues/new?title=Unexpected%20page-not-found%20error&body=URL%3A%20%0AExpected%20page%3A%20)

So I fixed the link.

https://notaryproject.dev/docs/quickstart-guides/quickstart/