### PR TITLE
bump: release v1.3.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ package version
 
 var (
 	// Version shows the current notation version, optionally with pre-release.
-	Version = "v1.3.0"
+	Version = "v1.3.1"
 
 	// BuildMetadata stores the build metadata.
 	//


### PR DESCRIPTION
## Release

This would mean tagging as bb571ddfb04f9d175daf64520fd18e7bea8ecbdf `v1.3.1` to release.

## Vote

We need at least `4` approvals from `6` maintainers to release `v1.3.1`.

- [x] Junjie Gao (@JeyJeyGao)
- [ ] Rakesh Gariganti (@rgnote)
- [ ] Milind Gokarn (@gokarnm)
- [x] Vani Rao (@vaninrao10)
- [x] Shiwei Zhang (@shizhMSFT)
- [x] Patrick Zheng (@Two-Hearts)

## What's Changed
* bump: release v1.3.0 by @Two-Hearts in https://github.com/notaryproject/notation/pull/1149
* bump: bump up dependencies for release-1.3 branch by @Two-Hearts in https://github.com/notaryproject/notation/pull/1184

**Full Changelog**: https://github.com/notaryproject/notation/compare/v1.3.0...bb571ddfb04f9d175daf64520fd18e7bea8ecbdf

## Actions
Please review the PR and vote by approving.