### PR TITLE
bump: release v2.0.0-alpha.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ package version
 
 var (
 	// Version shows the current notation version, optionally with pre-release.
-	Version = "v1.2.0-beta.1"
+	Version = "v2.0.0-alpha.1"
 
 	// BuildMetadata stores the build metadata.
 	//


### PR DESCRIPTION
## Release

This would mean tagging 88a3273bf2e7bb7439c8937b35a88ece22af74c7 as `v2.0.0-alpha.1` to release.

## Release note
### New features:
1. Added new command: `notation blob` with subcommands `notation blob sign`, `notation blob verify`, `notation blob policy`, and `notation blob inspect`. It enables blob signing and verification with blob trust policy configuration.
2. Compliant with OCI-1.1 specs, namely [distribution-spec v1.1.1](https://github.com/opencontainers/distribution-spec/tree/v1.1.1) and [image-spec v1.1.1](https://github.com/opencontainers/image-spec/tree/v1.1.1). With the new update, `notation sign` command now stores signatures in the registry as a referrer of the target artifact by default, no extra image index will be created in this case. Removed the deprecated flag `--allow-referrers-api`.
3. Delta CRL support during CRL certificate revocation checks.

## Vote

We need at least `4` approvals from `6` maintainers to release `v2.0.0-alpha.1`.

- [x] Junjie Gao (@JeyJeyGao)
- [ ] Rakesh Gariganti (@rgnote)
- [ ] Milind Gokarn (@gokarnm)
- [ ] Vani Rao (@vaninrao10)
- [ ] Shiwei Zhang (@shizhMSFT)
- [x] Patrick Zheng (@Two-Hearts)

## What's Changed
* fix: github actions permissions by @JeyJeyGao in https://github.com/notaryproject/notation/pull/1059
* fix: fix debug log by @Two-Hearts in https://github.com/notaryproject/notation/pull/1061
* build(deps): Bump github.com/onsi/gomega from 1.34.1 to 1.34.2 in /test/e2e by @dependabot in https://github.com/notaryproject/notation/pull/1049
* test: add unit tests by @Two-Hearts in https://github.com/notaryproject/notation/pull/1075
* fix: discard crl cache error by @Two-Hearts in https://github.com/notaryproject/notation/pull/1076
* build(deps): Bump codecov/codecov-action from 4.5.0 to 4.6.0 by @dependabot in https://github.com/notaryproject/notation/pull/1054
* build(deps): Bump github.com/notaryproject/notation-go from 1.2.0-beta.1.0.20240926015724-84c2ec076201 to 1.3.0-rc.1 in /test/e2e/plugin by @dependabot in https://github.com/notaryproject/notation/pull/1051
* build(deps): Bump github.com/spf13/cobra from 1.7.0 to 1.8.1 in /test/e2e/plugin by @dependabot in https://github.com/notaryproject/notation/pull/1050
* build(deps): Bump golang.org/x/term from 0.24.0 to 0.25.0 by @dependabot in https://github.com/notaryproject/notation/pull/1055
* build(deps): Bump actions/cache from 4.0.2 to 4.1.2 by @dependabot in https://github.com/notaryproject/notation/pull/1073
* build(deps): Bump actions/upload-artifact from 4.4.0 to 4.4.3 by @dependabot in https://github.com/notaryproject/notation/pull/1066
* build(deps): Bump actions/checkout from 4.1.7 to 4.2.2 by @dependabot in https://github.com/notaryproject/notation/pull/1074
* build(deps): Bump github.com/golang-jwt/jwt/v4 from 4.5.0 to 4.5.1 in /test/e2e/plugin by @dependabot in https://github.com/notaryproject/notation/pull/1077
* feat: crl cache with log by @Two-Hearts in https://github.com/notaryproject/notation/pull/1078
* build(deps): Bump golang.org/x/term from 0.25.0 to 0.26.0 by @dependabot in https://github.com/notaryproject/notation/pull/1081
* fix&test: discard error for NewFileCache & E2E test for CRL with cache by @JeyJeyGao in https://github.com/notaryproject/notation/pull/1079
* build(deps): Bump github.com/golang-jwt/jwt/v4 from 4.5.0 to 4.5.1 by @dependabot in https://github.com/notaryproject/notation/pull/1086
* build(deps): Bump github/codeql-action from 3.26.8 to 3.27.1 by @dependabot in https://github.com/notaryproject/notation/pull/1085
* build(deps): Bump goreleaser/goreleaser-action from 6.0.0 to 6.1.0 by @dependabot in https://github.com/notaryproject/notation/pull/1084
* build(deps): Bump golang.org/x/net from 0.29.0 to 0.31.0 by @dependabot in https://github.com/notaryproject/notation/pull/1082
* build(deps): Bump github.com/onsi/gomega from 1.34.2 to 1.35.1 in /test/e2e by @dependabot in https://github.com/notaryproject/notation/pull/1087
* build(deps): Bump actions/setup-go from 5.0.2 to 5.1.0 by @dependabot in https://github.com/notaryproject/notation/pull/1090
* build(deps): Bump github/codeql-action from 3.27.1 to 3.27.5 by @dependabot in https://github.com/notaryproject/notation/pull/1091
* build(deps): Bump codecov/codecov-action from 4.6.0 to 5.0.7 by @dependabot in https://github.com/notaryproject/notation/pull/1092
* fix: add timestamping cert chain revocation check during signing by @Two-Hearts in https://github.com/notaryproject/notation/pull/1094
* build(deps): Bump github.com/onsi/ginkgo/v2 from 2.21.0 to 2.22.0 in /test/e2e by @dependabot in https://github.com/notaryproject/notation/pull/1093
* build(deps): Bump golang.org/x/term from 0.26.0 to 0.27.0 by @dependabot in https://github.com/notaryproject/notation/pull/1098
* build(deps): Bump actions/cache from 4.1.2 to 4.2.0 by @dependabot in https://github.com/notaryproject/notation/pull/1101
* build(deps): Bump codecov/codecov-action from 5.0.7 to 5.1.1 by @dependabot in https://github.com/notaryproject/notation/pull/1102
* build(deps): Bump github/codeql-action from 3.27.5 to 3.27.6 by @dependabot in https://github.com/notaryproject/notation/pull/1103
* build(deps): Bump github.com/notaryproject/tspclient-go from 0.2.1-0.20241030015323-90a141e7525c to 1.0.0-rc.1 by @dependabot in https://github.com/notaryproject/notation/pull/1100
* build(deps): Bump golang.org/x/net from 0.31.0 to 0.32.0 by @dependabot in https://github.com/notaryproject/notation/pull/1099
* build(deps): Bump github.com/onsi/gomega from 1.35.1 to 1.36.1 in /test/e2e by @dependabot in https://github.com/notaryproject/notation/pull/1106
* build(deps): Bump golang.org/x/crypto from 0.29.0 to 0.31.0 by @dependabot in https://github.com/notaryproject/notation/pull/1105
* fix: `context` and bump up golang.org/x/net by @JeyJeyGao in https://github.com/notaryproject/notation/pull/1119
* build(deps): Bump actions/upload-artifact from 4.4.3 to 4.5.0 by @dependabot in https://github.com/notaryproject/notation/pull/1122
* docs: spec update regarding blob signature file extensions by @Two-Hearts in https://github.com/notaryproject/notation/pull/1118
* build(deps): Bump codecov/codecov-action from 5.1.1 to 5.1.2 by @dependabot in https://github.com/notaryproject/notation/pull/1123
* build(deps): Bump github.com/onsi/gomega from 1.36.1 to 1.36.2 in /test/e2e by @dependabot in https://github.com/notaryproject/notation/pull/1131
* build(deps): Bump github/codeql-action from 3.27.6 to 3.28.0 by @dependabot in https://github.com/notaryproject/notation/pull/1124
* feat: `blob sign` command by @Two-Hearts in https://github.com/notaryproject/notation/pull/1128
* ci: update runner version to ubuntu-24.04 by @JeyJeyGao in https://github.com/notaryproject/notation/pull/1140
* build(deps): Bump actions/setup-go from 5.1.0 to 5.2.0 by @dependabot in https://github.com/notaryproject/notation/pull/1112
* build(deps): Bump github.com/notaryproject/tspclient-go from 1.0.0-rc.1 to 1.0.0 by @dependabot in https://github.com/notaryproject/notation/pull/1143
* build(deps): Bump github/codeql-action from 3.28.0 to 3.28.1 by @dependabot in https://github.com/notaryproject/notation/pull/1142
* fix: load config error by @JeyJeyGao in https://github.com/notaryproject/notation/pull/1145
* build(deps): Bump github.com/onsi/ginkgo/v2 from 2.22.1 to 2.22.2 in /test/e2e by @dependabot in https://github.com/notaryproject/notation/pull/1132
* build(deps): Bump golang.org/x/term from 0.27.0 to 0.28.0 by @dependabot in https://github.com/notaryproject/notation/pull/1135
* build(deps): Bump actions/upload-artifact from 4.5.0 to 4.6.0 by @dependabot in https://github.com/notaryproject/notation/pull/1141
* feat: add `blob policy import` and `show` commands by @JeyJeyGao in https://github.com/notaryproject/notation/pull/1126
* bump: bump up dependencies by @Two-Hearts in https://github.com/notaryproject/notation/pull/1146
* docs: fix inspect command spec by @JeyJeyGao in https://github.com/notaryproject/notation/pull/1156
* build(deps): Bump github/codeql-action from 3.28.1 to 3.28.8 by @dependabot in https://github.com/notaryproject/notation/pull/1166
* build(deps): Bump codecov/codecov-action from 5.1.2 to 5.3.1 by @dependabot in https://github.com/notaryproject/notation/pull/1157
* build(deps): Bump actions/stale from 9.0.0 to 9.1.0 by @dependabot in https://github.com/notaryproject/notation/pull/1159
* build(deps): Bump actions/setup-go from 5.2.0 to 5.3.0 by @dependabot in https://github.com/notaryproject/notation/pull/1160
* build(deps): Bump github.com/spf13/pflag from 1.0.5 to 1.0.6 by @dependabot in https://github.com/notaryproject/notation/pull/1162
* refactor: extract inspect rendering logic to be display handlers by @JeyJeyGao in https://github.com/notaryproject/notation/pull/1150
* refactor: verify display handler by @JeyJeyGao in https://github.com/notaryproject/notation/pull/1167
* build(deps): Bump golang.org/x/term from 0.28.0 to 0.29.0 by @dependabot in https://github.com/notaryproject/notation/pull/1169
* build(deps): Bump github/codeql-action from 3.28.8 to 3.28.9 by @dependabot in https://github.com/notaryproject/notation/pull/1168
* feat: `blob verify` command by @Two-Hearts in https://github.com/notaryproject/notation/pull/1137
* test: OCSP E2E by @JeyJeyGao in https://github.com/notaryproject/notation/pull/1172
* feat: `blob inspect` command by @JeyJeyGao in https://github.com/notaryproject/notation/pull/1133
* build(deps): Bump github.com/spf13/cobra from 1.8.1 to 1.9.1 by @dependabot in https://github.com/notaryproject/notation/pull/1177
* build(deps): Bump github.com/spf13/cobra from 1.8.1 to 1.9.1 in /test/e2e/plugin by @dependabot in https://github.com/notaryproject/notation/pull/1178
* build(deps): Bump goreleaser/goreleaser-action from 6.1.0 to 6.2.1 by @dependabot in https://github.com/notaryproject/notation/pull/1179
* bump: update go v1.24 by @JeyJeyGao in https://github.com/notaryproject/notation/pull/1181
* fix: update the output format `text` to `tree` by @JeyJeyGao in https://github.com/notaryproject/notation/pull/1182
* fix: blob policy command messages with docs by @JeyJeyGao in https://github.com/notaryproject/notation/pull/1175
* bump: bump up dependencies by @Two-Hearts in https://github.com/notaryproject/notation/pull/1185
* feat: update policy command to support OCI trust policy by @JeyJeyGao in https://github.com/notaryproject/notation/pull/1173
* build(deps): Bump ossf/scorecard-action from 2.4.0 to 2.4.1 by @dependabot in https://github.com/notaryproject/notation/pull/1191
* build(deps): Bump github/codeql-action from 3.28.9 to 3.28.10 by @dependabot in https://github.com/notaryproject/notation/pull/1189
* feat: OCI 1.1 support by @Two-Hearts in https://github.com/notaryproject/notation/pull/1192
* refactor: list output handler by @JeyJeyGao in https://github.com/notaryproject/notation/pull/1176
* fix: output in streaming fashion for `inspect` command in `tree` format by @JeyJeyGao in https://github.com/notaryproject/notation/pull/1194
* doc: add blob policy init command by @yizha1 in https://github.com/notaryproject/notation/pull/1197
* chore: move common flags to `cmd` package by @JeyJeyGao in https://github.com/notaryproject/notation/pull/1195
* fix: notify context cancellation when SIGINT is received by @JeyJeyGao in https://github.com/notaryproject/notation/pull/1198
* fix: goreleaser deprecated options by @JeyJeyGao in https://github.com/notaryproject/notation/pull/1201
* docs: add the proposal for Notation blob signing and verification by @yizha1 in https://github.com/notaryproject/notation/pull/1180
* refactor: refactor internal packages by @Two-Hearts in https://github.com/notaryproject/notation/pull/1205
* docs: specs clean up by @Two-Hearts in https://github.com/notaryproject/notation/pull/1206
* feat: blob policy init command by @JeyJeyGao in https://github.com/notaryproject/notation/pull/1196
* feat: output signature manifest reference after sign by @JeyJeyGao in https://github.com/notaryproject/notation/pull/1204
* build(deps): Bump actions/upload-artifact from 4.6.0 to 4.6.1 by @dependabot in https://github.com/notaryproject/notation/pull/1190
* build(deps): Bump actions/cache from 4.2.0 to 4.2.2 by @dependabot in https://github.com/notaryproject/notation/pull/1199
* build(deps): Bump codecov/codecov-action from 5.3.1 to 5.4.0 by @dependabot in https://github.com/notaryproject/notation/pull/1200
* build(deps): Bump github/codeql-action from 3.28.10 to 3.28.11 by @dependabot in https://github.com/notaryproject/notation/pull/1207
* build(deps): Bump golang.org/x/term from 0.29.0 to 0.30.0 by @dependabot in https://github.com/notaryproject/notation/pull/1209
* build(deps): Bump github.com/onsi/ginkgo/v2 from 2.22.2 to 2.23.0 in /test/e2e by @dependabot in https://github.com/notaryproject/notation/pull/1211
* build(deps): Bump github.com/opencontainers/image-spec from 1.1.0 to 1.1.1 by @dependabot in https://github.com/notaryproject/notation/pull/1208
* build(deps): Bump github.com/opencontainers/image-spec from 1.1.0 to 1.1.1 in /test/e2e by @dependabot in https://github.com/notaryproject/notation/pull/1210
* bump: bump up dependencies for v2.0 alpha release by @Two-Hearts in https://github.com/notaryproject/notation/pull/1212

**Full Changelog**: https://github.com/notaryproject/notation/compare/v1.3.1...88a3273bf2e7bb7439c8937b35a88ece22af74c7

## Actions
Please review the PR and vote by approving.