### PR TITLE
fix: update the output format `text` to `tree`

### DIFF
--- a/cmd/notation/blob/inspect.go
+++ b/cmd/notation/blob/inspect.go
@@ -58,7 +58,7 @@ Example - Inspect a signature and output as JSON:
 		},
 	}
 
-	opts.Format.ApplyFlags(command.Flags(), option.FormatTypeText, option.FormatTypeJSON)
+	opts.Format.ApplyFlags(command.Flags(), option.FormatTypeTree, option.FormatTypeJSON)
 	return command
 }
 

--- a/cmd/notation/inspect.go
+++ b/cmd/notation/inspect.go
@@ -88,7 +88,7 @@ Example - Inspect signatures on an OCI artifact identified by a digest and outpu
 	cmd.SetPflagReferrersAPI(command.Flags(), &opts.allowReferrersAPI, fmt.Sprintf(cmd.PflagReferrersUsageFormat, "inspect"))
 
 	// set output format
-	opts.Format.ApplyFlags(command.Flags(), option.FormatTypeText, option.FormatTypeJSON)
+	opts.Format.ApplyFlags(command.Flags(), option.FormatTypeTree, option.FormatTypeJSON)
 	return command
 }
 

--- a/cmd/notation/inspect_test.go
+++ b/cmd/notation/inspect_test.go
@@ -25,8 +25,8 @@ func TestInspectCommand_SecretsFromArgs(t *testing.T) {
 	opts := &inspectOpts{}
 	command := inspectCommand(opts)
 	format := option.Format{}
-	format.ApplyFlags(&pflag.FlagSet{}, option.FormatTypeText, option.FormatTypeJSON)
-	format.CurrentType = string(option.FormatTypeText)
+	format.ApplyFlags(&pflag.FlagSet{}, option.FormatTypeTree, option.FormatTypeJSON)
+	format.CurrentType = string(option.FormatTypeTree)
 	expected := &inspectOpts{
 		reference: "ref",
 		SecureFlagOpts: SecureFlagOpts{
@@ -58,7 +58,7 @@ func TestInspectCommand_SecretsFromEnv(t *testing.T) {
 	t.Setenv(defaultPasswordEnv, "password")
 
 	format := option.Format{}
-	format.ApplyFlags(&pflag.FlagSet{}, option.FormatTypeText, option.FormatTypeJSON)
+	format.ApplyFlags(&pflag.FlagSet{}, option.FormatTypeTree, option.FormatTypeJSON)
 	format.CurrentType = string(option.FormatTypeJSON)
 	expected := &inspectOpts{
 		reference: "ref",

--- a/cmd/notation/inspect_test.go
+++ b/cmd/notation/inspect_test.go
@@ -42,7 +42,7 @@ func TestInspectCommand_SecretsFromArgs(t *testing.T) {
 		expected.reference,
 		"-u", expected.Username,
 		"--insecure-registry",
-		"--output", "text"}); err != nil {
+		"--output", "tree"}); err != nil {
 		t.Fatalf("Parse Flag failed: %v", err)
 	}
 	if err := command.Args(command, command.Flags().Args()); err != nil {

--- a/cmd/notation/internal/display/handler.go
+++ b/cmd/notation/internal/display/handler.go
@@ -36,7 +36,7 @@ func NewInspectHandler(printer *output.Printer, format option.Format) (metadata.
 	switch option.FormatType(format.CurrentType) {
 	case option.FormatTypeJSON:
 		return json.NewInspectHandler(printer), nil
-	case option.FormatTypeText:
+	case option.FormatTypeTree:
 		return tree.NewInspectHandler(printer), nil
 	}
 	return nil, fmt.Errorf("unrecognized output format %s", format.CurrentType)
@@ -48,7 +48,7 @@ func NewBlobInspectHandler(printer *output.Printer, format option.Format) (metad
 	switch option.FormatType(format.CurrentType) {
 	case option.FormatTypeJSON:
 		return json.NewBlobInspectHandler(printer), nil
-	case option.FormatTypeText:
+	case option.FormatTypeTree:
 		return tree.NewBlobInspectHandler(printer), nil
 	}
 	return nil, fmt.Errorf("unrecognized output format %s", format.CurrentType)

--- a/cmd/notation/internal/option/format.go
+++ b/cmd/notation/internal/option/format.go
@@ -46,6 +46,8 @@ var (
 	FormatTypeJSON FormatType = "json"
 	// FormatTypeText is the text format type for human-readable output.
 	FormatTypeText FormatType = "text"
+	// FormatTypeTree is the tree format type for human-readable output.
+	FormatTypeTree FormatType = "tree"
 )
 
 // Format contains input and parsed options for formatted output flags.

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -24,11 +24,6 @@ import (
 	"github.com/spf13/pflag"
 )
 
-const (
-	OutputPlaintext = "text"
-	OutputJSON      = "json"
-)
-
 var (
 	PflagKey = &pflag.Flag{
 		Name:      "key",

--- a/specs/commandline/blob.md
+++ b/specs/commandline/blob.md
@@ -104,7 +104,7 @@ Usage:
   notation blob inspect [flags] <signature_path>
 
 Flags:
-  -o, --output string         output format, options: 'json', 'text' (default "text")
+  -o, --output string         output format, options: 'json', 'tree' (default "tree")
   -d, --debug                 debug mode
   -v, --verbose               verbose mode
   -h, --help                  help for inspect

--- a/specs/commandline/inspect.md
+++ b/specs/commandline/inspect.md
@@ -42,7 +42,7 @@ Flags:
   -h, --help                  help for inspect
       --insecure-registry     use HTTP protocol while connecting to registries. Should be used only for testing
       --max-signatures int    maximum number of signatures to evaluate or examine (default 100)
-  -o, --output string         output format, options: 'json', 'text' (default "text")
+  -o, --output string         output format, options: 'json', 'tree' (default "tree")
   -p, --password string       password for registry operations (default to $NOTATION_PASSWORD if not specified)
   -u, --username string       username for registry operations (default to $NOTATION_USERNAME if not specified)
   -v, --verbose               verbose mode

--- a/test/e2e/suite/command/blob/inspect.go
+++ b/test/e2e/suite/command/blob/inspect.go
@@ -116,7 +116,7 @@ var _ = Describe("notation blob inspect", func() {
     ├── digest: sha256:c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
     └── size: 11357
 `
-			notation.Exec("blob", "inspect", jwsBlobSigPath).
+			notation.Exec("blob", "inspect", "--output", "tree", jwsBlobSigPath).
 				MatchContent(expectedContent)
 		})
 	})

--- a/test/e2e/suite/command/inspect.go
+++ b/test/e2e/suite/command/inspect.go
@@ -215,7 +215,7 @@ localhost:5000/e2e-insepct-timestamped@sha256:53b0191218aed9a3c1f7c661736ac40cfc
             └── size: 582
 `
 
-			notation.Exec("inspect", artifact.ReferenceWithDigest()).
+			notation.Exec("inspect", "--output", "tree", artifact.ReferenceWithDigest()).
 				MatchContent(expectedOutput)
 		})
 	})


### PR DESCRIPTION
Update the output format `text` to `tree`.
```
-o, --output string        output format, options: 'json', 'tree' (default "tree")
```

Resolves #1170 