### PR TITLE
bump: bump up and vote for v1.2.0-alpha.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ package version
 
 var (
 	// Version shows the current notation version, optionally with pre-release.
-	Version = "v1.1.0"
+	Version = "v1.2.0-alpha.1"
 
 	// BuildMetadata stores the build metadata.
 	//


### PR DESCRIPTION
## Release

This would mean tagging 2f4387276b4a73fb4b81f9499afe0aa156b56218 `v1.2.0-alpha.1` to release.
## Vote

We need at least `4` approvals from `6` maintainers to release `notation v1.2.0-alpha.1`.

- [x] Junjie Gao (@JeyJeyGao)
- [ ] Milind Gokarn (@gokarnm)
- [ ] Patrick Zheng (@Two-Hearts)
- [x] Pritesh Bandi (@priteshbandi)
- [ ] Rakesh Gariganti (@rgnote)
- [x] Shiwei Zhang (@shizhMSFT)
- [x] Yi Zha (@yizha1)

## Changes

The code changes compared to `v1.1.0` include:
* bump: tag and release version v1.1.0 by @Two-Hearts in https://github.com/notaryproject/notation/pull/876
* build(deps): Bump actions/upload-artifact from 4.2.0 to 4.3.0 by @dependabot in https://github.com/notaryproject/notation/pull/878
* build(deps): Bump codecov/codecov-action from 3.1.4 to 3.1.5 by @dependabot in https://github.com/notaryproject/notation/pull/879
* build(deps): Bump github/codeql-action from 3.23.1 to 3.23.2 by @dependabot in https://github.com/notaryproject/notation/pull/877
* bump: bump up oras-go and image-spec by @Two-Hearts in https://github.com/notaryproject/notation/pull/881
* build(deps): Bump github/codeql-action from 3.23.2 to 3.24.0 by @dependabot in https://github.com/notaryproject/notation/pull/883
* build(deps): Bump codecov/codecov-action from 3.1.5 to 4.0.1 by @dependabot in https://github.com/notaryproject/notation/pull/884
* build(deps): Bump golang.org/x/term from 0.16.0 to 0.17.0 by @dependabot in https://github.com/notaryproject/notation/pull/886
* build(deps): Bump actions/upload-artifact from 4.3.0 to 4.3.1 by @dependabot in https://github.com/notaryproject/notation/pull/887
* build(deps): Bump codecov/codecov-action from 4.0.1 to 4.0.2 by @dependabot in https://github.com/notaryproject/notation/pull/896
* build(deps): Bump github/codeql-action from 3.24.0 to 3.24.5 by @dependabot in https://github.com/notaryproject/notation/pull/895
* build(deps): Bump github.com/opencontainers/image-spec from 1.1.0-rc6 to 1.1.0 by @dependabot in https://github.com/notaryproject/notation/pull/891
* build(deps): Bump codecov/codecov-action from 4.0.2 to 4.1.0 by @dependabot in https://github.com/notaryproject/notation/pull/898
* build(deps): Bump actions/cache from 4.0.0 to 4.0.1 by @dependabot in https://github.com/notaryproject/notation/pull/900
* build(deps): Bump actions/add-to-project from 0.5.0 to 0.6.0 by @dependabot in https://github.com/notaryproject/notation/pull/901
* docs: spec updates for arbitrary blob signing by @rgnote in https://github.com/notaryproject/notation/pull/811
* build(deps): Bump github/codeql-action from 3.24.5 to 3.24.6 by @dependabot in https://github.com/notaryproject/notation/pull/899
* build(deps): Bump golang.org/x/term from 0.17.0 to 0.18.0 by @dependabot in https://github.com/notaryproject/notation/pull/906
* chore: add GitHub action for stale issues and PRs by @yizha1 in https://github.com/notaryproject/notation/pull/841
* build(deps): Bump github/codeql-action from 3.24.6 to 3.24.7 by @dependabot in https://github.com/notaryproject/notation/pull/908
* build(deps): Bump actions/checkout from 4.1.1 to 4.1.2 by @dependabot in https://github.com/notaryproject/notation/pull/907
* build(deps): Bump actions/stale from 8 to 9 by @dependabot in https://github.com/notaryproject/notation/pull/915
* build(deps): Bump actions/add-to-project from 0.6.0 to 0.6.1 by @dependabot in https://github.com/notaryproject/notation/pull/912
* build(deps): Bump github/codeql-action from 3.24.7 to 3.24.9 by @dependabot in https://github.com/notaryproject/notation/pull/913
* build(deps): Bump actions/cache from 4.0.1 to 4.0.2 by @dependabot in https://github.com/notaryproject/notation/pull/914
* build(deps): Bump actions/add-to-project from 0.6.1 to 1.0.0 by @dependabot in https://github.com/notaryproject/notation/pull/918
* build(deps): Bump codecov/codecov-action from 4.1.0 to 4.1.1 by @dependabot in https://github.com/notaryproject/notation/pull/917
* Moved org maintainers to emeritus by @toddysm in https://github.com/notaryproject/notation/pull/919
* fix(ci): update codecov token by @JeyJeyGao in https://github.com/notaryproject/notation/pull/920
* feat: upgrade to OCI 1.1 by @Two-Hearts in https://github.com/notaryproject/notation/pull/916
* fix: improve error message for --signature-format flag by @JeyJeyGao in https://github.com/notaryproject/notation/pull/925
* build(deps): Bump github/codeql-action from 3.24.9 to 3.24.10 by @dependabot in https://github.com/notaryproject/notation/pull/922
* build(deps): Bump golang.org/x/term from 0.18.0 to 0.19.0 by @dependabot in https://github.com/notaryproject/notation/pull/924
* build(deps): Bump codecov/codecov-action from 4.1.1 to 4.3.0 by @dependabot in https://github.com/notaryproject/notation/pull/927
* build(deps): Bump actions/add-to-project from 1.0.0 to 1.0.1 by @dependabot in https://github.com/notaryproject/notation/pull/928
* build(deps): Bump golang.org/x/net from 0.17.0 to 0.23.0 in /test/e2e by @dependabot in https://github.com/notaryproject/notation/pull/929
* build(deps): Bump actions/upload-artifact from 4.3.1 to 4.3.3 by @dependabot in https://github.com/notaryproject/notation/pull/936
* build(deps): Bump actions/setup-go from 5.0.0 to 5.0.1 by @dependabot in https://github.com/notaryproject/notation/pull/939
* build(deps): Bump golang.org/x/term from 0.19.0 to 0.20.0 by @dependabot in https://github.com/notaryproject/notation/pull/940
* build(deps): Bump codecov/codecov-action from 4.3.0 to 4.4.0 by @dependabot in https://github.com/notaryproject/notation/pull/944
* build(deps): Bump github/codeql-action from 3.24.10 to 3.25.5 by @dependabot in https://github.com/notaryproject/notation/pull/945
* build(deps): Bump actions/checkout from 4.1.2 to 4.1.6 by @dependabot in https://github.com/notaryproject/notation/pull/946
* fix: error message for trust policy by @JeyJeyGao in https://github.com/notaryproject/notation/pull/933
* doc: add Notation CLI Error Handling and Message Guideline by @FeynmanZhou in https://github.com/notaryproject/notation/pull/834
* build(deps): Bump goreleaser/goreleaser-action from 5.0.0 to 5.1.0 by @dependabot in https://github.com/notaryproject/notation/pull/951
* build(deps): Bump ossf/scorecard-action from 2.3.1 to 2.3.3 by @dependabot in https://github.com/notaryproject/notation/pull/950
* build(deps): Bump codecov/codecov-action from 4.4.0 to 4.4.1 by @dependabot in https://github.com/notaryproject/notation/pull/949
* build(deps): Bump github/codeql-action from 3.25.5 to 3.25.6 by @dependabot in https://github.com/notaryproject/notation/pull/948
* build(deps): Bump github/codeql-action from 3.25.6 to 3.25.7 by @dependabot in https://github.com/notaryproject/notation/pull/955
* bump: bump up notation-go v1.1.1 and other dependencies by @JeyJeyGao in https://github.com/notaryproject/notation/pull/952
* build(deps): Bump golang.org/x/term from 0.20.0 to 0.21.0 by @dependabot in https://github.com/notaryproject/notation/pull/960
* build(deps): Bump github/codeql-action from 3.25.7 to 3.25.8 by @dependabot in https://github.com/notaryproject/notation/pull/961
* build(deps): Bump goreleaser/goreleaser-action from 5.1.0 to 6.0.0 by @dependabot in https://github.com/notaryproject/notation/pull/962
* fix(ci): update goreleaser to use --clean flag by @JeyJeyGao in https://github.com/notaryproject/notation/pull/964


**Full Changelog**: https://github.com/notaryproject/notation/compare/v1.1.0...2f4387276b4a73fb4b81f9499afe0aa156b56218

Resolve part of #947 