### PR TITLE
bump: release v1.2.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ package version
 
 var (
 	// Version shows the current notation version, optionally with pre-release.
-	Version = "v1.2.0-rc.1"
+	Version = "v1.2.0"
 
 	// BuildMetadata stores the build metadata.
 	//


### PR DESCRIPTION
## Release

This would mean tagging 4700ad6f1bef13e411772d7ae4399f891fc3a6ae as `v1.2.0` to release.

## Vote

We need at least `4` approvals from `6` maintainers to release `notation v1.2.0`.

- [x] Pritesh Bandi (@priteshbandi)
- [x] Junjie Gao (@JeyJeyGao)
- [ ] Rakesh Gariganti (@rgnote)
- [ ] Milind Gokarn (@gokarnm)
- [x] Shiwei Zhang (@shizhMSFT)
- [x] Patrick Zheng (@Two-Hearts)


## What's Changed
* bump: release v1.2.0-rc.1 by @Two-Hearts in https://github.com/notaryproject/notation/pull/1017
* bump: bump up for v1.2.0 stable release by @Two-Hearts in https://github.com/notaryproject/notation/pull/1021

**Full Changelog**: https://github.com/notaryproject/notation/compare/v1.2.0-rc.1...4700ad6f1bef13e411772d7ae4399f891fc3a6ae

## Actions
Please review the PR and vote by approving.