### PR TITLE
docs: add Long description and example to version command

### DIFF
--- a/cmd/notation/version.go
+++ b/cmd/notation/version.go
@@ -25,7 +25,12 @@ func versionCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Show the notation version information",
-		Args:  cobra.NoArgs,
+		Long: `Show the notation version information
+
+Example - Show notation version:
+  notation version
+`,
+		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			runVersion()
 		},


### PR DESCRIPTION
The `version` command had a `Short:` description but no `Long:` or example, unlike most other commands. Add a `Long:` with a usage example to match the pattern used by other notation commands.