### PR TITLE
bump: release v1.3.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ package version
 
 var (
 	// Version shows the current notation version, optionally with pre-release.
-	Version = "v1.3.0-rc.2"
+	Version = "v1.3.0"
 
 	// BuildMetadata stores the build metadata.
 	//


### PR DESCRIPTION
## Release

This would mean tagging 8e5b5d59f5f5b45db20277614d5cfd73d4845c3a as `v1.3.0` to release.

## Vote

We need at least `4` approvals from `6` maintainers to release `v1.3.0`.

- [ ] Pritesh Bandi (@priteshbandi)
- [ ] Junjie Gao (@JeyJeyGao)
- [ ] Milind Gokarn (@gokarnm)
- [ ] Vani Rao (@vaninrao10)
- [ ] Shiwei Zhang (@shizhMSFT)
- [ ] Patrick Zheng (@Two-Hearts)

## What's Changed
* bump: release v1.3.0-rc.2 by @Two-Hearts in https://github.com/notaryproject/notation/pull/1130
* cherry-pick: cherry pick from main to release-1.3 branch by @Two-Hearts in https://github.com/notaryproject/notation/pull/1147
* bump: bump up dependencies and workflows by @Two-Hearts in https://github.com/notaryproject/notation/pull/1148

**Full Changelog**: https://github.com/notaryproject/notation/compare/v1.3.0-rc.2...8e5b5d59f5f5b45db20277614d5cfd73d4845c3a

## Actions
Please review the PR and vote by approving.