### PR TITLE
fix: `notation plugin install` fails to install a single plugin executable file

### DIFF
--- a/cmd/notation/internal/plugin/plugin.go
+++ b/cmd/notation/internal/plugin/plugin.go
@@ -57,7 +57,7 @@ const (
 const DownloadPluginFromURLTimeout = 10 * time.Minute
 
 // DownloadPluginFromURL downloads plugin source from url to a tmp dir on file
-// system. On success, it returns the downloaded file.
+// system. On success, it returns the downloaded file path.
 func DownloadPluginFromURL(ctx context.Context, pluginURL, tmpDir string) (string, error) {
 	// Get the data
 	client := httputil.NewAuthClient(ctx, &http.Client{Timeout: DownloadPluginFromURLTimeout})

--- a/cmd/notation/internal/plugin/plugin.go
+++ b/cmd/notation/internal/plugin/plugin.go
@@ -74,6 +74,7 @@ func DownloadPluginFromURL(ctx context.Context, pluginURL, tmpDir string) (*os.F
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("%s %q: https response bad status: %s", resp.Request.Method, resp.Request.URL, resp.Status)
 	}
+	// get the downloaded file name
 	var downloadedFilename string
 	if cd := resp.Header.Get("Content-Disposition"); cd != "" {
 		_, params, err := mime.ParseMediaType(cd)

--- a/cmd/notation/internal/plugin/plugin.go
+++ b/cmd/notation/internal/plugin/plugin.go
@@ -83,7 +83,7 @@ func DownloadPluginFromURL(ctx context.Context, pluginURL, tmpDir string) (*os.F
 		}
 	}
 	if downloadedFilename == "" {
-		downloadedFilename = path.Base(req.URL.Path)
+		downloadedFilename = path.Base(path.Clean(req.URL.Path))
 	}
 	// Write the body to file
 	tmpFilePath := filepath.Join(tmpDir, downloadedFilename)

--- a/cmd/notation/internal/plugin/plugin.go
+++ b/cmd/notation/internal/plugin/plugin.go
@@ -83,7 +83,7 @@ func DownloadPluginFromURL(ctx context.Context, pluginURL, tmpDir string) (*os.F
 		}
 	}
 	if downloadedFilename == "" {
-		downloadedFilename = path.Base(path.Clean(req.URL.Path))
+		downloadedFilename = path.Base(req.URL.Path)
 	}
 	// Write the body to file
 	tmpFilePath := filepath.Join(tmpDir, downloadedFilename)

--- a/cmd/notation/plugin/install.go
+++ b/cmd/notation/plugin/install.go
@@ -138,7 +138,7 @@ func install(command *cobra.Command, opts *pluginInstallOpts) error {
 		}
 		tmpDir, err := os.MkdirTemp("", pluginDownloadTmpDir)
 		if err != nil {
-			return fmt.Errorf("failed to create temporary directory: %w", err)
+			return fmt.Errorf("failed to create temporary directory required for downloading plugin: %w", err)
 		}
 		defer os.RemoveAll(tmpDir)
 		fmt.Printf("Downloading plugin from %s\n", opts.pluginSource)
@@ -147,7 +147,7 @@ func install(command *cobra.Command, opts *pluginInstallOpts) error {
 			return fmt.Errorf("failed to download plugin from URL %s with error: %w", opts.pluginSource, err)
 		}
 		fmt.Println("Download completed")
-		if err := installPlugin(ctx, tmpFile.Name(), opts.inputChecksum, opts.force); err != nil {
+		if err := installPlugin(ctx, tmpFile, opts.inputChecksum, opts.force); err != nil {
 			return fmt.Errorf("plugin installation failed: %w", err)
 		}
 		return nil
@@ -223,7 +223,7 @@ func installPluginFromFS(ctx context.Context, pluginFS fs.FS, force bool) error 
 	// extracting all regular files from root into tmpDir
 	tmpDir, err := os.MkdirTemp("", pluginDecompressTmpDir)
 	if err != nil {
-		return fmt.Errorf("failed to create temporary directory: %w", err)
+		return fmt.Errorf("failed to create temporary directory required for extracting plugin files: %w", err)
 	}
 	defer os.RemoveAll(tmpDir)
 	var pluginFileSize int64
@@ -285,7 +285,7 @@ func installPluginFromTarGz(ctx context.Context, tarGzPath string, force bool) e
 	// extracting all regular files into tmpDir
 	tmpDir, err := os.MkdirTemp("", pluginDecompressTmpDir)
 	if err != nil {
-		return fmt.Errorf("failed to create temporary directory: %w", err)
+		return fmt.Errorf("failed to create temporary directory required for extracting plugin files: %w", err)
 	}
 	defer os.RemoveAll(tmpDir)
 	var pluginFileSize int64

--- a/go.mod
+++ b/go.mod
@@ -30,3 +30,5 @@ require (
 	golang.org/x/sync v0.4.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 )
+
+replace github.com/notaryproject/notation-go => github.com/Two-Hearts/notation-go v0.0.0-20240105090010-4123784659e0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 h1:mFRzDkZVAjdal+s7s0MwaRv9igoPqLRdzOLzw/8Xvq8=
 github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
+github.com/Two-Hearts/notation-go v0.0.0-20240105090010-4123784659e0 h1:RpVSNaPA5u+Tx4QxEiOGUdNQf7+7xi1WIcPgPlHp5oM=
+github.com/Two-Hearts/notation-go v0.0.0-20240105090010-4123784659e0/go.mod h1:Sj9N0ZRdwIEHL8ewzMjKFEIcLCJhp0r8h6IoT48Q/8E=
 github.com/alexbrainman/sspi v0.0.0-20210105120005-909beea2cc74 h1:Kk6a4nehpJ3UuJRqlA3JxYxBZEqCeOmATOvrbT4p9RA=
 github.com/alexbrainman/sspi v0.0.0-20210105120005-909beea2cc74/go.mod h1:cEWa1LVoE5KvSD9ONXsZrj0z6KqySlCCNKHlLzbqAt4=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
@@ -20,8 +22,6 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/notaryproject/notation-core-go v1.0.1 h1:01doxjDERbd0vocLQrlJdusKrRLNNn50OJzp0c5I4Cw=
 github.com/notaryproject/notation-core-go v1.0.1/go.mod h1:rayl8WlKgS4YxOZgDO0iGGB4Ef515ZFZUFaZDmsPXgE=
-github.com/notaryproject/notation-go v1.0.2-0.20231218132318-85a5bb9826c6 h1:9YgUKLuNU8eNlv2H696aBQzW8CtSjevRgbMGld59wrY=
-github.com/notaryproject/notation-go v1.0.2-0.20231218132318-85a5bb9826c6/go.mod h1:nqDueF9YCCX0u41Eec7aGJEXgGdM0a3KD79wqhCnxq0=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0-rc5 h1:Ygwkfw9bpDvs+c9E34SdgGOj41dX/cbdlwvlWt0pnFI=


### PR DESCRIPTION
This PR fixes the following bug:
When installing a single plugin executable file from URL, the downloaded file name is not preserved. Since Notation relies on file name and file extension to retrieve the plugin name ([spec](https://github.com/notaryproject/specifications/blob/main/specs/plugin-extensibility.md#installation)) and check whether it's executable on the OS, the downloaded file name has to be preserved.

This PR depends on PR: https://github.com/notaryproject/notation-go/pull/369.