### PR TITLE
fix(ci): update goreleaser to use --clean flag

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -50,6 +50,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix:
- replace `--rm-dist` with `--clean`

Goreleaser was updated to v6.0.0 in #962. However the flag `--rm-dist` was deprecated in the latest version. Please see the details in the official document: https://goreleaser.com/deprecations/#-rm-dist

Test:
- the test release was successful: https://github.com/JeyJeyGao/notation/actions/runs/9460066788/job/26058225155

Signed-off-by: Junjie Gao <junjiegao@microsoft.com>