### PR TITLE
fix: goreleaser deprecated options

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -49,7 +49,7 @@ jobs:
         uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v6.2.1
         with:
           distribution: goreleaser
-          version: latest
+          version: v2
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+version: 2
 builds:
   - main: ./cmd/notation
     id: notation
@@ -37,10 +38,10 @@ builds:
     ldflags:
       - -s -w -X {{.ModulePath}}/internal/version.Version={{.Version}} -X {{.ModulePath}}/internal/version.GitCommit={{.FullCommit}} -X {{.ModulePath}}/internal/version.BuildMetadata=
 archives:
-  - format: tar.gz
+  - formats: [ 'tar.gz' ]
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [ 'zip' ]
     files:
       - LICENSE
 release:


### PR DESCRIPTION
Release pipeline with **warnings**: https://github.com/notaryproject/notation/actions/runs/13489436510/job/37685202798

Fix:
- locked goreleaser version to v2
- added configuration `version: 2`: https://goreleaser.com/errors/version/?h=configuration+version#unsupported-configuration-version
- updated deprecated 
   - `format` option: https://goreleaser.com/deprecations/#archivesformat
   - `overrides.format` option: https://goreleaser.com/deprecations/#archivesformat_overridesformat


Test:
- tested release pipeline in forked repo