### PR TITLE
feat: add notation config environment variable

### DIFF
--- a/cmd/notation/main.go
+++ b/cmd/notation/main.go
@@ -16,6 +16,7 @@ package main
 import (
 	"os"
 
+	"github.com/notaryproject/notation-go/dir"
 	"github.com/notaryproject/notation/cmd/notation/cert"
 	"github.com/notaryproject/notation/cmd/notation/policy"
 	"github.com/spf13/cobra"
@@ -31,6 +32,16 @@ func main() {
 			// to avoid leaking credentials
 			os.Unsetenv(defaultUsernameEnv)
 			os.Unsetenv(defaultPasswordEnv)
+
+			// update Notation config directory
+			if notationConfig := os.Getenv("NOTATION_CONFIG"); notationConfig != "" {
+				dir.UserConfigDir = notationConfig
+			}
+
+			// update Notation Libexec directory (for plugins)
+			if notationLibexec := os.Getenv("NOTATION_LIBEXEC"); notationLibexec != "" {
+				dir.UserLibexecDir = notationLibexec
+			}
 		},
 	}
 	cmd.AddCommand(

--- a/test/e2e/suite/command/verify.go
+++ b/test/e2e/suite/command/verify.go
@@ -155,4 +155,26 @@ var _ = Describe("notation verify", func() {
 				NoMatchErrKeyWords(HTTPSRequest)
 		})
 	})
+
+	It("incorrect NOTATION_CONFIG path", func() {
+		Host(BaseOptions(), func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+			notation.Exec("sign", artifact.ReferenceWithDigest()).
+				MatchKeyWords(SignSuccessfully)
+
+			vhost.UpdateEnv(map[string]string{"NOTATION_CONFIG": "/not/exist"})
+			notation.ExpectFailure().Exec("verify", artifact.ReferenceWithDigest(), "-v").
+				MatchErrKeyWords("trust policy is not present")
+		})
+	})
+
+	It("correct NOTATION_CONFIG path", func() {
+		Host(BaseOptions(), func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+			notation.Exec("sign", artifact.ReferenceWithDigest()).
+				MatchKeyWords(SignSuccessfully)
+
+			vhost.UpdateEnv(map[string]string{"NOTATION_CONFIG": vhost.AbsolutePath(NotationDirName)})
+			notation.Exec("verify", artifact.ReferenceWithDigest(), "-v").
+				MatchKeyWords(VerifySuccessfully)
+		})
+	})
 })


### PR DESCRIPTION
Feat:
- added NOTATION_CONFIG and NOTATION_LIBEXEC environment variables

Test:
- notation sign with NOTATION_LIBEXEC locally
- notation verify with NOTATION_CONFIG locally

Resolves #822 
Signed-off-by: Junjie Gao <junjiegao@microsoft.com>