### PR TITLE
bump: release v1.1.2

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ package version
 
 var (
 	// Version shows the current notation version, optionally with pre-release.
-	Version = "v1.1.1"
+	Version = "v1.1.2"
 
 	// BuildMetadata stores the build metadata.
 	//


### PR DESCRIPTION
## Release

This would mean tagging d055873720b1a21aa627ee56edc548e0d104002a as `v1.1.2` to release.

This release removed the blob signing docs and fixed the `signingAgent` value to be `notation-go/1.1.2`

## Vote

We need at least `4` approvals from `6` maintainers to release `v1.1.2`.

- [x] Pritesh Bandi (@priteshbandi)
- [x] Junjie Gao (@JeyJeyGao)
- [ ] Rakesh Gariganti (@rgnote)
- [ ] Milind Gokarn (@gokarnm)
- [x] Shiwei Zhang (@shizhMSFT)
- [x] Patrick Zheng (@Two-Hearts)


## What's Changed
* bump: bump up and vote notation v1.1.1 by @JeyJeyGao in https://github.com/notaryproject/notation/pull/963
* fix(docs): remove blob signing docs for `release-1.1` branch by @JeyJeyGao in https://github.com/notaryproject/notation/pull/1013
* bump: update notation-go v1.1.2 by @JeyJeyGao in https://github.com/notaryproject/notation/pull/1041
* bump: dependencies for release-1.1 branch by @JeyJeyGao in https://github.com/notaryproject/notation/pull/1057


**Full Changelog**: https://github.com/notaryproject/notation/compare/v1.1.1...d055873720b1a21aa627ee56edc548e0d104002a