### PR TITLE
fix: increase e2e test stability on release-1.3 branch

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ package version
 
 var (
 	// Version shows the current notation version, optionally with pre-release.
-	Version = "v1.3.2"
+	Version = "v1.3.1"
 
 	// BuildMetadata stores the build metadata.
 	//

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ package version
 
 var (
 	// Version shows the current notation version, optionally with pre-release.
-	Version = "v1.3.1"
+	Version = "v1.3.2"
 
 	// BuildMetadata stores the build metadata.
 	//

--- a/test/e2e/suite/command/sign.go
+++ b/test/e2e/suite/command/sign.go
@@ -298,7 +298,7 @@ var _ = Describe("notation sign", func() {
 		Host(BaseOptions(), func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
 			notation.ExpectFailure().Exec("sign", "--timestamp-url", "http://localhost.test", "--timestamp-root-cert", filepath.Join(NotationE2EConfigPath, "timestamp", "globalsignTSARoot.cer"), artifact.ReferenceWithDigest()).
 				MatchErrKeyWords("Error: timestamp: Post \"http://localhost.test\"").
-				MatchErrKeyWords("server misbehaving")
+				MatchErrKeyWords("no such host")
 		})
 	})
 

--- a/test/e2e/suite/command/sign.go
+++ b/test/e2e/suite/command/sign.go
@@ -297,8 +297,7 @@ var _ = Describe("notation sign", func() {
 	It("with timestamping and invalid tsa server", func() {
 		Host(BaseOptions(), func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
 			notation.ExpectFailure().Exec("sign", "--timestamp-url", "http://localhost.test", "--timestamp-root-cert", filepath.Join(NotationE2EConfigPath, "timestamp", "globalsignTSARoot.cer"), artifact.ReferenceWithDigest()).
-				MatchErrKeyWords("Error: timestamp: Post \"http://localhost.test\"").
-				MatchErrKeyWords("no such host")
+				MatchErrKeyWords("Error: timestamp: Post \"http://localhost.test\"")
 		})
 	})
 

--- a/test/e2e/suite/command/sign.go
+++ b/test/e2e/suite/command/sign.go
@@ -296,8 +296,8 @@ var _ = Describe("notation sign", func() {
 
 	It("with timestamping and invalid tsa server", func() {
 		Host(BaseOptions(), func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
-			notation.ExpectFailure().Exec("sign", "--timestamp-url", "http://invalid.com", "--timestamp-root-cert", filepath.Join(NotationE2EConfigPath, "timestamp", "globalsignTSARoot.cer"), artifact.ReferenceWithDigest()).
-				MatchErrKeyWords("Error: timestamp: Post \"http://invalid.com\"").
+			notation.ExpectFailure().Exec("sign", "--timestamp-url", "http://localhost.test", "--timestamp-root-cert", filepath.Join(NotationE2EConfigPath, "timestamp", "globalsignTSARoot.cer"), artifact.ReferenceWithDigest()).
+				MatchErrKeyWords("Error: timestamp: Post \"http://localhost.test\"").
 				MatchErrKeyWords("server misbehaving")
 		})
 	})

--- a/test/e2e/suite/plugin/install.go
+++ b/test/e2e/suite/plugin/install.go
@@ -166,15 +166,15 @@ var _ = Describe("notation plugin install", func() {
 
 	It("with invalid plugin URL scheme", func() {
 		Host(nil, func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
-			notation.ExpectFailure().Exec("plugin", "install", "--url", "http://invalid", "--sha256sum", "abcd").
+			notation.ExpectFailure().Exec("plugin", "install", "--url", "http://localhost", "--sha256sum", "abcd").
 				MatchErrContent("Error: failed to download plugin from URL: only the HTTPS scheme is supported, but got http\n")
 		})
 	})
 
 	It("with invalid plugin URL", func() {
 		Host(nil, func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
-			notation.ExpectFailure().Exec("plugin", "install", "--url", "https://invalid.test", "--sha256sum", "abcd").
-				MatchErrKeyWords("failed to download plugin from URL https://invalid.test")
+			notation.ExpectFailure().Exec("plugin", "install", "--url", "https://localhost.test", "--sha256sum", "abcd").
+				MatchErrKeyWords("failed to download plugin from URL https://localhost.test")
 		})
 	})
 })


### PR DESCRIPTION
This PR targets on the `release-1.3` branch.

After the vote PR https://github.com/notaryproject/notation/pull/1268 been merged, the e2e test on the release-1.3 branch is failing.

This is due to a bug on the e2e test, which did not pop up before the merge. Hence creating this new PR to fix it.