### PR TITLE
bump: tag and release v1.0.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ package version
 
 var (
 	// Version shows the current notation version, optionally with pre-release.
-	Version = "v1.0.0"
+	Version = "v1.0.1"
 
 	// BuildMetadata stores the build metadata.
 	//


### PR DESCRIPTION
## Release

This would mean tagging e2f4237fb6ac602f68a786afaaf6388fb30b866d as `v1.0.1` to release.

## Vote

We need at least `4` approvals from `6` maintainers to release `notation v1.0.1`.

- [x] Junjie Gao (@JeyJeyGao)
- [ ] Milind Gokarn (@gokarnm)
- [x] Patrick Zheng (@Two-Hearts)
- [x] Pritesh Bandi (@priteshbandi)
- [ ] Rakesh Gariganti (@rgnote)
- [x] Shiwei Zhang (@shizhMSFT)

## Changes

The code changes compared to `v1.0.0` include:

- #761
- #762
- #758
- #763
- #760
- #757
- #764
- #714
- #766
- #774
- #775
- #780
- #781
- #782
- #779
- #794
- #795
- #797
- #796
- #789
- #786
- #785
- #799
- #803
- #800
- #776
- #805
- #787
- #810
- #815
- #814
- #813
- #818
- #819

**Full Changelog**: https://github.com/notaryproject/notation/compare/v1.0.0...e2f4237fb6ac602f68a786afaaf6388fb30b866d

## Action Requested

Please respond LGTM (approve) or REJECT (request for changes).