### PR TITLE
fix: use %w instead of %v for error wrapping in login and logout

### DIFF
--- a/cmd/notation/login.go
+++ b/cmd/notation/login.go
@@ -112,16 +112,16 @@ func runLogin(ctx context.Context, opts *loginOpts) error {
 	cred := opts.Credential()
 	credsStore, err := auth.NewCredentialsStore()
 	if err != nil {
-		return fmt.Errorf("failed to get credentials store: %v", err)
+		return fmt.Errorf("failed to get credentials store: %w", err)
 	}
 	registry, err := getRegistryLoginClient(ctx, &opts.SecureFlagOpts, serverAddress)
 	if err != nil {
-		return fmt.Errorf("failed to get registry client: %v", err)
+		return fmt.Errorf("failed to get registry client: %w", err)
 	}
 	if err := credentials.Login(ctx, credsStore, registry, cred); err != nil {
 		registryName := registry.Reference.Registry
 		if !errors.Is(err, credentials.ErrPlaintextPutDisabled) {
-			return fmt.Errorf("failed to log in to %s: %v", registryName, err)
+			return fmt.Errorf("failed to log in to %s: %w", registryName, err)
 		}
 
 		// ErrPlaintextPutDisabled returned by Login() indicates that the

--- a/cmd/notation/logout.go
+++ b/cmd/notation/logout.go
@@ -56,10 +56,10 @@ func runLogout(ctx context.Context, opts *logoutOpts) error {
 	ctx = opts.LoggingFlagOpts.InitializeLogger(ctx)
 	credsStore, err := auth.NewCredentialsStore()
 	if err != nil {
-		return fmt.Errorf("failed to get credentials store: %v", err)
+		return fmt.Errorf("failed to get credentials store: %w", err)
 	}
 	if err := credentials.Logout(ctx, credsStore, opts.server); err != nil {
-		return fmt.Errorf("failed to log out of %s: %v", opts.server, err)
+		return fmt.Errorf("failed to log out of %s: %w", opts.server, err)
 	}
 
 	fmt.Println("Logout Succeeded")


### PR DESCRIPTION
Switch `return fmt.Errorf(...)` calls in `cmd/notation/login.go` and `cmd/notation/logout.go` from `%v` to `%w` so callers can inspect the underlying error with `errors.Is`/`errors.As`. The house style across the rest of the codebase already uses `%w` for these patterns (22 non-test files).

**Files changed:**
- `cmd/notation/login.go` (3 sites: credentials store, registry client, login failure)
- `cmd/notation/logout.go` (2 sites: credentials store, logout failure)