### PR TITLE
docs: add contributing guide link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Notary Project is a [CNCF Incubating project](https://www.cncf.io/projects/notar
 - [Build Notation from source code](/building.md)
 - [Governance for Notary Project](https://github.com/notaryproject/.github/blob/master/GOVERNANCE.md)
 - [Maintainers and reviewers list](https://github.com/notaryproject/notation/blob/main/CODEOWNERS)
+- [Contributing Guide](https://github.com/notaryproject/.github/blob/main/CONTRIBUTING.md)
 - Regular conversations for Notary Project occur on the [Cloud Native Computing Slack](https://slack.cncf.io/) **notary-project** channel.
 
 ### Notary Project Community Meeting


### PR DESCRIPTION
This PR adds a link to the "Contributing Guide" section in the README file, providing contributors with easy access to the project's contributing guidelines.
**fix #1224** 