### PR TITLE
fix: fix linter complain, don't use deprecated types

### DIFF
--- a/cmd/notation/internal/verify/verify.go
+++ b/cmd/notation/internal/verify/verify.go
@@ -135,7 +135,7 @@ func parseErrorOnVerificationFailure(err error) error {
 		}
 	}
 
-	var errorVerificationFailed notation.ErrorVerificationFailed
+	var errorVerificationFailed notation.VerificationFailedError
 	if !errors.As(err, &errorVerificationFailed) {
 		return fmt.Errorf("signature verification failed: %w", err)
 	}


### PR DESCRIPTION
This PR fixes issue highlighted by `staticcheck` - using deprecated constructs.

It partially addresses https://github.com/notaryproject/notation/issues/1256

