### PR TITLE
feat: crl cache with log

### DIFF
--- a/cmd/notation/verify.go
+++ b/cmd/notation/verify.go
@@ -39,6 +39,7 @@ import (
 	"github.com/spf13/cobra"
 
 	corecrl "github.com/notaryproject/notation-core-go/revocation/crl"
+	internalcrl "github.com/notaryproject/notation/internal/crl"
 )
 
 type verifyOpts struct {
@@ -242,9 +243,12 @@ func getVerifier(ctx context.Context) (notation.Verifier, error) {
 	if err != nil {
 		return nil, err
 	}
-	crlFetcher.Cache, err = crl.NewFileCache(cacheRoot)
+	fileCache, err := crl.NewFileCache(cacheRoot)
 	if err != nil {
 		return nil, err
+	}
+	crlFetcher.Cache = &internalcrl.CrlCacheWithLog{
+		Cache: fileCache,
 	}
 	crlFetcher.DiscardCacheError = true // discard cache error
 	revocationCodeSigningValidator, err := revocation.NewWithOptions(revocation.Options{

--- a/cmd/notation/verify.go
+++ b/cmd/notation/verify.go
@@ -39,7 +39,7 @@ import (
 	"github.com/spf13/cobra"
 
 	corecrl "github.com/notaryproject/notation-core-go/revocation/crl"
-	internalcrl "github.com/notaryproject/notation/internal/crl"
+	clicrl "github.com/notaryproject/notation/internal/crl"
 )
 
 type verifyOpts struct {
@@ -239,6 +239,7 @@ func getVerifier(ctx context.Context) (notation.Verifier, error) {
 	if err != nil {
 		return nil, err
 	}
+	crlFetcher.DiscardCacheError = true // discard crl cache error
 	cacheRoot, err := dir.CacheFS().SysPath(dir.PathCRLCache)
 	if err != nil {
 		return nil, err
@@ -247,10 +248,10 @@ func getVerifier(ctx context.Context) (notation.Verifier, error) {
 	if err != nil {
 		return nil, err
 	}
-	crlFetcher.Cache = &internalcrl.CrlCacheWithLog{
-		Cache: fileCache,
+	crlFetcher.Cache = &clicrl.CrlCacheWithLog{
+		Cache:             fileCache,
+		DiscardCacheError: crlFetcher.DiscardCacheError,
 	}
-	crlFetcher.DiscardCacheError = true // discard cache error
 	revocationCodeSigningValidator, err := revocation.NewWithOptions(revocation.Options{
 		OCSPHTTPClient:   ocspHttpClient,
 		CRLFetcher:       crlFetcher,

--- a/internal/crl/crl.go
+++ b/internal/crl/crl.go
@@ -1,0 +1,64 @@
+// Copyright The Notary Project Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crl
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+
+	corecrl "github.com/notaryproject/notation-core-go/revocation/crl"
+	"github.com/notaryproject/notation-go/log"
+)
+
+// CrlCacheWithLog implements corecrl.Cache with logging
+type CrlCacheWithLog struct {
+	corecrl.Cache
+
+	// logDiscardCrlCacheErrorOnce guarantees the discard crl cache error
+	// warning is logged only once
+	logDiscardCrlCacheErrorOnce sync.Once
+}
+
+// Get retrieves the CRL bundle with the given url
+func (c *CrlCacheWithLog) Get(ctx context.Context, url string) (*corecrl.Bundle, error) {
+	logger := log.GetLogger(ctx)
+
+	bundle, err := c.Cache.Get(ctx, url)
+	if err != nil && !errors.Is(err, corecrl.ErrCacheMiss) {
+		c.logDiscardCrlCacheErrorOnce.Do(c.logDiscardCrlCacheError)
+		logger.Debug(err.Error())
+	}
+	return bundle, err
+}
+
+// Set stores the CRL bundle with the given url
+func (c *CrlCacheWithLog) Set(ctx context.Context, url string, bundle *corecrl.Bundle) error {
+	logger := log.GetLogger(ctx)
+
+	err := c.Cache.Set(ctx, url, bundle)
+	if err != nil {
+		c.logDiscardCrlCacheErrorOnce.Do(c.logDiscardCrlCacheError)
+		logger.Debug(err.Error())
+	}
+	return err
+}
+
+// logDiscardCrlCacheError logs the warning when CRL cache error is
+// discarded
+func (c *CrlCacheWithLog) logDiscardCrlCacheError() {
+	fmt.Fprintln(os.Stderr, "Warning: CRL cache error discarded")
+}

--- a/internal/crl/crl_test.go
+++ b/internal/crl/crl_test.go
@@ -57,7 +57,8 @@ func TestSet(t *testing.T) {
 
 func TestLogDiscardErrorOnce(t *testing.T) {
 	cache := &CrlCacheWithLog{
-		Cache: &dummyCache{},
+		Cache:             &dummyCache{},
+		DiscardCacheError: true,
 	}
 	oldStderr := os.Stderr
 	defer func() {
@@ -75,6 +76,7 @@ func TestLogDiscardErrorOnce(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			cache.Get(context.Background(), "")
+			cache.Set(context.Background(), "", nil)
 		}()
 	}
 	wg.Wait()

--- a/internal/crl/crl_test.go
+++ b/internal/crl/crl_test.go
@@ -1,0 +1,105 @@
+// Copyright The Notary Project Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crl
+
+import (
+	"context"
+	"errors"
+	"os"
+	"sync"
+	"testing"
+
+	corecrl "github.com/notaryproject/notation-core-go/revocation/crl"
+)
+
+func TestGet(t *testing.T) {
+	cache := &CrlCacheWithLog{
+		Cache: &dummyCache{},
+	}
+	expectedErrMsg := "cache get failed"
+	_, err := cache.Get(context.Background(), "")
+	if err == nil || err.Error() != expectedErrMsg {
+		t.Fatalf("expected error %q, but got %q", expectedErrMsg, err)
+	}
+
+	cache = &CrlCacheWithLog{
+		Cache: &dummyCache{
+			cacheMiss: true,
+		},
+	}
+	_, err = cache.Get(context.Background(), "")
+	if err == nil || !errors.Is(err, corecrl.ErrCacheMiss) {
+		t.Fatalf("expected error %q, but got %q", corecrl.ErrCacheMiss, err)
+	}
+}
+
+func TestSet(t *testing.T) {
+	cache := &CrlCacheWithLog{
+		Cache: &dummyCache{},
+	}
+	expectedErrMsg := "cache set failed"
+	err := cache.Set(context.Background(), "", nil)
+	if err == nil || err.Error() != expectedErrMsg {
+		t.Fatalf("expected error %q, but got %q", expectedErrMsg, err)
+	}
+}
+
+func TestLogDiscardErrorOnce(t *testing.T) {
+	cache := &CrlCacheWithLog{
+		Cache: &dummyCache{},
+	}
+	oldStderr := os.Stderr
+	defer func() {
+		os.Stderr = oldStderr
+	}()
+	testFile, err := os.CreateTemp(t.TempDir(), "testNotation")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer testFile.Close()
+	os.Stderr = testFile
+	var wg sync.WaitGroup
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cache.Get(context.Background(), "")
+		}()
+	}
+	wg.Wait()
+
+	b, err := os.ReadFile(testFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedMsg := "Warning: CRL cache error discarded\n"
+	if string(b) != expectedMsg {
+		t.Fatalf("expected to get %q, but got %q", expectedMsg, string(b))
+	}
+}
+
+type dummyCache struct {
+	cacheMiss bool
+}
+
+func (d *dummyCache) Get(ctx context.Context, url string) (*corecrl.Bundle, error) {
+	if d.cacheMiss {
+		return nil, corecrl.ErrCacheMiss
+	}
+	return nil, errors.New("cache get failed")
+}
+
+func (d *dummyCache) Set(ctx context.Context, url string, bundle *corecrl.Bundle) error {
+	return errors.New("cache set failed")
+}


### PR DESCRIPTION
This PR adds a wrapper of [FileCache](https://github.com/notaryproject/notation-go/blob/f855f2552698173168413cfb0e4c746a3dffb0a9/verifier/crl/crl.go#L52) to log any cache errors during revocation check. It also prints out a one-time warning if the cache error is set to be discarded, which is true for Notation CLI.