### PR TITLE
Correct broken link to quick start guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ You can find the Notary Project [README](https://github.com/notaryproject/.githu
 
 ## Quick Start
 
-- [Quick start: Sign and validate a container image](https://notaryproject.dev/docs/quickstart-guides/quickstart/)
+- [Quick start: Sign and validate a container image](https://notaryproject.dev/docs/quickstart-guides/quickstart-sign-image-artifact/)
 - [Try out Notation in this Killercoda interactive sandbox environment](https://killercoda.com/notaryproject/scenario/notation)
 - Build, sign, and verify container images using Notation with [Azure Key Vault](https://docs.microsoft.com/azure/container-registry/container-registry-tutorial-sign-build-push?wt.mc_id=azurelearn_inproduct_oss_notaryproject) or [AWS Signer](https://docs.aws.amazon.com/signer/latest/developerguide/container-workflow.html)
- 
+
 ## Community
 
 Notary Project is a [CNCF Incubating project](https://www.cncf.io/projects/notary/). We :heart: your contribution.


### PR DESCRIPTION
Similarly to https://github.com/notaryproject/notaryproject.dev/issues/360, 
I attempted to follow the link in the README.md for the quick start guide and discovered the broken link. Linking to the official page.

URL: https://notaryproject.dev/docs/quickstart/
Expected page: https://notaryproject.dev/docs/quickstart-guides/quickstart-sign-image-artifact/