### PR TITLE
fix: add os/arch in version command

### DIFF
--- a/cmd/notation/version.go
+++ b/cmd/notation/version.go
@@ -38,6 +38,7 @@ func runVersion() {
 
 	fmt.Printf("Version:     %s\n", version.GetVersion())
 	fmt.Printf("Go version:  %s\n", runtime.Version())
+	fmt.Printf("OS/Arch:     %s/%s\n", runtime.GOOS, runtime.GOARCH)
 
 	if version.GitCommit != "" {
 		fmt.Printf("Git commit:  %s\n", version.GitCommit)

--- a/specs/cmd/version.md
+++ b/specs/cmd/version.md
@@ -11,6 +11,7 @@ Notation - a tool to sign and verify artifacts.
 
 Version:     <MAJOR.MINOR.PATCH>
 Go version:  go<MAJOR.MINOR.PATCH>
+OS/Arch:     <OS>/<ARCH>
 Git commit:  <long_hash>
 ```
 
@@ -41,5 +42,6 @@ Notation - a tool to sign and verify artifacts.
 
 Version:     1.0.0
 Go Version:  go1.19.2
+OS/Arch:     linux/amd64
 Git commit:  1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a
 ```


### PR DESCRIPTION
Pending on https://github.com/notaryproject/notation/pull/1260

Example of notation version command
```
Notation - a tool to sign and verify artifacts.

Version:     v2.0.0-alpha.1+unreleased
Go version:  go1.24.0
OS/Arch:     linux/amd64
Git commit:  c68425f82871c27140a5c1b259b518750e558446
```

Resolve part of #1247 