### PR TITLE
fix: fix e2e test urls

### DIFF
--- a/test/e2e/suite/command/blob/sign.go
+++ b/test/e2e/suite/command/blob/sign.go
@@ -215,8 +215,8 @@ var _ = Describe("notation blob sign", func() {
 
 	It("with timestamping and invalid tsa server", func() {
 		HostWithBlob(BaseOptions(), func(notation *utils.ExecOpts, blobPath string, vhost *utils.VirtualHost) {
-			notation.ExpectFailure().Exec("blob", "sign", "--timestamp-url", "http://tsa.invalid", "--timestamp-root-cert", filepath.Join(NotationE2EConfigPath, "timestamp", "DigiCertTSARootSHA384.cer"), blobPath).
-				MatchErrKeyWords("Error: timestamp: Post \"http://tsa.invalid\"")
+			notation.ExpectFailure().Exec("blob", "sign", "--timestamp-url", "http://localhost.test", "--timestamp-root-cert", filepath.Join(NotationE2EConfigPath, "timestamp", "DigiCertTSARootSHA384.cer"), blobPath).
+				MatchErrKeyWords("Error: timestamp: Post \"http://localhost.test\"")
 		})
 	})
 

--- a/test/e2e/suite/command/sign.go
+++ b/test/e2e/suite/command/sign.go
@@ -235,8 +235,8 @@ var _ = Describe("notation sign", func() {
 
 	It("with timestamping and invalid tsa server", func() {
 		Host(BaseOptions(), func(notation *utils.ExecOpts, artifact *Artifact, vhost *utils.VirtualHost) {
-			notation.ExpectFailure().Exec("sign", "--timestamp-url", "http://tsa.invalid", "--timestamp-root-cert", filepath.Join(NotationE2EConfigPath, "timestamp", "globalsignTSARoot.cer"), artifact.ReferenceWithDigest()).
-				MatchErrKeyWords("Error: timestamp: Post \"http://tsa.invalid\"")
+			notation.ExpectFailure().Exec("sign", "--timestamp-url", "http://localhost.test", "--timestamp-root-cert", filepath.Join(NotationE2EConfigPath, "timestamp", "globalsignTSARoot.cer"), artifact.ReferenceWithDigest()).
+				MatchErrKeyWords("Error: timestamp: Post \"http://localhost.test\"")
 		})
 	})
 

--- a/test/e2e/suite/plugin/install.go
+++ b/test/e2e/suite/plugin/install.go
@@ -166,15 +166,15 @@ var _ = Describe("notation plugin install", func() {
 
 	It("with invalid plugin URL scheme", func() {
 		Host(nil, func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
-			notation.ExpectFailure().Exec("plugin", "install", "--url", "http://invalid", "--sha256sum", "abcd").
+			notation.ExpectFailure().Exec("plugin", "install", "--url", "http://localhost", "--sha256sum", "abcd").
 				MatchErrContent("Error: failed to download plugin from URL: only the HTTPS scheme is supported, but got http\n")
 		})
 	})
 
 	It("with invalid plugin URL", func() {
 		Host(nil, func(notation *utils.ExecOpts, _ *Artifact, vhost *utils.VirtualHost) {
-			notation.ExpectFailure().Exec("plugin", "install", "--url", "https://invalid.test", "--sha256sum", "abcd").
-				MatchErrKeyWords("failed to download plugin from URL https://invalid.test")
+			notation.ExpectFailure().Exec("plugin", "install", "--url", "https://localhost.test", "--sha256sum", "abcd").
+				MatchErrKeyWords("failed to download plugin from URL https://localhost.test")
 		})
 	})
 })


### PR DESCRIPTION
The current invalid urls in e2e tests may cause the test to fail occasionally.