### PR TITLE
bump: release v1.3.0-rc.2

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ package version
 
 var (
 	// Version shows the current notation version, optionally with pre-release.
-	Version = "v1.3.0-rc.1"
+	Version = "v1.3.0-rc.2"
 
 	// BuildMetadata stores the build metadata.
 	//


### PR DESCRIPTION
## Release

This would mean tagging 260968a379b1a3759d8881636595a997780b6e29 as `v1.3.0-rc.2` to release.

## Vote

We need at least `4` approvals from `6` maintainers to release `v1.3.0-rc.2`.

- [x] Pritesh Bandi (@priteshbandi)
- [x] Junjie Gao (@JeyJeyGao)
- [ ] Rakesh Gariganti (@rgnote)
- [ ] Milind Gokarn (@gokarnm)
- [x] Shiwei Zhang (@shizhMSFT)
- [x] Patrick Zheng (@Two-Hearts)

## What's Changed
* bump: release v1.3.0-rc.1 by @Two-Hearts in https://github.com/notaryproject/notation/pull/1056
* fix: cherry pick minor fixes from `main` to `release-1.3` by @Two-Hearts in https://github.com/notaryproject/notation/pull/1110
* bump: bump up dependencies for release-1.3 branch by @Two-Hearts in https://github.com/notaryproject/notation/pull/1109
* backport: CRL cache with log and E2E tests from `main` to `release-1.3` by @Two-Hearts in https://github.com/notaryproject/notation/pull/1117
* fix: fix context and bump up golang.org/x/net for `release-1.3` branch by @Two-Hearts in https://github.com/notaryproject/notation/pull/1120
* backport: timestamping cert chain revocation check during signing from `main` to `release-1.3` branch by @Two-Hearts in https://github.com/notaryproject/notation/pull/1121

**Full Changelog**: https://github.com/notaryproject/notation/compare/v1.3.0-rc.1...260968a379b1a3759d8881636595a997780b6e29

## Actions
Please review the PR and vote by approving.