### PR TITLE
bump: release v1.3.2

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ package version
 
 var (
 	// Version shows the current notation version, optionally with pre-release.
-	Version = "v1.3.1"
+	Version = "v1.3.2"
 
 	// BuildMetadata stores the build metadata.
 	//


### PR DESCRIPTION
## Release

This would mean tagging 001cc919603c1dc16c6aad387c94b4209cb9c901 as `v1.3.2` to release.

## Vote
We need at least `4` approvals from `6` maintainers to release `v1.3.2`.

## What's Changed
* bump: release v1.3.1 by @Two-Hearts in https://github.com/notaryproject/notation/pull/1186
* CVE-2025-30204: update golang-jwt by @artem-panchenko in https://github.com/notaryproject/notation/pull/1249
* backport: from main to release-1.3 branch by @Two-Hearts in https://github.com/notaryproject/notation/pull/1267

**Full Changelog**: https://github.com/notaryproject/notation/compare/v1.3.1...001cc919603c1dc16c6aad387c94b4209cb9c901

## Actions
Please review the PR and vote by approving.