### PR TITLE
bump: release v1.2.0-rc.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ package version
 
 var (
 	// Version shows the current notation version, optionally with pre-release.
-	Version = "v1.2.0-beta.1"
+	Version = "v1.2.0-rc.1"
 
 	// BuildMetadata stores the build metadata.
 	//


### PR DESCRIPTION
## Release

This would mean tagging as `v1.2.0-rc.1` to release.

## Vote

We need at least `4` approvals from `7` maintainers to release `notation v1.2.0-rc.1`.

- [ ] Junjie Gao (@JeyJeyGao)
- [ ] Milind Gokarn (@gokarnm)
- [ ] Patrick Zheng (@Two-Hearts)
- [ ] Pritesh Bandi (@priteshbandi)
- [ ] Rakesh Gariganti (@rgnote)
- [ ] Shiwei Zhang (@shizhMSFT)
- [ ] Yi Zha (@yizha1)

## What's Changed
* build: add support for armv7 binary release by @lmussier in https://github.com/notaryproject/notation/pull/956
* chore: move tsa url print out behind -v flag by @Two-Hearts in https://github.com/notaryproject/notation/pull/996
* feat: update inspect command with timestamping by @Two-Hearts in https://github.com/notaryproject/notation/pull/998
* build(deps): Bump golang.org/x/net from 0.23.0 to 0.27.0 by @dependabot in https://github.com/notaryproject/notation/pull/999
* build(deps): Bump ossf/scorecard-action from 2.3.3 to 2.4.0 by @dependabot in https://github.com/notaryproject/notation/pull/1000
* build(deps): Bump github/codeql-action from 3.25.13 to 3.25.15 by @dependabot in https://github.com/notaryproject/notation/pull/1001
* refactor: update verifier by @Two-Hearts in https://github.com/notaryproject/notation/pull/1002
* refactor!: remove blob sign/verify related contents by @Two-Hearts in https://github.com/notaryproject/notation/pull/1011
* bump: bump up dependencies for release-1.2 by @Two-Hearts in https://github.com/notaryproject/notation/pull/1014


**Full Changelog**: https://github.com/notaryproject/notation/compare/v1.2.0-beta.1...