### PR TITLE
ci: update runner version to ubuntu-24.04

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: write  # for goreleaser/goreleaser-action to create a GitHub release
     name: Release Notation Binaries
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         go-version: ['1.23']


### PR DESCRIPTION
CI:
- Updated the runner version to `ubuntu-24.04` for release pipeline as `ubuntu-20.04` is reaching the end of life on 2025-05-29.

Test:
- `goreleaser` works well in forked repo

Reference: https://en.wikipedia.org/wiki/Ubuntu_version_history#2004
Resolves #1139 