### PR TITLE
fix: fix debug log

### DIFF
--- a/internal/trace/context.go
+++ b/internal/trace/context.go
@@ -48,6 +48,7 @@ func WithLoggerLevel(ctx context.Context, level logrus.Level) context.Context {
 
 	// create logger
 	logger := logrus.New()
+	formatter.DisableQuote = true
 	logger.SetFormatter(&formatter)
 	logger.SetLevel(level)
 

--- a/internal/trace/transport.go
+++ b/internal/trace/transport.go
@@ -58,7 +58,7 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 	var logs strings.Builder
 	fmt.Fprintf(&logs, "> Request: %q %q\n", req.Method, req.URL)
 	fmt.Fprintln(&logs, "> Request headers:")
-	fmt.Fprintln(&logs, logHeader(req.Header))
+	fmt.Fprint(&logs, logHeader(req.Header))
 
 	resp, err = t.RoundTripper.RoundTrip(req)
 	if err != nil {
@@ -70,7 +70,7 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 	} else {
 		fmt.Fprintf(&logs, "< Response status: %q\n", resp.Status)
 		fmt.Fprintln(&logs, "< Response headers:")
-		fmt.Fprintln(&logs, logHeader(resp.Header))
+		fmt.Fprint(&logs, logHeader(resp.Header))
 		e.Debug(logs.String())
 	}
 	return resp, err

--- a/internal/trace/transport.go
+++ b/internal/trace/transport.go
@@ -55,22 +55,23 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 	e := log.GetLogger(ctx)
 
 	// logs to be printed out
-	logs := fmt.Sprintf("> Request: %q %q\n", req.Method, req.URL)
-	logs = logs + "> Request headers:\n"
-	logs = logs + logHeader(req.Header)
+	var logs strings.Builder
+	fmt.Fprintf(&logs, "> Request: %q %q\n", req.Method, req.URL)
+	fmt.Fprintln(&logs, "> Request headers:")
+	fmt.Fprintln(&logs, logHeader(req.Header))
 
 	resp, err = t.RoundTripper.RoundTrip(req)
 	if err != nil {
-		e.Debugf(logs)
+		e.Debug(logs.String())
 		e.Errorf("Error in getting response: %w", err)
 	} else if resp == nil {
-		e.Debugf(logs)
+		e.Debug(logs.String())
 		e.Errorf("No response obtained for request %s %q", req.Method, req.URL)
 	} else {
-		logs = logs + fmt.Sprintf("< Response status: %q\n", resp.Status)
-		logs = logs + "< Response headers:\n"
-		logs = logs + logHeader(resp.Header)
-		e.Debugf(logs)
+		fmt.Fprintf(&logs, "< Response status: %q\n", resp.Status)
+		fmt.Fprintln(&logs, "< Response headers:")
+		fmt.Fprintln(&logs, logHeader(resp.Header))
+		e.Debug(logs.String())
 	}
 	return resp, err
 }
@@ -79,14 +80,14 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 // scrubbed.
 func logHeader(header http.Header) string {
 	if len(header) > 0 {
-		var logs string
+		var logs strings.Builder
 		for k, v := range header {
 			if strings.EqualFold(k, "Authorization") {
 				v = []string{"*****"}
 			}
-			logs = logs + fmt.Sprintf("   %q: %q\n", k, strings.Join(v, ", "))
+			fmt.Fprintf(&logs, "   %q: %q\n", k, strings.Join(v, ", "))
 		}
-		return logs
+		return logs.String()
 	} else {
 		return "   Empty header"
 	}

--- a/internal/trace/transport.go
+++ b/internal/trace/transport.go
@@ -89,7 +89,7 @@ func logHeader(header http.Header) string {
 		}
 		return logs.String()
 	} else {
-		return "   Empty header"
+		return "   Empty header\n"
 	}
 }
 

--- a/internal/trace/transport.go
+++ b/internal/trace/transport.go
@@ -79,7 +79,7 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 	} else if resp == nil {
 		e.Errorf("No response obtained for request %s %q", req.Method, req.URL)
 	} else {
-		e.Debugf("Response #%d\n< Response Status: %q\n< Response headers:\n%s",
+		e.Debugf("Response #%d\n< Response status: %q\n< Response headers:\n%s",
 			id, resp.Status, logHeader(resp.Header))
 	}
 	return resp, err

--- a/internal/trace/transport.go
+++ b/internal/trace/transport.go
@@ -58,7 +58,7 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 	var logs strings.Builder
 	fmt.Fprintf(&logs, "> Request: %q %q\n", req.Method, req.URL)
 	fmt.Fprintln(&logs, "> Request headers:")
-	fmt.Fprint(&logs, logHeader(req.Header))
+	logHeader(req.Header, &logs)
 
 	resp, err = t.RoundTripper.RoundTrip(req)
 	if err != nil {
@@ -70,26 +70,27 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 	} else {
 		fmt.Fprintf(&logs, "< Response status: %q\n", resp.Status)
 		fmt.Fprintln(&logs, "< Response headers:")
-		fmt.Fprint(&logs, logHeader(resp.Header))
+		logHeader(resp.Header, &logs)
 		e.Debug(logs.String())
 	}
 	return resp, err
 }
 
-// logHeader returns string of provided header keys and values, with auth header
+// logHeader logs the provided header keys and values, with auth header
 // scrubbed.
-func logHeader(header http.Header) string {
+func logHeader(header http.Header, logs *strings.Builder) {
+	if logs == nil {
+		return
+	}
 	if len(header) > 0 {
-		var logs strings.Builder
 		for k, v := range header {
 			if strings.EqualFold(k, "Authorization") {
 				v = []string{"*****"}
 			}
-			fmt.Fprintf(&logs, "   %q: %q\n", k, strings.Join(v, ", "))
+			fmt.Fprintf(logs, "   %q: %q\n", k, strings.Join(v, ", "))
 		}
-		return logs.String()
 	} else {
-		return "   Empty header\n"
+		fmt.Fprintln(logs, "   Empty header")
 	}
 }
 

--- a/internal/trace/transport_test.go
+++ b/internal/trace/transport_test.go
@@ -87,7 +87,3 @@ func TestTransport_RoundTrip(t *testing.T) {
 		}
 	})
 }
-
-func TestLogHeaderWithNilLogs(t *testing.T) {
-	logHeader(http.Header{}, nil)
-}

--- a/internal/trace/transport_test.go
+++ b/internal/trace/transport_test.go
@@ -87,3 +87,7 @@ func TestTransport_RoundTrip(t *testing.T) {
 		}
 	})
 }
+
+func TestLogHeaderWithNilLogs(t *testing.T) {
+	logHeader(http.Header{}, nil)
+}

--- a/test/e2e/suite/command/verify.go
+++ b/test/e2e/suite/command/verify.go
@@ -253,7 +253,7 @@ var _ = Describe("notation verify", func() {
 
 			notation.Exec("verify", artifact.ReferenceWithDigest(), "-v").
 				MatchKeyWords(VerifySuccessfully).
-				MatchErrKeyWords("Timestamp verification disabled: verifyTimestamp is set to \\\"afterCertExpiry\\\" and signing cert chain unexpired")
+				MatchErrKeyWords("Timestamp verification disabled: verifyTimestamp is set to \"afterCertExpiry\" and signing cert chain unexpired")
 		})
 	})
 })

--- a/test/e2e/suite/plugin/verify.go
+++ b/test/e2e/suite/plugin/verify.go
@@ -46,7 +46,7 @@ var _ = Describe("notation plugin verify", func() {
 				MatchErrKeyWords(
 					"Plugin verify-signature request",
 					"Plugin verify-signature response",
-					`{\"verificationResults\":{\"SIGNATURE_VERIFIER.REVOCATION_CHECK\":{\"success\":true},\"SIGNATURE_VERIFIER.TRUSTED_IDENTITY\":{\"success\":true}},\"processedAttributes\":null}`).
+					`{"verificationResults":{"SIGNATURE_VERIFIER.REVOCATION_CHECK":{"success":true},"SIGNATURE_VERIFIER.TRUSTED_IDENTITY":{"success":true}},"processedAttributes":null}`).
 				MatchKeyWords(VerifySuccessfully)
 		})
 	})
@@ -77,7 +77,7 @@ var _ = Describe("notation plugin verify", func() {
 				MatchErrKeyWords(
 					"Plugin verify-signature request",
 					"Plugin verify-signature response",
-					`revocation check by verification plugin \"e2e-plugin\" failed with reason \"revocation check failed\"`,
+					`revocation check by verification plugin "e2e-plugin" failed with reason "revocation check failed"`,
 					VerifyFailed)
 		})
 	})
@@ -108,7 +108,7 @@ var _ = Describe("notation plugin verify", func() {
 				MatchErrKeyWords(
 					"Plugin verify-signature request",
 					"Plugin verify-signature response",
-					`trusted identify verification by plugin \"e2e-plugin\" failed with reason \"trusted identity check failed\"`,
+					`trusted identify verification by plugin "e2e-plugin" failed with reason "trusted identity check failed"`,
 					VerifyFailed)
 		})
 	})
@@ -138,7 +138,7 @@ var _ = Describe("notation plugin verify", func() {
 				MatchErrKeyWords(
 					"Plugin verify-signature request",
 					"Plugin verify-signature response",
-					`{\"verificationResults\":{\"SIGNATURE_VERIFIER.REVOCATION_CHECK\":{\"success\":true},\"SIGNATURE_VERIFIER.TRUSTED_IDENTITY\":{\"success\":true}},\"processedAttributes\":null}`).
+					`{"verificationResults":{"SIGNATURE_VERIFIER.REVOCATION_CHECK":{"success":true},"SIGNATURE_VERIFIER.TRUSTED_IDENTITY":{"success":true}},"processedAttributes":null}`).
 				MatchKeyWords(VerifySuccessfully)
 		})
 	})
@@ -197,7 +197,7 @@ var _ = Describe("notation plugin verify", func() {
 				MatchErrKeyWords(
 					"Plugin verify-signature request",
 					"Plugin verify-signature response",
-					`{\"verificationResults\":{\"SIGNATURE_VERIFIER.REVOCATION_CHECK\":{\"success\":true},\"SIGNATURE_VERIFIER.TRUSTED_IDENTITY\":{\"success\":true}},\"processedAttributes\":null}`).
+					`{"verificationResults":{"SIGNATURE_VERIFIER.REVOCATION_CHECK":{"success":true},"SIGNATURE_VERIFIER.TRUSTED_IDENTITY":{"success":true}},"processedAttributes":null}`).
 				MatchKeyWords(VerifySuccessfully)
 		})
 	})


### PR DESCRIPTION
Currently the debug log has issues under multi-thread scenarios. This may cause a request log being followed by a response log of another request, which is confusing for log readers.

This PR fixes the issue by labeling the request and response pairs.

This PR does not change any log content. It only makes the log more readable.