### PR TITLE
fix: improve error message for --signature-format flag

### DIFF
--- a/internal/envelope/envelope.go
+++ b/internal/envelope/envelope.go
@@ -46,7 +46,7 @@ func GetEnvelopeMediaType(sigFormat string) (string, error) {
 	case COSE:
 		return cose.MediaTypeEnvelope, nil
 	}
-	return "", fmt.Errorf("signature format %q not supported", sigFormat)
+	return "", fmt.Errorf("signature format %q not supported\nPlease use the supported signature envelope format \"jws\" or \"cose\"", sigFormat)
 }
 
 // ValidatePayloadContentType validates signature payload's content type.

--- a/internal/envelope/envelope.go
+++ b/internal/envelope/envelope.go
@@ -46,7 +46,7 @@ func GetEnvelopeMediaType(sigFormat string) (string, error) {
 	case COSE:
 		return cose.MediaTypeEnvelope, nil
 	}
-	return "", fmt.Errorf("signature format %q not supported\nPlease use the supported signature envelope format \"jws\" or \"cose\"", sigFormat)
+	return "", fmt.Errorf("signature format %q not supported\nSupported signature envelope formats are \"jws\" and \"cose\"", sigFormat)
 }
 
 // ValidatePayloadContentType validates signature payload's content type.

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -111,4 +111,4 @@ export NOTATION_E2E_PLUGIN_TAR_GZ_PATH=$CWD/plugin/bin/$PLUGIN_NAME.tar.gz
 export NOTATION_E2E_MALICIOUS_PLUGIN_ARCHIVE_PATH=$CWD/testdata/malicious-plugin
 
 # run tests
-ginkgo -r -p -v --focus
+ginkgo -r -p -v

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -69,7 +69,7 @@ if [ ! -f "$NOTATION_E2E_OLD_BINARY_PATH" ]; then
 fi
 
 # install dependency
-go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.9.5
+go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.11.0
 
 # build e2e plugin and tar.gz
 PLUGIN_NAME=notation-e2e-plugin

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -111,4 +111,4 @@ export NOTATION_E2E_PLUGIN_TAR_GZ_PATH=$CWD/plugin/bin/$PLUGIN_NAME.tar.gz
 export NOTATION_E2E_MALICIOUS_PLUGIN_ARCHIVE_PATH=$CWD/testdata/malicious-plugin
 
 # run tests
-ginkgo -r -p -v
+ginkgo -r -p -v --focus

--- a/test/e2e/suite/command/cert.go
+++ b/test/e2e/suite/command/cert.go
@@ -1,0 +1,42 @@
+// Copyright The Notary Project Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	. "github.com/notaryproject/notation/test/e2e/internal/notation"
+	"github.com/notaryproject/notation/test/e2e/internal/utils"
+
+	// . "github.com/notaryproject/notation/test/e2e/suite/common"
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("notation", func() {
+	It("show certs", func() {
+		Host(BaseOptions(), func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+			notation.Exec("cert", "list").
+				MatchKeyWords(
+					"STORE TYPE   STORE NAME   CERTIFICATE",
+				)
+		})
+	})
+
+	It("delete all certs", func() {
+		Host(BaseOptions(), func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+			notation.Exec("cert", "delete", "--all", "--type", "ca", "--store", "e2e", "-y").
+				MatchKeyWords(
+					"Successfully deleted",
+				)
+		})
+	})
+})

--- a/test/e2e/suite/command/cert.go
+++ b/test/e2e/suite/command/cert.go
@@ -21,8 +21,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 )
 
-var _ = Describe("notation", func() {
-	It("show certs", func() {
+var _ = Describe("notation cert", func() {
+	It("show all", func() {
 		Host(BaseOptions(), func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
 			notation.Exec("cert", "list").
 				MatchKeyWords(
@@ -31,11 +31,47 @@ var _ = Describe("notation", func() {
 		})
 	})
 
-	It("delete all certs", func() {
+	It("delete all", func() {
 		Host(BaseOptions(), func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
 			notation.Exec("cert", "delete", "--all", "--type", "ca", "--store", "e2e", "-y").
 				MatchKeyWords(
 					"Successfully deleted",
+				)
+		})
+	})
+
+	It("delete a specfic cert", func() {
+		Host(BaseOptions(), func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+			notation.Exec("cert", "delete", "--type", "ca", "--store", "e2e", "e2e.crt", "-y").
+				MatchKeyWords(
+					"Successfully deleted e2e.crt",
+				)
+		})
+	})
+
+	It("delete a non-exist cert", func() {
+		Host(BaseOptions(), func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+			notation.ExpectFailure().Exec("cert", "delete", "--type", "ca", "--store", "e2e", "non-exist.crt", "-y").
+				MatchErrKeyWords(
+					"failed to delete the certificate file",
+				)
+		})
+	})
+
+	It("show e2e cert", func() {
+		Host(BaseOptions(), func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+			notation.Exec("cert", "list", "--type", "ca", "--store", "e2e").
+				MatchKeyWords(
+					"e2e.crt",
+				)
+		})
+	})
+
+	It("list", func() {
+		Host(BaseOptions(), func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+			notation.Exec("cert", "list").
+				MatchKeyWords(
+					"STORE TYPE   STORE NAME   CERTIFICATE",
 				)
 		})
 	})

--- a/test/e2e/suite/command/cert.go
+++ b/test/e2e/suite/command/cert.go
@@ -60,9 +60,9 @@ var _ = Describe("notation cert", func() {
 
 	It("show e2e cert", func() {
 		Host(BaseOptions(), func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
-			notation.Exec("cert", "list", "--type", "ca", "--store", "e2e").
+			notation.Exec("cert", "show", "--type", "ca", "--store", "e2e", "e2e.crt").
 				MatchKeyWords(
-					"e2e.crt",
+					"Issuer: CN=e2e,O=Notary,L=Seattle,ST=WA,C=US",
 				)
 		})
 	})
@@ -72,6 +72,36 @@ var _ = Describe("notation cert", func() {
 			notation.Exec("cert", "list").
 				MatchKeyWords(
 					"STORE TYPE   STORE NAME   CERTIFICATE",
+				)
+		})
+	})
+
+	It("list with type", func() {
+		Host(BaseOptions(), func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+			notation.Exec("cert", "list", "--type", "ca").
+				MatchKeyWords(
+					"STORE TYPE   STORE NAME   CERTIFICATE",
+					"e2e.crt",
+				)
+		})
+	})
+
+	It("list with store", func() {
+		Host(BaseOptions(), func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+			notation.Exec("cert", "list", "--store", "e2e").
+				MatchKeyWords(
+					"STORE TYPE   STORE NAME   CERTIFICATE",
+					"e2e.crt",
+				)
+		})
+	})
+
+	It("list with type and store", func() {
+		Host(BaseOptions(), func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
+			notation.Exec("cert", "list", "--type", "ca", "--store", "e2e").
+				MatchKeyWords(
+					"STORE TYPE   STORE NAME   CERTIFICATE",
+					"e2e.crt",
 				)
 		})
 	})


### PR DESCRIPTION
Previous error message:
```
$ notation sign localhost:5000/hello-app:v1 --plugin azure-kv --id https://x.vault.azure.net/certificates/self-signed-pem/xxx --signature-format xxx
Error: signature format "xxx" not supported
```

Improved error message:
```
$ notation sign localhost:5000/hello-app:v1 --plugin azure-kv --id https://x.vault.azure.net/certificates/self-signed-pem/xxx --signature-format xxx
Error: signature format "xxx" not supported
Please use the supported signature envelope format "jws" or "cose"
```

Test(not related to the fix):
- added unit test and e2e test to reach codecov target 

Resolves #868
Signed-off-by: Junjie Gao <junjiegao@microsoft.com>