### PR TITLE
fix: add "release-*" to workflows trigger events

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,9 +15,13 @@ name: "CodeQL"
 
 on:
   push:
-    branches: main
+    branches: 
+      - main
+      - release-*
   pull_request:
-    branches: main
+    branches: 
+      - main
+      - release-*
   schedule:
     - cron: '38 21 * * 1'
 

--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -15,9 +15,13 @@ name: License Checker
 
 on:
   push:
-    branches: main
+    branches: 
+      - main
+      - release-*
   pull_request:
-    branches: main
+    branches: 
+      - main
+      - release-*
 
 permissions:
   contents: read

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -18,7 +18,7 @@ on:
     # Weekly on Saturdays.
     - cron: '30 1 * * 6'
   push:
-    branches: [ main ]
+    branches: [ main, release-* ]
     paths:
     - '!docs/**'
     - '!specs/**'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -18,7 +18,9 @@ on:
     # Weekly on Saturdays.
     - cron: '30 1 * * 6'
   push:
-    branches: [ main, release-* ]
+    branches: 
+      - main
+      - release-*
     paths:
     - '!docs/**'
     - '!specs/**'


### PR DESCRIPTION
Since notation v1.0.1 is a patch release, we need to create a new branch named `release-1.0` for the release. Current workflows take effect on the `main` branch only. Adding `release-*` as a fix.