### PR TITLE
bump: update go v1.24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.23']
+        go-version: ['1.24']
       fail-fast: true
     steps:
       - name: Set up Go ${{ matrix.go-version }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
       security-events: write
     strategy:
       matrix:
-        go-version: ['1.23']
+        go-version: ['1.24']
       fail-fast: false
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        go-version: ['1.23']
+        go-version: ['1.24']
       fail-fast: true
     steps:
       - name: Set up Go ${{ matrix.go-version }}

--- a/building.md
+++ b/building.md
@@ -4,7 +4,7 @@ The notation repo contains the following:
 
 - `notation` - A CLI for signing and verifying artifacts with Notation
 
-Building above binaries require [golang](https://golang.org/dl/) with version `>= 1.23`.
+Building above binaries require [golang](https://golang.org/dl/) with version `>= 1.24`.
 
 ## Windows with WSL or Linux
 

--- a/cmd/notation/internal/display/metadata/tree/tree_test.go
+++ b/cmd/notation/internal/display/metadata/tree/tree_test.go
@@ -48,7 +48,8 @@ func TestNodeAddPair(t *testing.T) {
 	}
 }
 
-func ExampleRootPrint() {
+// example for Print emthod of node type
+func Examplenode_Print() {
 	root := newNode("root")
 	root.Print(os.Stdout)
 
@@ -56,7 +57,7 @@ func ExampleRootPrint() {
 	// root
 }
 
-func ExampleSingleLayerPrint() {
+func Examplenode_Print_singleLayer() {
 	root := newNode("root")
 	root.Add("child1")
 	root.Add("child2")
@@ -68,7 +69,7 @@ func ExampleSingleLayerPrint() {
 	// └── child2
 }
 
-func ExampleMultiLayerPrint() {
+func Examplenode_Print_multiLayer() {
 	root := newNode("root")
 	child1 := root.Add("child1")
 	child1.AddPair("key", "value")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/notaryproject/notation
 
-go 1.23
+go 1.24.0
 
 require (
 	github.com/notaryproject/notation-core-go v1.2.0

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/notaryproject/notation/test/e2e
 
-go 1.23
+go 1.24.0
 
 require (
 	github.com/notaryproject/notation-core-go v1.2.0

--- a/test/e2e/plugin/go.mod
+++ b/test/e2e/plugin/go.mod
@@ -1,6 +1,6 @@
 module github.com/notaryproject/notation/test/e2e/plugin
 
-go 1.23
+go 1.24.0
 
 require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible


### PR DESCRIPTION
Fix:
- fixed the [testable example](https://go.dev/blog/examples) function name, which is enforced by go v1.24

Bump:
- updated go 1.24