### PR TITLE
bump: tag and release version v1.1.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ package version
 
 var (
 	// Version shows the current notation version, optionally with pre-release.
-	Version = "v1.0.0"
+	Version = "v1.1.0"
 
 	// BuildMetadata stores the build metadata.
 	//


### PR DESCRIPTION
## Release

This would mean tagging 99ca669edf9e171a912278166323b4c82f3d9706 as `v1.1.0` to release.

## Vote

We need at least `4` approvals from `6` maintainers to release `notation v1.1.0`.

- [x] Junjie Gao (@JeyJeyGao)
- [ ] Milind Gokarn (@gokarnm)
- [x] Patrick Zheng (@Two-Hearts)
- [x] Pritesh Bandi (@priteshbandi)
- [ ] Rakesh Gariganti (@rgnote)
- [x] Shiwei Zhang (@shizhMSFT)

## Changes

The code changes compared to `v1.0.1` include:

* feat: update notation cert list command output by @Two-Hearts in https://github.com/notaryproject/notation/pull/798
* fix: Code scanning issues by @JeyJeyGao in https://github.com/notaryproject/notation/pull/799
* fix: legacy docker config support by @JeyJeyGao in https://github.com/notaryproject/notation/pull/803
* build(deps): Bump golang.org/x/net from 0.12.0 to 0.17.0 in /test/e2e by @dependabot in https://github.com/notaryproject/notation/pull/800
* build(deps): Bump oras.land/oras-go/v2 from 2.2.1 to 2.3.0 by @dependabot in https://github.com/notaryproject/notation/pull/776
* build(deps): Bump actions/checkout from 4.1.0 to 4.1.1 by @dependabot in https://github.com/notaryproject/notation/pull/805
* docs: fix broken links by @suzuki-shunsuke in https://github.com/notaryproject/notation/pull/787
* fix: improve error messages of notation CLI by @Two-Hearts in https://github.com/notaryproject/notation/pull/810
* bump: update dependencies by @Two-Hearts in https://github.com/notaryproject/notation/pull/815
* build(deps): Bump ossf/scorecard-action from 2.3.0 to 2.3.1 by @dependabot in https://github.com/notaryproject/notation/pull/814
* build(deps): Bump github/codeql-action from 2.22.0 to 2.22.5 by @dependabot in https://github.com/notaryproject/notation/pull/813
* bump: bump up dependencies including E2E tests by @Two-Hearts in https://github.com/notaryproject/notation/pull/818
* fix: add "release-*" to workflows trigger events by @Two-Hearts in https://github.com/notaryproject/notation/pull/819
* fix: fix the license check by @Two-Hearts in https://github.com/notaryproject/notation/pull/826
* bump: bump up to go version 1.21 by @Two-Hearts in https://github.com/notaryproject/notation/pull/833
* doc: update plugin spec by @FeynmanZhou in https://github.com/notaryproject/notation/pull/809
* build(deps): Bump github.com/spf13/cobra from 1.7.0 to 1.8.0 by @dependabot in https://github.com/notaryproject/notation/pull/823
* build(deps): Bump github/codeql-action from 2.22.5 to 2.22.7 by @dependabot in https://github.com/notaryproject/notation/pull/835
* Correct broken link to quick start guide by @rcrozean in https://github.com/notaryproject/notation/pull/831
* chore: update tag to digest by @yizha1 in https://github.com/notaryproject/notation/pull/837
* feat: add notation plugin uninstall command by @Two-Hearts in https://github.com/notaryproject/notation/pull/842
* chore: update references with the tag version by @yizha1 in https://github.com/notaryproject/notation/pull/836
* build(deps): Bump golang.org/x/term from 0.13.0 to 0.15.0 by @dependabot in https://github.com/notaryproject/notation/pull/843
* build(deps): Bump actions/setup-go from 4.1.0 to 5.0.0 by @dependabot in https://github.com/notaryproject/notation/pull/845
* build(deps): Bump github/codeql-action from 2.22.7 to 2.22.9 by @dependabot in https://github.com/notaryproject/notation/pull/846
* build(deps): Bump golang.org/x/crypto from 0.15.0 to 0.17.0 by @dependabot in https://github.com/notaryproject/notation/pull/850
* build(deps): Bump golang.org/x/crypto from 0.14.0 to 0.17.0 in /test/e2e/plugin by @dependabot in https://github.com/notaryproject/notation/pull/849
* build(deps): Bump github/codeql-action from 2.22.9 to 3.22.11 by @dependabot in https://github.com/notaryproject/notation/pull/847
* build(deps): Bump actions/upload-artifact from 3.1.3 to 4.0.0 by @dependabot in https://github.com/notaryproject/notation/pull/848
* feat: notation plugin install command by @Two-Hearts in https://github.com/notaryproject/notation/pull/827
* feat: add notation config environment variable by @JeyJeyGao in https://github.com/notaryproject/notation/pull/821
* fix: fix bug in `SetHTTPDebugLog` by @Two-Hearts in https://github.com/notaryproject/notation/pull/857
* fix: `notation plugin install` error messages and tests by @Two-Hearts in https://github.com/notaryproject/notation/pull/855
* build(deps): Bump github/codeql-action from 3.22.11 to 3.22.12 by @dependabot in https://github.com/notaryproject/notation/pull/854
* Updated CODEOWNERS and MAINTAINERS files by @toddysm in https://github.com/notaryproject/notation/pull/862
* build(deps): Bump golang.org/x/term from 0.15.0 to 0.16.0 by @dependabot in https://github.com/notaryproject/notation/pull/860
* bump: bump up notation-go by @Two-Hearts in https://github.com/notaryproject/notation/pull/863
* build(deps): Bump actions/cache from 3.3.2 to 3.3.3 by @dependabot in https://github.com/notaryproject/notation/pull/866
* build(deps): Bump github/codeql-action from 3.22.12 to 3.23.0 by @dependabot in https://github.com/notaryproject/notation/pull/865
* build(deps): Bump actions/upload-artifact from 4.0.0 to 4.1.0 by @dependabot in https://github.com/notaryproject/notation/pull/864
* fix: improve error message for plugin by @JeyJeyGao in https://github.com/notaryproject/notation/pull/870
* build(deps): Bump actions/upload-artifact from 4.1.0 to 4.2.0 by @dependabot in https://github.com/notaryproject/notation/pull/872
* build(deps): Bump actions/cache from 3.3.3 to 4.0.0 by @dependabot in https://github.com/notaryproject/notation/pull/873
* build(deps): Bump github/codeql-action from 3.23.0 to 3.23.1 by @dependabot in https://github.com/notaryproject/notation/pull/874
* bump: bump up notation-go and notation-core-go including e2e tests by @Two-Hearts in https://github.com/notaryproject/notation/pull/875

**Full Changelog**: https://github.com/notaryproject/notation/compare/v1.0.1...99ca669edf9e171a912278166323b4c82f3d9706

## Action Requested

Please respond LGTM (approve) or REJECT (request for changes).