### PR TITLE
bump: release v1.2.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ package version
 
 var (
 	// Version shows the current notation version, optionally with pre-release.
-	Version = "v1.2.0"
+	Version = "v1.2.1"
 
 	// BuildMetadata stores the build metadata.
 	//


### PR DESCRIPTION
## Release

This would mean tagging 471a24b4b1f331a84554a4065ca449f9a60919cf as `v1.2.1` to release.

## Vote

We need at least `4` approvals from `6` maintainers to release `notation v1.2.1`.

- [ ] Pritesh Bandi (@priteshbandi)
- [ ] Junjie Gao (@JeyJeyGao)
- [ ] Rakesh Gariganti (@rgnote)
- [ ] Milind Gokarn (@gokarnm)
- [ ] Shiwei Zhang (@shizhMSFT)
- [x] Patrick Zheng (@Two-Hearts)


## What's Changed
* [Merge pull request](https://github.com/notaryproject/notation/commit/e4500024e73c7e033edb15793fbd7dd8b45d6587) https://github.com/notaryproject/notation/pull/1022 [from Two-Hearts/release-1.2](https://github.com/notaryproject/notation/commit/e4500024e73c7e033edb15793fbd7dd8b45d6587)
* [bump: bump up dependencies](https://github.com/notaryproject/notation/commit/e7c70819d0e6193b366e7bc0586b6a0afef48a7d)

**Full Changelog**: https://github.com/notaryproject/notation/compare/v1.2.0...471a24b4b1f331a84554a4065ca449f9a60919cf

## Actions
Please review the PR and vote by approving.