### PR TITLE
bump: release v1.3.0-rc.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ package version
 
 var (
 	// Version shows the current notation version, optionally with pre-release.
-	Version = "v1.2.0"
+	Version = "v1.3.0-rc.1"
 
 	// BuildMetadata stores the build metadata.
 	//


### PR DESCRIPTION
## Release

This would mean tagging 0d9ceacde56c4b61dbbd7d83a7875986195781f8 as `v1.3.0-rc.1` to release.

## Vote

We need at least `4` approvals from `6` maintainers to release `v1.3.0-rc.1`.

- [x] Pritesh Bandi (@priteshbandi)
- [x] Junjie Gao (@JeyJeyGao)
- [ ] Rakesh Gariganti (@rgnote)
- [ ] Milind Gokarn (@gokarnm)
- [x] Shiwei Zhang (@shizhMSFT)
- [x] Patrick Zheng (@Two-Hearts)


## What's Changed
* build(deps): Bump golang.org/x/net from 0.27.0 to 0.28.0 by @dependabot in https://github.com/notaryproject/notation/pull/1007
* build(deps): Bump actions/upload-artifact from 4.3.4 to 4.3.6 by @dependabot in https://github.com/notaryproject/notation/pull/1009
* build(deps): Bump github/codeql-action from 3.25.15 to 3.26.0 by @dependabot in https://github.com/notaryproject/notation/pull/1010
* bump: upgrade golang version to v1.23 by @Two-Hearts in https://github.com/notaryproject/notation/pull/1019
* build(deps): Bump actions/upload-artifact from 4.3.6 to 4.4.0 by @dependabot in https://github.com/notaryproject/notation/pull/1025
* build(deps): Bump github/codeql-action from 3.26.0 to 3.26.6 by @dependabot in https://github.com/notaryproject/notation/pull/1026
* build(deps): Bump github.com/notaryproject/notation-core-go from 1.1.0-rc.1 to 1.1.0 by @dependabot in https://github.com/notaryproject/notation/pull/1024
* chore: updated dependabot.yml to cover test/e2e by @Two-Hearts in https://github.com/notaryproject/notation/pull/1030
* build(deps): Bump golang.org/x/term from 0.23.0 to 0.24.0 by @dependabot in https://github.com/notaryproject/notation/pull/1033
* build(deps): Bump github.com/onsi/ginkgo/v2 from 2.11.0 to 2.20.2 in /test/e2e by @dependabot in https://github.com/notaryproject/notation/pull/1036
* build(deps): Bump github/codeql-action from 3.26.6 to 3.26.8 by @dependabot in https://github.com/notaryproject/notation/pull/1044
* build(deps): Bump oras.land/oras-go/v2 from 2.4.0 to 2.5.0 in /test/e2e by @dependabot in https://github.com/notaryproject/notation/pull/1035
* build(deps): Bump github.com/notaryproject/notation-core-go from 1.1.0-rc.1 to 1.1.0 in /test/e2e/plugin by @dependabot in https://github.com/notaryproject/notation/pull/1038
* build(deps): Bump golang.org/x/net from 0.28.0 to 0.29.0 by @dependabot in https://github.com/notaryproject/notation/pull/1034
* build(deps): Bump github.com/notaryproject/notation-core-go from 1.1.0-rc.1 to 1.1.0 in /test/e2e by @dependabot in https://github.com/notaryproject/notation/pull/1037
* feat: crl with file cache by @Two-Hearts in https://github.com/notaryproject/notation/pull/1043
* refactor!: remove blob sign/verify for v1.3.0-rc.1 release by @Two-Hearts in https://github.com/notaryproject/notation/pull/1045

**Full Changelog**: https://github.com/notaryproject/notation/compare/v1.2.0...0d9ceacde56c4b61dbbd7d83a7875986195781f8

## Actions
Please review the PR and vote by approving.