### PR TITLE
bump: vote for notation v1.2.0-beta.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ package version
 
 var (
 	// Version shows the current notation version, optionally with pre-release.
-	Version = "v1.2.0-alpha.1"
+	Version = "v1.2.0-beta.1"
 
 	// BuildMetadata stores the build metadata.
 	//


### PR DESCRIPTION
## Release

This would mean tagging 00af3ce880734837f4cad08dd9eb9099ccba5e8f as `v1.2.0-beta.1` to release.

## Vote

We need at least `4` approvals from `7` maintainers to release `notation v1.2.0-beta.1`.

- [x] Junjie Gao (@JeyJeyGao)
- [ ] Milind Gokarn (@gokarnm)
- [x] Patrick Zheng (@Two-Hearts)
- [x] Pritesh Bandi (@priteshbandi)
- [ ] Rakesh Gariganti (@rgnote)
- [x] Shiwei Zhang (@shizhMSFT)
- [ ] Yi Zha (@yizha1)

## What's Changed
* bump: bump up and vote for v1.2.0-alpha.1 by @JeyJeyGao in https://github.com/notaryproject/notation/pull/967
* build(deps): Bump github.com/spf13/cobra from 1.8.0 to 1.8.1 by @dependabot in https://github.com/notaryproject/notation/pull/969
* build(deps): Bump actions/checkout from 4.1.6 to 4.1.7 by @dependabot in https://github.com/notaryproject/notation/pull/970
* build(deps): Bump codecov/codecov-action from 4.4.1 to 4.5.0 by @dependabot in https://github.com/notaryproject/notation/pull/972
* build(deps): Bump actions/upload-artifact from 4.3.3 to 4.3.4 by @dependabot in https://github.com/notaryproject/notation/pull/983
* build(deps): Bump golang.org/x/term from 0.21.0 to 0.22.0 by @dependabot in https://github.com/notaryproject/notation/pull/982
* build(deps): Bump actions/add-to-project from 1.0.1 to 1.0.2 by @dependabot in https://github.com/notaryproject/notation/pull/981
* build(deps): Bump github/codeql-action from 3.25.8 to 3.25.11 by @dependabot in https://github.com/notaryproject/notation/pull/980
* docs: update RELEASE_CHECKLIST.md by @FeynmanZhou in https://github.com/notaryproject/notation/pull/713
* build(deps): Bump actions/setup-go from 5.0.1 to 5.0.2 by @dependabot in https://github.com/notaryproject/notation/pull/986
* build(deps): Bump github/codeql-action from 3.25.11 to 3.25.13 by @dependabot in https://github.com/notaryproject/notation/pull/991
* feat: Timestamp by @Two-Hearts in https://github.com/notaryproject/notation/pull/978
* build(deps): Bump golang.org/x/net from 0.22.0 to 0.23.0 by @dependabot in https://github.com/notaryproject/notation/pull/993
* bump: bump up dependencies for v1.2.0-beta.1 by @Two-Hearts in https://github.com/notaryproject/notation/pull/994


**Full Changelog**: https://github.com/notaryproject/notation/compare/v1.2.0-alpha.1...00af3ce880734837f4cad08dd9eb9099ccba5e8f