### PR TITLE
fix: output in streaming fashion for `inspect` command in `tree` format

### DIFF
--- a/cmd/notation/internal/display/metadata/tree/inspect.go
+++ b/cmd/notation/internal/display/metadata/tree/inspect.go
@@ -76,9 +76,11 @@ func (h *InspectHandler) InspectSignature(manifestDesc, signatureDesc ocispec.De
 
 // Render renders the metadata information when an operation is complete.
 func (h *InspectHandler) Render() error {
+	if err := h.sprinter.Flush(); err != nil {
+		return err
+	}
 	if !h.headerPrinted {
 		return h.printer.Printf("%s has no associated signature\n", h.rootReferenceNode.Value)
 	}
-
-	return h.sprinter.Flush()
+	return nil
 }

--- a/cmd/notation/internal/display/metadata/tree/inspect.go
+++ b/cmd/notation/internal/display/metadata/tree/inspect.go
@@ -25,19 +25,24 @@ import (
 type InspectHandler struct {
 	printer *output.Printer
 
+	// sprinter is a stream printer to print the signature nodes in
+	// a streaming fashion
+	sprinter *streamPrinter
+
 	// rootReferenceNode is the root node with the artifact reference as the
 	// value.
 	rootReferenceNode *node
-	// notationSignaturesNode is the node for all signatures associated with the
-	// artifact.
-	notationSignaturesNode *node
+
+	// headerPrinted is a flag to indicate if the header has been printed
+	headerPrinted bool
 }
 
 // NewInspectHandler creates an InspectHandler to inspect signature and print in
 // tree format.
 func NewInspectHandler(printer *output.Printer) *InspectHandler {
 	return &InspectHandler{
-		printer: printer,
+		printer:  printer,
+		sprinter: newStreamPrinter(subTreePrefixLast, printer),
 	}
 }
 
@@ -47,24 +52,33 @@ func NewInspectHandler(printer *output.Printer) *InspectHandler {
 // mediaType is a no-op for this handler.
 func (h *InspectHandler) OnReferenceResolved(reference, _ string) {
 	h.rootReferenceNode = newNode(reference)
-	h.notationSignaturesNode = h.rootReferenceNode.Add(registry.ArtifactTypeNotation)
+	h.rootReferenceNode.Add(registry.ArtifactTypeNotation)
 }
 
 // InspectSignature inspects a signature to get it ready to be rendered.
 func (h *InspectHandler) InspectSignature(manifestDesc, signatureDesc ocispec.Descriptor, envelope coresignature.Envelope) error {
+	// print the header if it hasn't been printed yet
+	if !h.headerPrinted {
+		h.printer.Println("Inspecting all signatures for signed artifact")
+		if err := h.rootReferenceNode.Print(h.printer); err != nil {
+			return err
+		}
+		h.headerPrinted = true
+	}
+
 	sigNode, err := newSignatureNode(manifestDesc.Digest.String(), signatureDesc.MediaType, envelope)
 	if err != nil {
 		return err
 	}
-	h.notationSignaturesNode.Children = append(h.notationSignaturesNode.Children, sigNode)
-	return nil
+
+	return h.sprinter.PrintNode(sigNode)
 }
 
 // Render renders the metadata information when an operation is complete.
 func (h *InspectHandler) Render() error {
-	if len(h.notationSignaturesNode.Children) == 0 {
+	if !h.headerPrinted {
 		return h.printer.Printf("%s has no associated signature\n", h.rootReferenceNode.Value)
 	}
-	h.printer.Println("Inspecting all signatures for signed artifact")
-	return h.rootReferenceNode.Print(h.printer)
+
+	return h.sprinter.Flush()
 }

--- a/cmd/notation/internal/display/metadata/tree/inspect_test.go
+++ b/cmd/notation/internal/display/metadata/tree/inspect_test.go
@@ -1,0 +1,72 @@
+// Copyright The Notary Project Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tree
+
+import (
+	"errors"
+	"testing"
+
+	coresignature "github.com/notaryproject/notation-core-go/signature"
+	"github.com/notaryproject/notation/cmd/notation/internal/display/output"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// errorWriter is a mock io.Writer that always returns an error
+type errorWriter struct{}
+
+func (w *errorWriter) Write(p []byte) (n int, err error) {
+	return 0, errors.New("mocked write error")
+}
+
+func TestInspectHandler_InspectSignature_Print_Error(t *testing.T) {
+	// Create a printer with an error writer
+	errorPrinter := output.NewPrinter(&errorWriter{}, &errorWriter{})
+	handler := NewInspectHandler(errorPrinter)
+
+	// Set reference to initialize rootReferenceNode
+	handler.OnReferenceResolved("test-reference", "")
+
+	// Mock descriptor and envelope
+	manifestDesc := ocispec.Descriptor{
+		Digest: "sha256:test",
+	}
+	signatureDesc := ocispec.Descriptor{
+		MediaType: "test-media-type",
+	}
+	var envelope coresignature.Envelope
+
+	// Test InspectSignature - should fail at printing header
+	err := handler.InspectSignature(manifestDesc, signatureDesc, envelope)
+	if err == nil {
+		t.Fatal("Expected error when printing header, but got nil")
+	}
+}
+
+func TestInspectHandler_Render_Flush_Error(t *testing.T) {
+	// Create a printer with an error writer
+	errorPrinter := output.NewPrinter(&errorWriter{}, &errorWriter{})
+	handler := NewInspectHandler(errorPrinter)
+
+	// Add a signature to ensure sprinter has something to flush
+	handler.OnReferenceResolved("test-reference", "")
+	handler.headerPrinted = true // Simulate header already printed
+
+	handler.sprinter.prevNode = &node{} // Simulate a node to flush
+
+	// Test Render - should fail at flushing
+	err := handler.Render()
+	if err == nil {
+		t.Fatal("Expected error when flushing, but got nil")
+	}
+}


### PR DESCRIPTION
The `inspect` command can now output in streaming fashion in `tree` format. Previously, the `inspect` command in `tree` format could only output when all signatures were read, which was not user-friendly when there were many signatures, and users had to wait for a while for the output.