### PR TITLE
fix error formatting issue reported by staticcheck

### DIFF
--- a/cmd/notation/plugin/install.go
+++ b/cmd/notation/plugin/install.go
@@ -329,17 +329,17 @@ func installPluginWithOptions(ctx context.Context, opts plugin.CLIInstallOptions
 	if err != nil {
 		var errPluginDowngrade plugin.PluginDowngradeError
 		if errors.As(err, &errPluginDowngrade) {
-			return fmt.Errorf("%w.\nIt is not recommended to install an older version. To force the installation, use the \"--force\" option", errPluginDowngrade)
+			return fmt.Errorf("%w it is not recommended to install an older version. To force the installation, use the \"--force\" option", errPluginDowngrade)
 		}
 
 		var errExeFile *plugin.PluginExecutableFileError
 		if errors.As(err, &errExeFile) {
-			return fmt.Errorf("%w.\nPlease ensure that the plugin executable file is compatible with %s/%s and has appropriate permissions.", err, runtime.GOOS, runtime.GOARCH)
+			return fmt.Errorf("%w please ensure that the plugin executable file is compatible with %s/%s and has appropriate permissions", err, runtime.GOOS, runtime.GOARCH)
 		}
 
 		var errMalformedPlugin *plugin.PluginMalformedError
 		if errors.As(err, &errMalformedPlugin) {
-			return fmt.Errorf("%w.\nPlease ensure that the plugin executable file is intact and compatible with %s/%s. Contact the plugin publisher for further assistance.", errMalformedPlugin, runtime.GOOS, runtime.GOARCH)
+			return fmt.Errorf("%w please ensure that the plugin executable file is intact and compatible with %s/%s. Contact the plugin publisher for further assistance", errMalformedPlugin, runtime.GOOS, runtime.GOARCH)
 		}
 		return err
 	}


### PR DESCRIPTION
This PR introduces following change:

- fix Go error formatting issue highlighted by `staticcheck` linter

This PR is first in a series of PRs related to https://github.com/notaryproject/notation/issues/1256