### PR TITLE
enhance: update notation cert list command output

### DIFF
--- a/cmd/notation/internal/truststore/truststore.go
+++ b/cmd/notation/internal/truststore/truststore.go
@@ -87,9 +87,11 @@ func AddCert(path, storeType, namedStore string, display bool) error {
 
 // ListCerts walks through root and lists all x509 certificates in it,
 // sub-dirs are ignored.
-func ListCerts(root string, depth int) error {
+func ListCerts(root string, depth int, certPaths *[]string) error {
 	maxDepth := strings.Count(root, string(os.PathSeparator)) + depth
-
+	if certPaths == nil {
+		return errors.New("certPaths cannot be nil")
+	}
 	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -107,7 +109,7 @@ func ListCerts(root string, depth int) error {
 				return err
 			}
 			if len(certs) != 0 {
-				fmt.Println(path)
+				*certPaths = append(*certPaths, path)
 			}
 		}
 		return nil

--- a/internal/ioutil/print.go
+++ b/internal/ioutil/print.go
@@ -61,7 +61,7 @@ func PrintMetadataMap(w io.Writer, metadata map[string]string) error {
 
 func PrintCertMap(w io.Writer, certPaths []string) error {
 	tw := newTabWriter(w)
-	fmt.Fprintln(tw, "STORE TYPE\tNAMED STORE\tCERTIFICATE\t")
+	fmt.Fprintln(tw, "STORE TYPE\tSTORE NAME\tCERTIFICATE\t")
 	for _, cert := range certPaths {
 		fileName := filepath.Base(cert)
 		dir := filepath.Dir(cert)

--- a/internal/ioutil/print.go
+++ b/internal/ioutil/print.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"path/filepath"
 	"text/tabwriter"
 
 	"github.com/notaryproject/notation-go/config"
@@ -55,6 +56,20 @@ func PrintMetadataMap(w io.Writer, metadata map[string]string) error {
 		fmt.Fprintf(tw, "%v\t%v\t\n", k, v)
 	}
 
+	return tw.Flush()
+}
+
+func PrintCertMap(w io.Writer, certPaths []string) error {
+	tw := newTabWriter(w)
+	fmt.Fprintln(tw, "STORE TYPE\tNAMED STORE\tCERTIFICATE\t")
+	for _, cert := range certPaths {
+		fileName := filepath.Base(cert)
+		dir := filepath.Dir(cert)
+		namedStore := filepath.Base(dir)
+		dir = filepath.Dir(dir)
+		storeType := filepath.Base(dir)
+		fmt.Fprintf(tw, "%s\t%s\t%s\t\n", storeType, namedStore, fileName)
+	}
 	return tw.Flush()
 }
 

--- a/specs/commandline/certificate.md
+++ b/specs/commandline/certificate.md
@@ -151,7 +151,7 @@ Upon successful adding, the certificate files are added into directory`{NOTATION
 notation certificate list
 ```
 
-Upon successful listing, all the certificate files in the trust store are printed out in a format of absolute filepath. If the listing fails, an error message is printed out with specific reasons. Nothing is printed out if the trust store is empty.
+Upon successful listing, all the certificate files in the trust store are printed out with information of store type, named store and certificate file name. If the listing fails, an error message is printed out with specific reasons. Nothing is printed out if the trust store is empty.
 
 ### List all certificate files of a certain named store
 
@@ -159,7 +159,7 @@ Upon successful listing, all the certificate files in the trust store are printe
 notation cert list --store <name>
 ```
 
-Upon successful listing, all the certificate files in the trust store named `<name>` are printed out in a format of absolute filepath. If the listing fails, an error message is printed out with specific reasons. Nothing is printed out if the trust store is empty.
+Upon successful listing, all the certificate files in the trust store named `<name>` are printed out with information of store type, named store and certificate file name. If the listing fails, an error message is printed out with specific reasons. Nothing is printed out if the trust store is empty.
 
 ### List all certificate files of a certain type of store
 
@@ -167,7 +167,7 @@ Upon successful listing, all the certificate files in the trust store named `<na
 notation cert list --type <type>
 ```
 
-Upon successful listing, all the certificate files in the trust store of type `<type>` are printed out in a format of absolute filepath. If the listing fails, an error message is printed out with specific reasons. Nothing is printed out if the trust store is empty.
+Upon successful listing, all the certificate files in the trust store of type `<type>` are printed out with information of store type, named store and certificate file name. If the listing fails, an error message is printed out with specific reasons. Nothing is printed out if the trust store is empty.
 
 ### List all certificate files of a certain named store of a certain type
 
@@ -175,7 +175,7 @@ Upon successful listing, all the certificate files in the trust store of type `<
 notation cert list --type <type> --store <name>
 ```
 
-Upon successful listing, all the certificate files in the trust store named `<name>` of type `<type>` are printed out in a format of absolute filepath. If the listing fails, an error message is printed out with specific reasons. Nothing is printed out if the trust store is empty.
+Upon successful listing, all the certificate files in the trust store named `<name>` of type `<type>` are printed out with information of store type, named store and certificate file name. If the listing fails, an error message is printed out with specific reasons. Nothing is printed out if the trust store is empty.
 
 ### Show details of a certain certificate file
 

--- a/specs/commandline/certificate.md
+++ b/specs/commandline/certificate.md
@@ -151,7 +151,7 @@ Upon successful adding, the certificate files are added into directory`{NOTATION
 notation certificate list
 ```
 
-Upon successful listing, all the certificate files in the trust store are printed out with information of store type, named store and certificate file name. If the listing fails, an error message is printed out with specific reasons. Nothing is printed out if the trust store is empty.
+Upon successful listing, all the certificate files in the trust store are printed out with information of store type, store name and certificate file name. If the listing fails, an error message is printed out with specific reasons. Nothing is printed out if the trust store is empty.
 
 ### List all certificate files of a certain named store
 
@@ -159,7 +159,7 @@ Upon successful listing, all the certificate files in the trust store are printe
 notation cert list --store <name>
 ```
 
-Upon successful listing, all the certificate files in the trust store named `<name>` are printed out with information of store type, named store and certificate file name. If the listing fails, an error message is printed out with specific reasons. Nothing is printed out if the trust store is empty.
+Upon successful listing, all the certificate files in the trust store named `<name>` are printed out with information of store type, store name and certificate file name. If the listing fails, an error message is printed out with specific reasons. Nothing is printed out if the trust store is empty.
 
 ### List all certificate files of a certain type of store
 
@@ -167,7 +167,7 @@ Upon successful listing, all the certificate files in the trust store named `<na
 notation cert list --type <type>
 ```
 
-Upon successful listing, all the certificate files in the trust store of type `<type>` are printed out with information of store type, named store and certificate file name. If the listing fails, an error message is printed out with specific reasons. Nothing is printed out if the trust store is empty.
+Upon successful listing, all the certificate files in the trust store of type `<type>` are printed out with information of store type, store name and certificate file name. If the listing fails, an error message is printed out with specific reasons. Nothing is printed out if the trust store is empty.
 
 ### List all certificate files of a certain named store of a certain type
 
@@ -175,7 +175,7 @@ Upon successful listing, all the certificate files in the trust store of type `<
 notation cert list --type <type> --store <name>
 ```
 
-Upon successful listing, all the certificate files in the trust store named `<name>` of type `<type>` are printed out with information of store type, named store and certificate file name. If the listing fails, an error message is printed out with specific reasons. Nothing is printed out if the trust store is empty.
+Upon successful listing, all the certificate files in the trust store named `<name>` of type `<type>` are printed out with information of store type, store name and certificate file name. If the listing fails, an error message is printed out with specific reasons. Nothing is printed out if the trust store is empty.
 
 ### Show details of a certain certificate file
 

--- a/test/e2e/suite/scenario/quickstart.go
+++ b/test/e2e/suite/scenario/quickstart.go
@@ -62,7 +62,11 @@ var _ = Describe("notation quickstart E2E test", Ordered, func() {
 			)
 
 		notation.Exec("cert", "ls").
-			MatchKeyWords("notation/truststore/x509/ca/wabbit-networks.io/wabbit-networks.io.crt")
+			MatchKeyWords(
+				"ca",
+				"wabbit-networks.io",
+				"wabbit-networks.io.crt",
+			)
 	})
 
 	It("sign the container image with jws format (by default)", func() {


### PR DESCRIPTION
This PR updates the output format of `notation cert list` command.
Example output,
```
STORE TYPE         STORE NAME         CERTIFICATE   
ca                 myStore            myCert.pem    
ca                 myStore            myCert2.pem    
ca                 anotherStore       myCert3.crt    
```